### PR TITLE
feat(deadcode): detect unreachable python function groups, also harden grep verification

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>1083</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>12408</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>1092</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>12526</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>33</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -655,7 +655,7 @@
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos" rel="noopener noreferrer">skylos</a></h3>
         <div class="stat-row">
           <span class="pill"><strong>files</strong> 7</span>
-          <span class="pill"><strong>symbols</strong> 317</span>
+          <span class="pill"><strong>symbols</strong> 318</span>
         </div>
       </div>
       <p>Root entrypoints and shared scan orchestration.</p>
@@ -1213,12 +1213,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.  test/test_underscore_discard_bindings.py skylos/core/grep_verify_common.py skylos/core/js_api_surface_members.py skylos/core/python_api_surface.py skylos/core/verify_change_schema.py skylos/core/gatekeeper.py skylos/core/evidence_contract.py skylos/core/go_api_surface.py skylos/core/grep_verify.py">
+    <article class="folder-card searchable" data-search="skylos/core small shared core types and helpers used across scan paths. use this only for concepts that are truly shared across the product.  test/test_underscore_discard_bindings.py skylos/core/grep_verify_common.py skylos/core/js_api_surface_members.py skylos/core/python_api_surface.py skylos/core/verify_change_schema.py skylos/core/gatekeeper.py skylos/core/grep_verify.py skylos/core/evidence_contract.py skylos/core/go_api_surface.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core" rel="noopener noreferrer">skylos/core</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 36</span>
-          <span class="pill"><strong>symbols</strong> 639</span>
+          <span class="pill"><strong>files</strong> 37</span>
+          <span class="pill"><strong>symbols</strong> 649</span>
         </div>
       </div>
       <p>Small shared core types and helpers used across scan paths.</p>
@@ -1237,9 +1237,9 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/python_api_surface.py" rel="noopener noreferrer">skylos/core/python_api_surface.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/verify_change_schema.py" rel="noopener noreferrer">skylos/core/verify_change_schema.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/gatekeeper.py" rel="noopener noreferrer">skylos/core/gatekeeper.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">skylos/core/grep_verify.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/evidence_contract.py" rel="noopener noreferrer">skylos/core/evidence_contract.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/go_api_surface.py" rel="noopener noreferrer">skylos/core/go_api_surface.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/grep_verify.py" rel="noopener noreferrer">skylos/core/grep_verify.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/core/go_api_surface.py" rel="noopener noreferrer">skylos/core/go_api_surface.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -1263,12 +1263,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/evidence.py skylos/deadcode/liveness.py skylos/deadcode/browser_refs.py skylos/deadcode/plugin_registry.py skylos/deadcode/java_fxml_refs.py skylos/deadcode/config_entrypoints.py skylos/deadcode/signature_contracts.py skylos/deadcode/external_protocols.py">
+    <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/evidence.py skylos/deadcode/liveness.py skylos/deadcode/browser_refs.py skylos/deadcode/plugin_registry.py skylos/deadcode/java_fxml_refs.py skylos/deadcode/config_entrypoints.py skylos/deadcode/reachability.py skylos/deadcode/_reachability_bindings.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode" rel="noopener noreferrer">skylos/deadcode</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 13</span>
-          <span class="pill"><strong>symbols</strong> 201</span>
+          <span class="pill"><strong>files</strong> 17</span>
+          <span class="pill"><strong>symbols</strong> 230</span>
         </div>
       </div>
       <p>Dead-code specific analysis, framework liveness, and evidence support.</p>
@@ -1288,8 +1288,8 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/plugin_registry.py" rel="noopener noreferrer">skylos/deadcode/plugin_registry.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/java_fxml_refs.py" rel="noopener noreferrer">skylos/deadcode/java_fxml_refs.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/config_entrypoints.py" rel="noopener noreferrer">skylos/deadcode/config_entrypoints.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/signature_contracts.py" rel="noopener noreferrer">skylos/deadcode/signature_contracts.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/external_protocols.py" rel="noopener noreferrer">skylos/deadcode/external_protocols.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/reachability.py" rel="noopener noreferrer">skylos/deadcode/reachability.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/_reachability_bindings.py" rel="noopener noreferrer">skylos/deadcode/_reachability_bindings.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -2049,8 +2049,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 305</span>
-          <span class="pill"><strong>symbols</strong> 5296</span>
+          <span class="pill"><strong>files</strong> 309</span>
+          <span class="pill"><strong>symbols</strong> 5374</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>
@@ -2112,7 +2112,7 @@
 
             <tr class="searchable" data-search="skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">skylos/analyzer.py</a></td>
-              <td>3 / 61</td>
+              <td>3 / 62</td>
               <td><span class="warn">many symbols</span> <span class="warn">shared path</span></td>
               <td>Root entrypoints and shared scan orchestration.</td>
             </tr>
@@ -7103,6 +7103,13 @@
               <td>skylos/analyzer.py</td>
             </tr>
 
+            <tr class="searchable" data-search="_index_grep_verify_candidates def skylos/analyzer.py root entrypoints and shared scan orchestration.">
+              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_index_grep_verify_candidates</a></td>
+              <td>def</td>
+              <td><span class="muted">private</span></td>
+              <td>skylos/analyzer.py</td>
+            </tr>
+
             <tr class="searchable" data-search="_apply_grep_verify_verdicts def skylos/analyzer.py root entrypoints and shared scan orchestration.">
               <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/analyzer.py" rel="noopener noreferrer">_apply_grep_verify_verdicts</a></td>
               <td>def</td>
@@ -8501,13 +8508,6 @@
               <td>def</td>
               <td><span class="ok">public</span></td>
               <td>skylos/cicd/review.py</td>
-            </tr>
-
-            <tr class="searchable" data-search="build_risk_passport def skylos/cicd/risk_passport.py ci workflow generation, annotations, review comments, evidence, and risk passport output.">
-              <td><a href="https://github.com/duriantaco/skylos/blob/main/skylos/cicd/risk_passport.py" rel="noopener noreferrer">build_risk_passport</a></td>
-              <td>def</td>
-              <td><span class="ok">public</span></td>
-              <td>skylos/cicd/risk_passport.py</td>
             </tr></tbody>
       </table>
     </section>

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -122,6 +122,7 @@ _OPTIONAL_RUN_STATE_ATTRIBUTES = (
     "_call_arg_types",
     "_grep_verify_report",
     "_grep_verify_incomplete_candidates",
+    "_python_reachability_report",
     "_dead_code_scope_keys",
     "_dead_code_liveness_report",
     "ts_consumed_exports",
@@ -1226,7 +1227,7 @@ def _collect_grep_verify_candidates(
     candidate_keys: frozenset | None = None,
 ) -> tuple[list[dict], dict]:
     candidates: list[dict] = []
-    candidate_defs: dict = {}
+    entries: dict = {}
     for key, defn in definitions.items():
         if candidate_keys is not None and key not in candidate_keys:
             continue
@@ -1234,10 +1235,27 @@ def _collect_grep_verify_candidates(
             continue
         payload = defn.to_dict()
         candidates.append(payload)
-        full_name = payload.get("full_name", payload.get("name", ""))
-        candidate_defs[full_name] = defn
+        entries[key] = (defn, payload)
     candidates.sort(key=_grep_verify_rescue_priority)
-    return candidates, candidate_defs
+    return candidates, _index_grep_verify_candidates(entries)
+
+
+def _index_grep_verify_candidates(entries: dict) -> dict:
+    names = Counter(
+        payload.get("full_name", payload.get("name", ""))
+        for _definition, payload in entries.values()
+    )
+    indexed = {}
+    for definition_key, (definition, payload) in entries.items():
+        full_name = payload.get("full_name", payload.get("name", ""))
+        verdict_key = full_name
+        if names[full_name] > 1:
+            # An import and its target can share a qualified name. Keep the
+            # search name intact while routing each verdict to its own symbol.
+            verdict_key = json.dumps([full_name, str(definition_key)])
+            payload["_verification_key"] = verdict_key
+        indexed[verdict_key] = definition
+    return indexed
 
 
 def _apply_grep_verify_verdicts(candidate_defs: dict, verdicts: dict) -> int:
@@ -1975,6 +1993,86 @@ class Skylos:
                     defn.confidence = 0
                     defn.skip_reason = "standalone ORM model module"
 
+    def _has_complete_python_reachability_scope(self):
+        # Negative reachability needs the whole selected project. File-only,
+        # subdirectory, changed-file and failed scans retain their prior policy.
+        scope = getattr(self, "_analysis_scope", {})
+        if (
+            scope.get("kind")
+            not in {"repository_root", "repository_root_with_exclusions"}
+            or scope.get("changed_files_only")
+            or not set(scope.get("excluded_folders", ())).issubset(
+                DEFAULT_EXCLUDE_FOLDERS
+            )
+        ):
+            return False
+        return Path(scope["scan_path"]).resolve() == Path(self._project_root).resolve()
+
+    def _prepare_python_reachability(
+        self, files, analysis_errors, *, module_names=None
+    ):
+        self.__dict__.pop("_python_reachability_report", None)
+        if analysis_errors:
+            return
+        try:
+            if not self._has_complete_python_reachability_scope():
+                return
+            from skylos.deadcode.reachability import analyze_python_reachability
+
+            report = analyze_python_reachability(
+                self.defs, files, self._project_root, module_names=module_names
+            )
+            if not report.complete:
+                return
+        except Exception:
+            logger.debug("Python reachability unavailable", exc_info=True)
+            return
+        self._python_reachability_report = report
+        self._apply_python_reachability(report)
+
+    def _apply_python_reachability(self, report):
+        for key in report.proven_reachable_keys:
+            defn = self.defs.get(key)
+            if defn is not None and defn.references <= 0:
+                defn.references = 1
+                defn.heuristic_refs["reachable_from_root"] = 1.0
+        for key in report.unreachable_keys:
+            defn = self.defs.get(key)
+            if defn is None:
+                continue
+            attribute_hints = max(0, getattr(defn, "_attr_name_ref_count", 0))
+            has_references = defn.references > attribute_hints or bool(defn.called_by)
+            defn.references = 0
+            if not has_references:
+                continue
+            defn.heuristic_refs["unreachable_group"] = 1.0
+            reason = report.reasons[key]
+            if reason not in defn.why_unused:
+                defn.why_unused.append(reason)
+
+    def _refresh_python_reachability(self):
+        report = getattr(self, "_python_reachability_report", None)
+        if report is None:
+            return
+        previously_unreachable = set(report.unreachable_keys)
+        previous_reasons = dict(report.reasons)
+        revived_roots = {
+            key for key in previously_unreachable if self.defs[key].references > 0
+        }
+        report.refresh(self.defs, additional_roots=revived_roots)
+        # An external callback or a later grep rescue may establish a real
+        # caller. Its callees must be restored in this same scan.
+        for key in previously_unreachable - report.unreachable_keys:
+            defn = self.defs.get(key)
+            if defn is None:
+                continue
+            defn.references = max(1, defn.references)
+            defn.heuristic_refs.pop("unreachable_group", None)
+            defn.heuristic_refs["reachable_from_root"] = 1.0
+            reason = previous_reasons.get(key)
+            if reason in defn.why_unused:
+                defn.why_unused.remove(reason)
+
     def _grep_verify(self, *, use_project_cache: bool = True):
         """Post-pass: use grep strategies to rescue false-positive dead code."""
         from skylos.core.grep_cache import GrepCache
@@ -2016,11 +2114,18 @@ class Skylos:
             grep_cache.load(grep_root)
         try:
             grep_budget = float(os.getenv("SKYLOS_GREP_BUDGET", "30"))
+            report_filter = getattr(self, "_python_reachability_report", None)
+            filter_kwargs = (
+                {"evidence_filter": report_filter.filter_grep_results}
+                if report_filter is not None
+                else {}
+            )
             verdicts = grep_verify_findings(
                 candidates,
                 project_root,
                 cache=grep_cache,
                 time_budget=grep_budget,
+                **filter_kwargs,
             )
         finally:
             if use_project_cache:
@@ -2052,6 +2157,7 @@ class Skylos:
             return 0
 
         rescued = _apply_grep_verify_verdicts(candidate_defs, verdicts)
+        self._refresh_python_reachability()
 
         if rescued:
             logger.info(f"Grep verify: rescued {rescued} findings from dead code")
@@ -4746,9 +4852,11 @@ class Skylos:
         if progress_callback:
             progress_callback(0, 1, Path("PHASE: transitive dead code"))
         self._propagate_transitive_dead()
+        self._prepare_python_reachability(files, analysis_errors, module_names=modmap)
         # Resolve library callbacks from surviving callers, so speculative
         # callback cycles cannot become roots or consume ordinary references.
         self._apply_external_protocol_liveness(files)
+        self._refresh_python_reachability()
         self._suppress_standalone_orm_models()
 
         grep_verify_report = {

--- a/skylos/core/grep_search_state.py
+++ b/skylos/core/grep_search_state.py
@@ -1,0 +1,78 @@
+"""Track bounded evidence loss separately from grep's surviving matches."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+
+
+class GrepSearchResults(dict[str, list[str]]):
+    """Raw evidence and whether a search or strategy discarded further hits."""
+
+    def __init__(
+        self,
+        evidence: Mapping[str, list[str]],
+        *,
+        truncated_strategies: frozenset[str] | set[str] = frozenset(),
+    ) -> None:
+        super().__init__(evidence)
+        self.truncated_strategies = frozenset(truncated_strategies)
+
+
+@dataclass
+class _EvidenceLimits:
+    truncated_strategies: set[str] = field(default_factory=set)
+
+
+UNCLASSIFIED_STRATEGY = "unclassified"
+_ACTIVE_STRATEGY: ContextVar[str] = ContextVar(
+    "grep_evidence_strategy", default=UNCLASSIFIED_STRATEGY
+)
+_ACTIVE_LIMITS: ContextVar[_EvidenceLimits | None] = ContextVar(
+    "grep_evidence_limits", default=None
+)
+
+
+@contextmanager
+def track_grep_evidence_limits() -> Iterator[_EvidenceLimits]:
+    """Keep each concurrent finding's completeness state independent."""
+    limits = _EvidenceLimits()
+    token = _ACTIVE_LIMITS.set(limits)
+    try:
+        yield limits
+    finally:
+        _ACTIVE_LIMITS.reset(token)
+
+
+@contextmanager
+def grep_evidence_strategy(name: str) -> Iterator[None]:
+    """Associate discarded raw matches with the strategy that requested them."""
+    token = _ACTIVE_STRATEGY.set(name)
+    try:
+        yield
+    finally:
+        _ACTIVE_STRATEGY.reset(token)
+
+
+def grep_probe_limit(limit: int) -> int:
+    """Ask for one extra hit to distinguish an exact limit from an overflow."""
+    return limit + 1 if _ACTIVE_LIMITS.get() is not None and limit > 0 else limit
+
+
+def limit_grep_evidence(
+    lines: list[str], limit: int, *, strategy: str | None = None
+) -> list[str]:
+    """Record loss before applying an evidence display/strategy bound."""
+    limits = _ACTIVE_LIMITS.get()
+    if limits is not None and len(lines) > limit:
+        limits.truncated_strategies.add(strategy or _ACTIVE_STRATEGY.get())
+    return lines[:limit]
+
+
+def retain_grep_probe(lines: list[str], limit: int) -> list[str]:
+    """Leave legacy searches unchanged; bound and record tracked probes."""
+    if _ACTIVE_LIMITS.get() is None:
+        return lines
+    return limit_grep_evidence(lines, limit)

--- a/skylos/core/grep_verify.py
+++ b/skylos/core/grep_verify.py
@@ -8,6 +8,11 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
+from skylos.core.grep_search_state import (
+    GrepSearchResults,
+    UNCLASSIFIED_STRATEGY,
+    track_grep_evidence_limits,
+)
 from skylos.core.grep_verify_common import (
     GrepRequest,
     _GrepDeadlineExceeded,
@@ -45,6 +50,8 @@ from skylos.core.grep_verify_strategies import (
 )
 
 logger = logging.getLogger(__name__)
+
+GrepEvidenceFilter = Callable[[dict, dict[str, list[str]]], dict[str, list[str]]]
 
 __all__ = [
     "_STRONG_ALIVE_STRATEGIES",
@@ -129,7 +136,7 @@ class _PendingBatchFinding:
     requests: tuple[GrepRequest, ...]
 
 
-_GREP_VERIFY_CACHE_VERSION = "v8"
+_GREP_VERIFY_CACHE_VERSION = "v11"
 _GREP_FINDING_BATCH_SIZE = 32
 _GREP_CACHE_MAX_STRATEGIES = 64
 _GREP_CACHE_MAX_LINES_PER_STRATEGY = 256
@@ -196,7 +203,19 @@ def _load_cached_group_results(
         logger.debug("Ignoring invalid grep verification cache entry: %s", exc)
         return None
 
-    return _normalize_cached_group_results(decoded)
+    if not isinstance(decoded, dict):
+        return None
+    truncated = decoded.get("truncated_strategies")
+    if (
+        not isinstance(truncated, list)
+        or len(truncated) > _GREP_CACHE_MAX_STRATEGIES
+        or not all(isinstance(name, str) for name in truncated)
+    ):
+        return None
+    evidence = _normalize_cached_group_results(decoded.get("evidence"))
+    if evidence is None:
+        return None
+    return GrepSearchResults(evidence, truncated_strategies=frozenset(truncated))
 
 
 def _normalize_cached_group_results(
@@ -245,7 +264,13 @@ def _store_cached_group_results(
     if cache_key is None:
         return
     try:
-        cache.put(cache_key, [_json.dumps(normalized)])
+        payload = {
+            "evidence": normalized,
+            "truncated_strategies": sorted(
+                getattr(results, "truncated_strategies", ())
+            ),
+        }
+        cache.put(cache_key, [_json.dumps(payload)])
     except (AttributeError, OSError, TypeError, ValueError) as exc:
         logger.debug("Failed to write grep verification cache entry: %s", exc)
 
@@ -254,8 +279,11 @@ def _finding_simple_name(finding: dict) -> str:
     return finding.get("simple_name", finding.get("name", ""))
 
 
-def _finding_full_name(finding: dict) -> str:
-    return finding.get("full_name", finding.get("name", ""))
+def _finding_verdict_key(finding: dict) -> str:
+    # Search strategies retain full_name; this key only routes the verdict.
+    return finding.get("_verification_key") or finding.get(
+        "full_name", finding.get("name", "")
+    )
 
 
 def _finding_language(finding: dict) -> str:
@@ -268,12 +296,14 @@ def multi_strategy_search(
     *,
     max_per_strategy: int = _MAX_RESULTS_PER_STRATEGY,
     early_exit_threshold: int = 5,
+    stop_after_strong_evidence: bool = True,
 ) -> dict[str, list[str]]:
     return _multi_strategy_search_impl(
         finding,
         project_root,
         max_per_strategy=max_per_strategy,
         early_exit_threshold=early_exit_threshold,
+        stop_after_strong_evidence=stop_after_strong_evidence,
     )
 
 
@@ -302,7 +332,9 @@ def parallel_multi_strategy_search(
 def _apply_deterministic_rules(
     search_results: dict[str, list[str]],
     finding: dict,
+    evidence_filter: GrepEvidenceFilter | None = None,
 ) -> GrepVerdict | None:
+    search_results = _filter_evidence(finding, search_results, evidence_filter)
     refs = search_results.get("references", [])
     if refs:
         simple_name = finding.get("simple_name", "")
@@ -338,7 +370,46 @@ def _apply_deterministic_rules(
                 evidence=search_results[strategy_key][:3],
             )
 
+    decision_strategies = {"references", UNCLASSIFIED_STRATEGY} | {
+        key for key, _code, _rationale in _DETERMINISTIC_RULES
+    }
+    if decision_strategies.intersection(
+        getattr(search_results, "truncated_strategies", ())
+    ):
+        raise _GrepExecutionIncomplete(
+            "Grep evidence was truncated before verification"
+        )
     return None
+
+
+def _filter_evidence(finding, results, evidence_filter):
+    if evidence_filter is None:
+        return results
+    try:
+        filtered = evidence_filter(finding, results)
+        return GrepSearchResults(
+            filtered,
+            truncated_strategies=getattr(results, "truncated_strategies", frozenset()),
+        )
+    except Exception as exc:
+        # A failed ownership check cannot justify a negative verdict.
+        raise _GrepExecutionIncomplete("Source ownership verification failed") from exc
+
+
+def _search_verification_evidence(
+    finding, project_root, *, search_all_strategies=False
+):
+    if search_all_strategies and _finding_language(finding) == "python":
+        # Search every strategy; retained evidence is still bounded. A lost
+        # match must not silently become a negative ownership conclusion.
+        with track_grep_evidence_limits() as limits:
+            results = multi_strategy_search(
+                finding, project_root, stop_after_strong_evidence=False
+            )
+        return GrepSearchResults(
+            results, truncated_strategies=limits.truncated_strategies
+        )
+    return multi_strategy_search(finding, project_root)
 
 
 def _serial_group_name(finding: dict) -> str:
@@ -350,24 +421,29 @@ def _plan_batched_finding(
     finding: dict,
     project_root: str,
     cache: Any,
+    evidence_filter: GrepEvidenceFilter | None = None,
 ) -> tuple[GrepVerdict | None, _PendingBatchFinding | None]:
     deterministic_verdict = _deterministic_suppression_verdict(finding)
     if deterministic_verdict:
         return deterministic_verdict, None
 
     group_name = _serial_group_name(finding)
+    if evidence_filter is not None:
+        group_name += ":all_strategies"
     cached = _load_cached_group_results(cache, group_name, finding)
     if cached is not None:
-        return _apply_deterministic_rules(cached, finding), None
+        return _apply_deterministic_rules(cached, finding, evidence_filter), None
 
     with record_grep_requests() as recorded:
-        planned_results = multi_strategy_search(finding, project_root)
+        planned_results = _search_verification_evidence(
+            finding, project_root, search_all_strategies=evidence_filter is not None
+        )
     unique_requests = tuple(dict.fromkeys(recorded))
     if unique_requests:
         return None, _PendingBatchFinding(finding, group_name, unique_requests)
 
     _store_cached_group_results(cache, group_name, finding, planned_results)
-    return _apply_deterministic_rules(planned_results, finding), None
+    return _apply_deterministic_rules(planned_results, finding, evidence_filter), None
 
 
 def _execute_pending_findings(
@@ -375,6 +451,7 @@ def _execute_pending_findings(
     project_root: str,
     cache: Any,
     deadline: float,
+    evidence_filter: GrepEvidenceFilter | None = None,
 ) -> tuple[dict[str, GrepVerdict], int, str | None]:
     requests = [request for item in pending for request in item.requests]
     try:
@@ -382,8 +459,7 @@ def _execute_pending_findings(
     except _GrepExecutionIncomplete as exc:
         reason = (
             "budget_exhausted"
-            if isinstance(exc, _GrepDeadlineExceeded)
-            or time.monotonic() >= deadline
+            if isinstance(exc, _GrepDeadlineExceeded) or time.monotonic() >= deadline
             else "verification_incomplete"
         )
         return {}, 0, reason
@@ -402,7 +478,11 @@ def _execute_pending_findings(
             return verdicts, verified_count, reason
         try:
             with replay_grep_results(batch_results, deadline=deadline):
-                search_results = multi_strategy_search(item.finding, project_root)
+                search_results = _search_verification_evidence(
+                    item.finding,
+                    project_root,
+                    search_all_strategies=evidence_filter is not None,
+                )
         except _GrepExecutionIncomplete as exc:
             logger.debug("grep replay was incomplete: %s", exc)
             reason = (
@@ -419,11 +499,13 @@ def _execute_pending_findings(
             _store_cached_group_results(
                 cache, item.group_name, item.finding, search_results
             )
-        verdict = _apply_deterministic_rules(search_results, item.finding)
+        verdict = _apply_deterministic_rules(
+            search_results, item.finding, evidence_filter
+        )
         if request_incomplete and not (verdict and verdict.alive):
             return verdicts, verified_count, "verification_incomplete"
         if verdict:
-            verdicts[_finding_full_name(item.finding)] = verdict
+            verdicts[_finding_verdict_key(item.finding)] = verdict
         verified_count += 1
         if time.monotonic() >= deadline and index + 1 < len(pending):
             return verdicts, verified_count, "budget_exhausted"
@@ -436,8 +518,11 @@ def _grep_verify_findings_batched(
     time_budget: float,
     cache: Any,
     start_time: float,
+    evidence_filter: GrepEvidenceFilter | None = None,
 ) -> GrepVerificationResult:
-    eligible_findings = [finding for finding in findings if _finding_full_name(finding)]
+    eligible_findings = [
+        finding for finding in findings if _finding_verdict_key(finding)
+    ]
     verdicts: dict[str, GrepVerdict] = {}
     pending: list[_PendingBatchFinding] = []
     deadline = start_time + time_budget
@@ -448,9 +533,14 @@ def _grep_verify_findings_batched(
         if time.monotonic() >= deadline:
             incomplete_reason = "budget_exhausted"
             break
-        full_name = _finding_full_name(finding)
+        full_name = _finding_verdict_key(finding)
 
-        verdict, planned = _plan_batched_finding(finding, project_root, cache)
+        if evidence_filter is None:
+            verdict, planned = _plan_batched_finding(finding, project_root, cache)
+        else:
+            verdict, planned = _plan_batched_finding(
+                finding, project_root, cache, evidence_filter
+            )
         if verdict:
             verdicts[full_name] = verdict
         if planned:
@@ -462,8 +552,8 @@ def _grep_verify_findings_batched(
         if time.monotonic() >= deadline:
             incomplete_reason = "budget_exhausted"
             break
-        batch_verdicts, batch_verified, incomplete_reason = (
-            _execute_pending_findings(pending, project_root, cache, deadline)
+        batch_verdicts, batch_verified, incomplete_reason = _execute_pending_findings(
+            pending, project_root, cache, deadline, evidence_filter
         )
         verdicts.update(batch_verdicts)
         verified_count += batch_verified
@@ -476,7 +566,9 @@ def _grep_verify_findings_batched(
             incomplete_reason = "budget_exhausted"
         else:
             batch_verdicts, batch_verified, incomplete_reason = (
-                _execute_pending_findings(pending, project_root, cache, deadline)
+                _execute_pending_findings(
+                    pending, project_root, cache, deadline, evidence_filter
+                )
             )
             verdicts.update(batch_verdicts)
             verified_count += batch_verified
@@ -499,7 +591,7 @@ def _process_finding(
     search_fn: Callable[[dict], dict[str, list[str]]],
     deadline: float | None = None,
 ) -> tuple[str, GrepVerdict | None]:
-    full_name = _finding_full_name(finding)
+    full_name = _finding_verdict_key(finding)
     if not full_name:
         return "", None
 
@@ -525,11 +617,9 @@ def _submit_next_finding(
     if time.monotonic() >= deadline:
         return False
     for finding in findings:
-        if not _finding_full_name(finding):
+        if not _finding_verdict_key(finding):
             continue
-        pending.add(
-            executor.submit(_process_finding, finding, search_fn, deadline)
-        )
+        pending.add(executor.submit(_process_finding, finding, search_fn, deadline))
         return True
     return False
 
@@ -575,7 +665,9 @@ def _grep_verify_findings_parallel(
     max_workers: int,
     start_time: float,
 ) -> GrepVerificationResult:
-    eligible_findings = [finding for finding in findings if _finding_full_name(finding)]
+    eligible_findings = [
+        finding for finding in findings if _finding_verdict_key(finding)
+    ]
     verdicts: dict[str, GrepVerdict] = {}
     worker_count = max(1, int(max_workers or _DEFAULT_GREP_WORKERS))
     deadline = start_time + time_budget
@@ -640,22 +732,39 @@ def grep_verify_findings(
     parallel: bool = False,
     max_workers: int = _DEFAULT_GREP_WORKERS,
     cache: Any = None,
+    evidence_filter: GrepEvidenceFilter | None = None,
 ) -> GrepVerificationResult:
     cache_binder = getattr(type(cache), "bind_repository", None)
     if callable(cache_binder):
         cache_binder(cache, project_root)
     start_time = time.monotonic()
     if not parallel:
-        return _grep_verify_findings_batched(
-            findings, project_root, time_budget, cache, start_time
-        )
+        try:
+            return _grep_verify_findings_batched(
+                findings, project_root, time_budget, cache, start_time, evidence_filter
+            )
+        except _GrepExecutionIncomplete:
+            return GrepVerificationResult(
+                {},
+                candidate_count=sum(bool(_finding_verdict_key(f)) for f in findings),
+                verified_count=0,
+                time_budget=time_budget,
+                incomplete_reason="verification_incomplete",
+            )
 
     search_fn = _build_grep_search_fn(
         project_root,
         parallel=False,
         max_workers=max_workers,
         cache=cache,
+        search_all_strategies=evidence_filter is not None,
     )
+    if evidence_filter is not None:
+        raw_search_fn = search_fn
+
+        def search_fn(finding):
+            return _filter_evidence(finding, raw_search_fn(finding), evidence_filter)
+
     return _grep_verify_findings_parallel(
         findings, search_fn, time_budget, max_workers, start_time
     )
@@ -667,8 +776,9 @@ def _build_grep_search_fn(
     parallel: bool,
     max_workers: int,
     cache: Any,
+    search_all_strategies: bool = False,
 ) -> Callable[[dict], dict[str, list[str]]]:
-    if parallel:
+    if parallel and not search_all_strategies:
 
         def search_fn(finding: dict) -> dict[str, list[str]]:
             return parallel_multi_strategy_search(
@@ -679,22 +789,30 @@ def _build_grep_search_fn(
 
     def search_fn(finding: dict) -> dict[str, list[str]]:
         if cache is None:
-            return multi_strategy_search(finding, project_root)
-        return _cached_serial_search_results(finding, project_root, cache)
+            return _search_verification_evidence(
+                finding, project_root, search_all_strategies=search_all_strategies
+            )
+        return _cached_serial_search_results(
+            finding, project_root, cache, search_all_strategies=search_all_strategies
+        )
 
     return search_fn
 
 
 def _cached_serial_search_results(
-    finding: dict, project_root: str, cache: Any
+    finding: dict, project_root: str, cache: Any, *, search_all_strategies: bool = False
 ) -> dict[str, list[str]]:
     lang = _finding_language(finding)
     group_name = "python_core" if lang == "python" else f"serial_{lang}"
+    if search_all_strategies:
+        group_name += ":all_strategies"
     return _cached_group_results(
         cache,
         group_name,
         finding,
-        lambda: multi_strategy_search(finding, project_root),
+        lambda: _search_verification_evidence(
+            finding, project_root, search_all_strategies=search_all_strategies
+        ),
     )
 
 

--- a/skylos/core/grep_verify_common.py
+++ b/skylos/core/grep_verify_common.py
@@ -19,6 +19,8 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from skylos.core.grep_search_state import grep_probe_limit, retain_grep_probe
+
 logger = logging.getLogger(__name__)
 
 
@@ -161,9 +163,7 @@ class _GrepEvidence(str):
 
     __slots__ = ("path", "line_number", "content")
 
-    def __new__(
-        cls, path: str, line_number: int, content: str
-    ) -> _GrepEvidence:
+    def __new__(cls, path: str, line_number: int, content: str) -> _GrepEvidence:
         value = super().__new__(cls, f"{path}:{line_number}:{content}")
         value.path = path
         value.line_number = line_number
@@ -258,9 +258,7 @@ class _GrepBatchResults(dict[GrepRequest, tuple[str, ...]]):
 
     def merge(self, other: Mapping[GrepRequest, tuple[str, ...]]) -> None:
         self.update(other)
-        self.incomplete_requests.update(
-            getattr(other, "incomplete_requests", ())
-        )
+        self.incomplete_requests.update(getattr(other, "incomplete_requests", ()))
 
 
 _GREP_REQUEST_RECORDER: ContextVar[list[GrepRequest] | None] = ContextVar(
@@ -485,9 +483,7 @@ def _split_grep_evidence(line: str) -> tuple[str, int | None, str]:
 
 def _is_ignored_grep_path(path: str) -> bool:
     components = [
-        component
-        for component in path.replace("\\", "/").split("/")
-        if component
+        component for component in path.replace("\\", "/").split("/") if component
     ]
     ignored_names = {
         ".git",
@@ -695,9 +691,7 @@ def _raise_for_bounded_process_failure(
     if state.timed_out:
         raise subprocess.TimeoutExpired(list(cmd), timeout)
     if state.stderr_overflow.is_set():
-        raise _GrepExecutionIncomplete(
-            "ripgrep stderr exceeded its size limit"
-        )
+        raise _GrepExecutionIncomplete("ripgrep stderr exceeded its size limit")
     if state.overflow.is_set():
         raise _GrepOutputLimitExceeded("ripgrep output exceeded its size limit")
     if state.thread_errors:
@@ -884,9 +878,7 @@ def _ripgrep_match_from_event(event: Mapping[str, object]) -> _GrepMatch | None:
     if not isinstance(data, dict):
         raise ValueError("ripgrep match has no data object")
     path = _ripgrep_json_text(data.get("path"), "path")
-    content = _remove_one_line_ending(
-        _ripgrep_json_text(data.get("lines"), "lines")
-    )
+    content = _remove_one_line_ending(_ripgrep_json_text(data.get("lines"), "lines"))
     return _GrepMatch(
         path=path,
         line_number=_ripgrep_line_number(data),
@@ -1051,28 +1043,22 @@ def _streamed_request_matches(
     regex = state.regexes[request]
     assert regex is not None
     python_matches = regex.search(match.content) is not None
-    if (
-        _ENGINE_SENSITIVE_SPACE_PATTERN.search(request.pattern)
-        and _contains_engine_divergent_space(match.content)
-    ):
+    if _ENGINE_SENSITIVE_SPACE_PATTERN.search(
+        request.pattern
+    ) and _contains_engine_divergent_space(match.content):
         state.requests_requiring_exact_search.add(request)
         return False
     if not match.content.isascii():
         needs_adjudication = bool(
             _UNICODE_CASE_INSENSITIVE_PATTERN.search(request.pattern)
         )
-        if (
-            not needs_adjudication
-            and _UNICODE_WORD_PATTERN.search(request.pattern)
-        ):
+        if not needs_adjudication and _UNICODE_WORD_PATTERN.search(request.pattern):
             needs_adjudication = _rust_and_python_word_classes_can_differ(
                 match.content,
                 deadline=state.deadline,
             )
         if needs_adjudication:
-            required_literal = _required_trailing_boundary_literal(
-                request.pattern
-            )
+            required_literal = _required_trailing_boundary_literal(request.pattern)
             if required_literal is None or required_literal in match.content:
                 state.requests_requiring_exact_search.add(request)
                 python_matches = False
@@ -1199,8 +1185,7 @@ def _prepare_streamed_grep(
     trust_ripgrep_attribution: bool,
 ) -> tuple[bytes, _StreamedGrepState]:
     retained_slots = sum(
-        max(request.max_results, _GREP_BATCH_RESULT_FLOOR)
-        for request in requests
+        max(request.max_results, _GREP_BATCH_RESULT_FLOOR) for request in requests
     )
     if retained_slots > _GREP_BATCH_MAX_MATCHES:
         raise _GrepOutputLimitExceeded(
@@ -1216,12 +1201,9 @@ def _prepare_streamed_grep(
         for request in requests
     }
     if any(
-        regex is None and not request.fixed_string
-        for request, regex in regexes.items()
+        regex is None and not request.fixed_string for request, regex in regexes.items()
     ):
-        raise _GrepExecutionIncomplete(
-            "streamed grep received an unsupported regex"
-        )
+        raise _GrepExecutionIncomplete("streamed grep received an unsupported regex")
     return encoded_input, _StreamedGrepState(
         requests=tuple(requests),
         matches={request: [] for request in requests},
@@ -1447,9 +1429,7 @@ def _ripgrep_stdin_match_positions(
     whole request there would drop real evidence.
     """
     positions: set[int] = set()
-    for offset, chunk in _grep_stdin_chunks(
-        contents, _GREP_UNICODE_MAX_INPUT_BYTES
-    ):
+    for offset, chunk in _grep_stdin_chunks(contents, _GREP_UNICODE_MAX_INPUT_BYTES):
         if _deadline_expired(deadline):
             raise _GrepDeadlineExceeded("deadline exceeded while adjudicating grep")
         result = _run_bounded_subprocess(
@@ -1514,9 +1494,7 @@ def _word_divergent_lines(
             raise _GrepDeadlineExceeded(
                 "deadline exceeded while checking non-ASCII lines"
             )
-        if _rust_and_python_word_classes_can_differ(
-            line[1], deadline=deadline
-        ):
+        if _rust_and_python_word_classes_can_differ(line[1], deadline=deadline):
             divergent.append(line)
     return divergent
 
@@ -1655,17 +1633,13 @@ def _run_ripgrep_batch(
     if not batched:
         return _run_serial_grep_requests(direct, deadline=deadline)
 
-    grep_matches = _run_ripgrep_pattern_file(
-        batched, rg, timeout, deadline=deadline
-    )
+    grep_matches = _run_ripgrep_pattern_file(batched, rg, timeout, deadline=deadline)
     non_ascii_lines = [
         (index, match.content)
         for index, match in enumerate(grep_matches)
         if not match.content.isascii()
     ]
-    word_divergent_lines = _word_divergent_lines(
-        non_ascii_lines, deadline=deadline
-    )
+    word_divergent_lines = _word_divergent_lines(non_ascii_lines, deadline=deadline)
     has_space_pattern = any(
         not request.fixed_string
         and _ENGINE_SENSITIVE_SPACE_PATTERN.search(request.pattern)
@@ -1744,9 +1718,7 @@ def _run_ripgrep_batch(
                 request.pattern,
                 exc,
             )
-    batch_results.merge(
-        _run_serial_grep_requests(direct, deadline=deadline)
-    )
+    batch_results.merge(_run_serial_grep_requests(direct, deadline=deadline))
     return batch_results
 
 
@@ -1803,13 +1775,9 @@ def _recover_from_grep_resource_limit(
     midpoint = len(requests) // 2
     logger.debug("splitting oversized grep batch of %d requests", len(requests))
     results = _GrepBatchResults()
-    results.merge(
-        _execute_grep_chunk(requests[:midpoint], rg, deadline=deadline)
-    )
+    results.merge(_execute_grep_chunk(requests[:midpoint], rg, deadline=deadline))
     if not _deadline_expired(deadline):
-        results.merge(
-            _execute_grep_chunk(requests[midpoint:], rg, deadline=deadline)
-        )
+        results.merge(_execute_grep_chunk(requests[midpoint:], rg, deadline=deadline))
     return results
 
 
@@ -1908,7 +1876,7 @@ def _run_grep(
         use_regex=use_regex,
         include_globs=include_globs,
         fixed_string=fixed_string,
-        max_results=max_results,
+        max_results=grep_probe_limit(max_results),
     )
     recorder = _GREP_REQUEST_RECORDER.get()
     if recorder is not None:
@@ -1919,21 +1887,23 @@ def _run_grep(
     if replay is not None:
         replayed = replay.get(request)
         if replayed is not None:
-            return list(replayed)
+            return retain_grep_probe(list(replayed), max_results)
         logger.warning("grep replay miss for pattern %r; executing directly", pattern)
         deadline = _GREP_REPLAY_DEADLINE.get()
-        return (
+        lines = (
             _run_grep_request(request)
             if deadline is None
             else _run_grep_request(request, deadline=deadline)
         )
+        return retain_grep_probe(lines, max_results)
 
     deadline = _GREP_EXECUTION_DEADLINE.get()
-    return (
+    lines = (
         _run_grep_request(request)
         if deadline is None
         else _run_grep_request(request, deadline=deadline)
     )
+    return retain_grep_probe(lines, max_results)
 
 
 def repo_relative_path(file_path: str, project_root: str | Path) -> str:
@@ -2066,9 +2036,7 @@ def _grep_paths_equal(first: str, second: str) -> bool:
     normalized_first = first.replace("\\", "/")
     normalized_second = second.replace("\\", "/")
     if _HOST_PATH_CASE_INSENSITIVE:
-        return ntpath.normcase(normalized_first) == ntpath.normcase(
-            normalized_second
-        )
+        return ntpath.normcase(normalized_first) == ntpath.normcase(normalized_second)
     return normalized_first == normalized_second
 
 
@@ -2267,11 +2235,7 @@ def _deduplicate_grep_results(
         unique = []
         for line in lines:
             path, line_number, _ = _split_grep_evidence(line)
-            key = (
-                f"{path}\0{line_number}"
-                if line_number is not None
-                else str(line)
-            )
+            key = f"{path}\0{line_number}" if line_number is not None else str(line)
             if key not in seen_in_strategy:
                 seen_in_strategy.add(key)
                 unique.append(line)

--- a/skylos/core/grep_verify_python_strategy.py
+++ b/skylos/core/grep_verify_python_strategy.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 
+from skylos.core.grep_search_state import grep_evidence_strategy, limit_grep_evidence
+
 from skylos.core.grep_verify_common import (
     _deduplicate_grep_results,
     _filter_other_owner_same_method_calls,
@@ -22,6 +24,11 @@ from skylos.core.grep_verify_strategies import (
 )
 
 
+def _strategy_search(strategy, *args, **kwargs):
+    with grep_evidence_strategy(strategy):
+        return _run_grep(*args, **kwargs)
+
+
 def _parameter_contract_search(
     finding: dict,
     project_root: str,
@@ -37,7 +44,8 @@ def _parameter_contract_search(
         return results
 
     callback_pattern = rf"callback\s*=\s*(?:[\w\.]+\.)*{re.escape(owner_simple_name)}\b"
-    callback_refs = _run_grep(
+    callback_refs = _strategy_search(
+        "callback_registrations",
         callback_pattern,
         project_root,
         use_regex=True,
@@ -45,12 +53,15 @@ def _parameter_contract_search(
         max_results=max_per_strategy,
     )
     if callback_refs:
-        results["callback_registrations"] = callback_refs[:max_per_strategy]
+        results["callback_registrations"] = limit_grep_evidence(
+            callback_refs, max_per_strategy, strategy="callback_registrations"
+        )
 
     signature_pattern = (
         rf"def\s+{re.escape(owner_simple_name)}\s*\([^)]*\b{re.escape(simple_name)}\b"
     )
-    signature_refs = _run_grep(
+    signature_refs = _strategy_search(
+        "signature_overrides",
         signature_pattern,
         project_root,
         use_regex=True,
@@ -70,7 +81,9 @@ def _parameter_contract_search(
                 continue
             override_refs.append(ref)
         if override_refs:
-            results["signature_overrides"] = override_refs[:max_per_strategy]
+            results["signature_overrides"] = limit_grep_evidence(
+                override_refs, max_per_strategy, strategy="signature_overrides"
+            )
 
     return _deduplicate_grep_results(results)
 
@@ -81,6 +94,7 @@ def multi_strategy_search(
     *,
     max_per_strategy: int = _MAX_RESULTS_PER_STRATEGY,
     early_exit_threshold: int = 5,
+    stop_after_strong_evidence: bool = True,
 ) -> dict[str, list[str]]:
     simple_name = finding.get("simple_name", finding.get("name", ""))
     full_name = finding.get("full_name", "")
@@ -123,6 +137,8 @@ def multi_strategy_search(
         )
 
     def _should_early_exit() -> bool:
+        if not stop_after_strong_evidence:
+            return False
         for strategy in _STRONG_ALIVE_STRATEGIES:
             hits = results.get(strategy, [])
             if len(hits) >= early_exit_threshold:
@@ -131,7 +147,8 @@ def multi_strategy_search(
 
     boundary_pattern = rf"\b{simple_name}\b"
     if kind != "import":
-        refs = _run_grep(
+        refs = _strategy_search(
+            "references",
             boundary_pattern,
             project_root,
             use_regex=True,
@@ -148,7 +165,9 @@ def multi_strategy_search(
             refs = _filter_other_owner_same_method_calls(refs, finding)
             _defs, usages = filter_grep_results(refs, finding)
             if usages:
-                results["references"] = usages[:max_per_strategy]
+                results["references"] = limit_grep_evidence(
+                    usages, max_per_strategy, strategy="references"
+                )
             elif _defs:
                 results["references_definition_only"] = [
                     "(only the definition itself found, no usages)"
@@ -158,7 +177,8 @@ def multi_strategy_search(
         return _deduplicate_grep_results(results)
 
     if full_name and full_name != simple_name:
-        qualified_refs = _run_grep(
+        qualified_refs = _strategy_search(
+            "qualified_references",
             rf"\b{re.escape(full_name)}\b",
             project_root,
             use_regex=True,
@@ -173,11 +193,14 @@ def multi_strategy_search(
             ]
             _defs, usages = filter_grep_results(qualified_refs, finding)
             if usages:
-                results["qualified_references"] = usages[:max_per_strategy]
+                results["qualified_references"] = limit_grep_evidence(
+                    usages, max_per_strategy, strategy="qualified_references"
+                )
 
     if kind in ("method", "function"):
         call_pattern = rf"\.{re.escape(simple_name)}[[:space:]]*\("
-        call_refs = _run_grep(
+        call_refs = _strategy_search(
+            "method_calls",
             call_pattern,
             project_root,
             use_regex=True,
@@ -188,11 +211,14 @@ def multi_strategy_search(
             call_refs = _filter_other_owner_same_method_calls(call_refs, finding)
             _defs, usages = filter_grep_results(call_refs, finding)
             if usages:
-                results["method_calls"] = usages[:max_per_strategy]
+                results["method_calls"] = limit_grep_evidence(
+                    usages, max_per_strategy, strategy="method_calls"
+                )
 
     if kind != "import":
         import_pattern = rf"import.*\b{simple_name}\b"
-        import_refs = _run_grep(
+        import_refs = _strategy_search(
+            "imports",
             import_pattern,
             project_root,
             use_regex=True,
@@ -202,7 +228,9 @@ def multi_strategy_search(
         if import_refs:
             _defs, usages = filter_grep_results(import_refs, finding)
             if usages:
-                results["imports"] = usages[:max_per_strategy]
+                results["imports"] = limit_grep_evidence(
+                    usages, max_per_strategy, strategy="imports"
+                )
 
     if _should_early_exit():
         return _deduplicate_grep_results(results)
@@ -215,7 +243,8 @@ def multi_strategy_search(
         rf"[{quote_chars}]{re.escape(simple_name)}[{quote_chars}][[:space:]]*:[[:space:]]*[[:alnum:]_]+[[:space:]]*\(",
     ]
     for dp in dispatch_patterns:
-        dp_refs = _run_grep(
+        dp_refs = _strategy_search(
+            "string_dispatch",
             dp,
             project_root,
             use_regex=True,
@@ -230,13 +259,20 @@ def multi_strategy_search(
             ]
             _defs, usages = filter_grep_results(dp_refs, finding)
             if usages:
-                results["string_dispatch"] = usages[:max_per_strategy]
-                break
+                combined = _deduplicate_grep_results(
+                    {"string_dispatch": results.get("string_dispatch", []) + usages}
+                )["string_dispatch"]
+                results["string_dispatch"] = limit_grep_evidence(
+                    combined, max_per_strategy, strategy="string_dispatch"
+                )
+                if stop_after_strong_evidence:
+                    break
 
     if _should_early_exit():
         return _deduplicate_grep_results(results)
 
-    all_refs = _run_grep(
+    all_refs = _strategy_search(
+        "exported_in_all",
         rf"__all__.*\b{simple_name}\b",
         project_root,
         use_regex=True,
@@ -244,11 +280,14 @@ def multi_strategy_search(
         max_results=max_per_strategy,
     )
     if all_refs:
-        results["exported_in_all"] = all_refs[:max_per_strategy]
+        results["exported_in_all"] = limit_grep_evidence(
+            all_refs, max_per_strategy, strategy="exported_in_all"
+        )
 
     if kind in ("import", "variable", "class"):
         cast_pattern = rf'cast\(\s*["\x27]{simple_name}["\x27]'
-        cast_refs = _run_grep(
+        cast_refs = _strategy_search(
+            "cast_usage",
             cast_pattern,
             project_root,
             use_regex=True,
@@ -258,10 +297,13 @@ def multi_strategy_search(
         if cast_refs:
             _defs, usages = filter_grep_results(cast_refs, finding)
             if usages:
-                results["cast_usage"] = usages[:max_per_strategy]
+                results["cast_usage"] = limit_grep_evidence(
+                    usages, max_per_strategy, strategy="cast_usage"
+                )
 
         bound_pattern = rf'bound\s*=\s*["\x27]{simple_name}["\x27]'
-        bound_refs = _run_grep(
+        bound_refs = _strategy_search(
+            "typevar_bound",
             bound_pattern,
             project_root,
             use_regex=True,
@@ -271,7 +313,9 @@ def multi_strategy_search(
         if bound_refs:
             _defs, usages = filter_grep_results(bound_refs, finding)
             if usages:
-                results["typevar_bound"] = usages[:max_per_strategy]
+                results["typevar_bound"] = limit_grep_evidence(
+                    usages, max_per_strategy, strategy="typevar_bound"
+                )
 
     elif kind == "method":
         method_parts = full_name.split(".")
@@ -279,7 +323,8 @@ def multi_strategy_search(
             parent_class = method_parts[-2]
             if len(parent_class) > 2:
                 cast_pattern = rf"cast\([^,]+,\s*[^)]*\b{parent_class}\b"
-                cast_refs = _run_grep(
+                cast_refs = _strategy_search(
+                    "cast_protocol",
                     cast_pattern,
                     project_root,
                     use_regex=True,
@@ -289,9 +334,12 @@ def multi_strategy_search(
                 if cast_refs:
                     _defs, usages = filter_grep_results(cast_refs, finding)
                     if usages:
-                        results["cast_protocol"] = usages[:max_per_strategy]
+                        results["cast_protocol"] = limit_grep_evidence(
+                            usages, max_per_strategy, strategy="cast_protocol"
+                        )
 
-    test_refs = _run_grep(
+    test_refs = _strategy_search(
+        "test_references",
         rf"\b{simple_name}\b",
         project_root,
         use_regex=True,
@@ -302,21 +350,30 @@ def multi_strategy_search(
         test_refs = [r for r in test_refs if not is_substring_match(r, simple_name)]
         _defs, test_usages = filter_grep_results(test_refs, finding)
         if test_usages:
-            results["test_references"] = test_usages[:max_per_strategy]
+            results["test_references"] = limit_grep_evidence(
+                test_usages, max_per_strategy, strategy="test_references"
+            )
 
     if _should_early_exit():
         return _deduplicate_grep_results(results)
 
     if rel_file and rel_file.endswith(".py"):
-        file_refs = _run_grep(
-            rel_file, project_root, fixed_string=True, max_results=max_per_strategy
+        file_refs = _strategy_search(
+            "file_path_references",
+            rel_file,
+            project_root,
+            fixed_string=True,
+            max_results=max_per_strategy,
         )
         if file_refs:
             _defs, usages = filter_grep_results(file_refs, finding)
             if usages:
-                results["file_path_references"] = usages[:max_per_strategy]
+                results["file_path_references"] = limit_grep_evidence(
+                    usages, max_per_strategy, strategy="file_path_references"
+                )
 
-        config_refs = _run_grep(
+        config_refs = _strategy_search(
+            "config_references",
             rel_file,
             project_root,
             fixed_string=True,
@@ -326,19 +383,32 @@ def multi_strategy_search(
         if config_refs:
             _defs, usages = filter_grep_results(config_refs, finding)
             if usages:
-                results["config_references"] = usages[:max_per_strategy]
+                results["config_references"] = limit_grep_evidence(
+                    usages, max_per_strategy, strategy="config_references"
+                )
 
     for module_name in module_names:
-        module_refs = _run_grep(
-            module_name, project_root, fixed_string=True, max_results=max_per_strategy
+        module_refs = _strategy_search(
+            "module_references",
+            module_name,
+            project_root,
+            fixed_string=True,
+            max_results=max_per_strategy,
         )
         if module_refs:
             _defs, usages = filter_grep_results(module_refs, finding)
             if usages:
-                results["module_references"] = usages[:max_per_strategy]
-                break
+                combined = _deduplicate_grep_results(
+                    {"module_references": results.get("module_references", []) + usages}
+                )["module_references"]
+                results["module_references"] = limit_grep_evidence(
+                    combined, max_per_strategy, strategy="module_references"
+                )
+                if stop_after_strong_evidence:
+                    break
 
-    doc_refs = _run_grep(
+    doc_refs = _strategy_search(
+        "documentation",
         rf"\b{simple_name}\b",
         project_root,
         use_regex=True,
@@ -367,9 +437,11 @@ def multi_strategy_search(
                 )
             ]
             if compatibility_refs:
-                results["compatibility_references"] = compatibility_refs[
-                    :max_per_strategy
-                ]
+                results["compatibility_references"] = limit_grep_evidence(
+                    compatibility_refs,
+                    max_per_strategy,
+                    strategy="compatibility_references",
+                )
             sphinx_refs = [
                 r
                 for r in doc_refs
@@ -390,9 +462,13 @@ def multi_strategy_search(
                 )
             ]
             if sphinx_refs:
-                results["sphinx_directive"] = sphinx_refs[:max_per_strategy]
+                results["sphinx_directive"] = limit_grep_evidence(
+                    sphinx_refs, max_per_strategy, strategy="sphinx_directive"
+                )
             else:
-                results["doc_references"] = doc_refs[:max_per_strategy]
+                results["doc_references"] = limit_grep_evidence(
+                    doc_refs, max_per_strategy, strategy="doc_references"
+                )
 
             if not simple_name.startswith("_"):
                 changelog_patterns = [
@@ -417,14 +493,17 @@ def multi_strategy_search(
                         continue
                     api_refs.append(ref)
                 if api_refs:
-                    results["public_api_docs"] = api_refs[:max_per_strategy]
+                    results["public_api_docs"] = limit_grep_evidence(
+                        api_refs, max_per_strategy, strategy="public_api_docs"
+                    )
 
     if kind == "method":
         parts = full_name.split(".")
         if len(parts) >= 2:
             class_name = parts[-2]
             if len(class_name) > 2:
-                class_refs = _run_grep(
+                class_refs = _strategy_search(
+                    "class_usage",
                     rf"\b{class_name}\b",
                     project_root,
                     use_regex=True,
@@ -441,6 +520,8 @@ def multi_strategy_search(
                             continue
                         usage_lines.append(cr)
                     if usage_lines:
-                        results["class_usage"] = usage_lines[:max_per_strategy]
+                        results["class_usage"] = limit_grep_evidence(
+                            usage_lines, max_per_strategy, strategy="class_usage"
+                        )
 
     return _deduplicate_grep_results(results)

--- a/skylos/deadcode/_reachability_bindings.py
+++ b/skylos/deadcode/_reachability_bindings.py
@@ -1,0 +1,163 @@
+"""Lexical bindings used by the conservative Python reachability pass."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+Binding = tuple[str, str]
+Bindings = dict[str, Binding | None]
+FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+FUNCTION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef)
+MODULE_BINDING = "module"
+QUALIFIED_BINDING = "qualified"
+
+
+@dataclass
+class ModuleInfo:
+    path: Path
+    tree: ast.Module
+    names: set[str] = field(default_factory=set)
+    bindings: Bindings = field(default_factory=dict)
+    functions: dict[int, str] = field(default_factory=dict)
+
+
+class BoundNames(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.counts: Counter[str] = Counter()
+        self.scope_writes = False
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, (ast.Store, ast.Del)):
+            self.counts[node.id] += 1
+
+    def visit_FunctionDef(self, node: FunctionNode | ast.ClassDef) -> None:
+        self.counts[node.name] += 1
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+    visit_ClassDef = visit_FunctionDef
+
+    def visit(self, node: ast.AST) -> None:
+        """Skip lambda bodies, whose assignments have a separate scope."""
+        if not isinstance(node, ast.Lambda):
+            super().visit(node)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self.counts[alias.asname or alias.name.split(".")[0]] += 1
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        for alias in node.names:
+            self.counts[alias.asname or alias.name] += 1
+
+    def visit_Global(self, node: ast.Global | ast.Nonlocal) -> None:
+        self.scope_writes = True
+        self.counts.update(node.names)
+
+    visit_Nonlocal = visit_Global
+
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        if node.name:
+            self.counts[node.name] += 1
+        self.generic_visit(node)
+
+    def visit_MatchAs(self, node: ast.MatchAs | ast.MatchStar) -> None:
+        if node.name:
+            self.counts[node.name] += 1
+        self.generic_visit(node)
+
+    visit_MatchStar = visit_MatchAs
+
+    def visit_MatchMapping(self, node: ast.MatchMapping) -> None:
+        if node.rest:
+            self.counts[node.rest] += 1
+        self.generic_visit(node)
+
+
+def bound_names(nodes: Iterable[ast.AST]) -> BoundNames:
+    collector = BoundNames()
+    for node in nodes:
+        collector.visit(node)
+    return collector
+
+
+def _relative_parent(node: ast.ImportFrom, module: ModuleInfo) -> str | None:
+    identities = {name for name in module.names if name}
+    if len(identities) != 1:
+        return None
+    identity = next(iter(identities))
+    package = (
+        identity if module.path.name == "__init__.py" else identity.rpartition(".")[0]
+    )
+    parts = package.split(".") if package else []
+    if node.level > len(parts):
+        return None
+    prefix = parts[: len(parts) - node.level + 1]
+    if node.module:
+        prefix.append(node.module)
+    return ".".join(prefix)
+
+
+def import_bindings(node: ast.Import | ast.ImportFrom, module: ModuleInfo) -> Bindings:
+    if isinstance(node, ast.Import):
+        return {_import_name(alias): _import_target(alias) for alias in node.names}
+    parent = _relative_parent(node, module) if node.level else node.module or ""
+    return _from_imports(node, parent)
+
+
+def _from_imports(node: ast.ImportFrom, parent: str | None) -> Bindings:
+    if parent is None:
+        return {alias.asname or alias.name: None for alias in node.names}
+    return {
+        alias.asname or alias.name: (QUALIFIED_BINDING, f"{parent}.{alias.name}")
+        for alias in node.names
+        if alias.name != "*"
+    }
+
+
+def _import_name(alias: ast.alias) -> str:
+    return alias.asname or alias.name.split(".")[0]
+
+
+def _import_target(alias: ast.alias) -> Binding:
+    return (MODULE_BINDING, alias.name if alias.asname else alias.name.split(".")[0])
+
+
+def argument_nodes(arguments: ast.arguments) -> list[ast.arg]:
+    named = [*arguments.posonlyargs, *arguments.args, *arguments.kwonlyargs]
+    return named + [
+        arg for arg in (arguments.vararg, arguments.kwarg) if arg is not None
+    ]
+
+
+def default_expressions(arguments: ast.arguments) -> list[ast.expr]:
+    return [
+        *arguments.defaults,
+        *(value for value in arguments.kw_defaults if value is not None),
+    ]
+
+
+def function_bindings(node: FunctionNode, module: ModuleInfo) -> tuple[Bindings, bool]:
+    names = bound_names(node.body)
+    parameters = {arg.arg for arg in argument_nodes(node.args)}
+    local: Bindings = dict.fromkeys(names.counts.keys() | parameters)
+    for statement in node.body:
+        if isinstance(statement, (ast.Import, ast.ImportFrom)):
+            local.update(_stable_imports(statement, module, names.counts, parameters))
+    return local, names.scope_writes
+
+
+def _stable_imports(
+    statement: ast.Import | ast.ImportFrom,
+    module: ModuleInfo,
+    counts: Counter[str],
+    parameters: set[str],
+) -> Bindings:
+    return {
+        name: value
+        for name, value in import_bindings(statement, module).items()
+        if counts[name] == 1 and name not in parameters
+    }

--- a/skylos/deadcode/_reachability_graph.py
+++ b/skylos/deadcode/_reachability_graph.py
@@ -1,0 +1,193 @@
+"""Definition identities, source references and separate uncertainty edges."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter, defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from skylos.deadcode._reachability_bindings import (
+    MODULE_BINDING,
+    QUALIFIED_BINDING,
+    Binding,
+    Bindings,
+    ModuleInfo,
+)
+
+if TYPE_CHECKING:
+    from skylos.visitors.base import Definition
+
+
+@dataclass(frozen=True)
+class SourceReference:
+    name: str
+    target: str | None
+    owner: str | None
+
+
+@dataclass
+class SourceIndex:
+    modules: dict[Path, ModuleInfo] = field(default_factory=dict)
+    module_names: dict[str, list[ModuleInfo]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    candidates: dict[str, Definition] = field(default_factory=dict)
+    by_location: dict[tuple[Path, int], str] = field(default_factory=dict)
+    by_name: dict[str, list[str]] = field(default_factory=lambda: defaultdict(list))
+    by_simple_name: dict[str, set[str]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
+    initial_references: dict[str, int] = field(default_factory=dict)
+    binding_targets: dict[Binding | None, frozenset[str]] = field(default_factory=dict)
+
+    def qualified(self, name: str, seen: tuple[str, ...] = ()) -> Binding | None:
+        if name in seen or len(seen) >= 24:
+            return None
+        parts = name.split(".")
+        for end in range(len(parts), 0, -1):
+            modules = self.module_names.get(".".join(parts[:end]), ())
+            if len(modules) == 1:
+                return self._module_member(modules[0], name, parts, end, seen)
+        return None
+
+    def _module_member(
+        self,
+        module: ModuleInfo,
+        name: str,
+        parts: list[str],
+        end: int,
+        seen: tuple[str, ...],
+    ) -> Binding | None:
+        if end == len(parts):
+            return (MODULE_BINDING, name)
+        if end != len(parts) - 1:
+            return None
+        binding = module.bindings.get(parts[-1])
+        if binding and binding[0] == QUALIFIED_BINDING:
+            binding = self.qualified(binding[1], (*seen, name))
+        return binding
+
+    def resolve(
+        self, node: ast.AST, module: ModuleInfo, local: Bindings
+    ) -> Binding | None:
+        binding = None
+        if isinstance(node, ast.Name):
+            binding = (
+                local.get(node.id) if node.id in local else module.bindings.get(node.id)
+            )
+            if binding and binding[0] == QUALIFIED_BINDING:
+                binding = self.qualified(binding[1])
+        elif isinstance(node, ast.Attribute):
+            base = self.resolve(node.value, module, local)
+            if base and base[0] == MODULE_BINDING:
+                binding = self.qualified(f"{base[1]}.{node.attr}")
+        return binding
+
+    def escaped_symbols(self, binding: Binding | None) -> frozenset[str]:
+        cached = self.binding_targets.get(binding)
+        if cached is not None:
+            return cached
+        possible: set[str] = set()
+        todo = [binding]
+        seen = set()
+        while todo:
+            current = todo.pop()
+            if current and current not in seen:
+                seen.add(current)
+                self._expand_binding(current, possible, todo)
+        result = frozenset(possible)
+        self.binding_targets[binding] = result
+        return result
+
+    def _expand_binding(
+        self, binding: Binding, possible: set[str], todo: list[Binding | None]
+    ) -> None:
+        kind, name = binding
+        if kind == "symbol":
+            possible.add(name)
+        elif kind == QUALIFIED_BINDING:
+            todo.append(self.qualified(name))
+        elif kind == MODULE_BINDING:
+            for module in self.module_names.get(name, ()):
+                possible.update(module.functions.values())
+                todo.extend(module.bindings.values())
+
+
+@dataclass
+class ReferenceGraph:
+    edges: dict[str, set[str]] = field(default_factory=lambda: defaultdict(set))
+    uncertain_edges: dict[str, set[str]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
+    opaque_owners: set[str] = field(default_factory=set)
+    roots: set[str] = field(default_factory=set)
+    uncertain_roots: set[str] = field(default_factory=set)
+    observed: Counter[str] = field(default_factory=Counter)
+    references: dict[tuple[Path, int], list[SourceReference]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+
+    def protect(self, symbols: Iterable[str], owner: str | None) -> None:
+        destination = (
+            self.uncertain_roots if owner is None else self.uncertain_edges[owner]
+        )
+        destination.update(symbols)
+
+    def record(
+        self,
+        index: SourceIndex,
+        module: ModuleInfo,
+        node: ast.AST,
+        name: str,
+        binding: Binding | None,
+        *,
+        owner: str | None,
+        import_only: bool = False,
+        proven: bool = True,
+    ) -> None:
+        target = binding[1] if binding and binding[0] == "symbol" else None
+        self._record_lines(module.path, node, SourceReference(name, target, owner))
+        if target is None:
+            if not import_only:
+                self.protect(index.by_simple_name.get(name, ()), owner)
+            return
+        self.observed[target] += 1
+        if not import_only:
+            self._add_edge(target, owner, proven=proven)
+
+    def _record_lines(
+        self, path: Path, node: ast.AST, reference: SourceReference
+    ) -> None:
+        start = getattr(node, "lineno", 0)
+        end = getattr(node, "end_lineno", start)
+        if 0 < start <= end and end - start < 64:
+            for line in range(start, end + 1):
+                self.references[path, line].append(reference)
+
+    def _add_edge(self, target: str, owner: str | None, *, proven: bool) -> None:
+        if owner is None:
+            (self.roots if proven else self.uncertain_roots).add(target)
+        else:
+            self.edges[owner].add(target)
+
+    def traverse(
+        self, roots: Iterable[str], candidates: Iterable[str], *, uncertainty: bool
+    ) -> set[str]:
+        reached = set()
+        todo = list(roots)
+        expanded_opaque = False
+        while todo:
+            key = todo.pop()
+            if key in reached:
+                continue
+            reached.add(key)
+            todo.extend(self.edges.get(key, ()))
+            if uncertainty:
+                todo.extend(self.uncertain_edges.get(key, ()))
+                if key in self.opaque_owners and not expanded_opaque:
+                    todo.extend(candidates)
+                    expanded_opaque = True
+        return reached

--- a/skylos/deadcode/_reachability_visitor.py
+++ b/skylos/deadcode/_reachability_visitor.py
@@ -1,0 +1,264 @@
+"""AST source ownership, with explicit boundaries for deferred execution."""
+
+from __future__ import annotations
+import ast
+import re
+from skylos.deadcode._reachability_bindings import (
+    MODULE_BINDING,
+    Binding,
+    Bindings,
+    FunctionNode,
+    ModuleInfo,
+    argument_nodes,
+    bound_names,
+    default_expressions,
+    function_bindings,
+    import_bindings,
+)
+from skylos.deadcode._reachability_graph import (
+    ReferenceGraph,
+    SourceIndex,
+    SourceReference,
+)
+
+_EXPORT_LIST = "__all__"
+
+_DYNAMIC_NAMES = {
+    "eval",
+    "exec",
+    "globals",
+    "locals",
+    "__import__",
+    "__builtins__",
+    "getattr",
+    "setattr",
+    "delattr",
+    "vars",
+}
+_DYNAMIC_ATTRIBUTES = {
+    "import_module",
+    "__getattribute__",
+    "__dict__",
+    "__globals__",
+    "__builtins__",
+}
+
+
+class SourceVisitor(ast.NodeVisitor):
+    def __init__(
+        self, index: SourceIndex, graph: ReferenceGraph, module: ModuleInfo
+    ) -> None:
+        self.index = index
+        self.graph = graph
+        self.module = module
+        self.local: Bindings = {}
+        self.owner: str | None = None
+        self.proven_context = True
+
+    def _protect_binding(self, binding: Binding | None) -> None:
+        self.graph.protect(self.index.escaped_symbols(binding), self.owner)
+
+    def _binding_is_ambiguous(self, name: str) -> bool:
+        return self.index.resolve(ast.Name(id=name), self.module, self.local) is None
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if not isinstance(node.value, str):
+            return
+        if len(node.value) > 65_536:
+            self._opaque()
+            self.graph.references[self.module.path, node.lineno].append(
+                SourceReference("*", None, self.owner)
+            )
+            return
+        for name in set(re.findall(r"\w+", node.value)):
+            if name in self.index.by_simple_name:
+                self.graph.record(
+                    self.index, self.module, node, name, None, owner=self.owner
+                )
+
+    def visit_Name(self, node: ast.Name) -> None:
+        if isinstance(node.ctx, ast.Load):
+            if node.id in _DYNAMIC_NAMES:
+                self._opaque()
+            binding = self.index.resolve(node, self.module, self.local)
+            self.graph.record(
+                self.index,
+                self.module,
+                node,
+                node.id,
+                binding,
+                owner=self.owner,
+                proven=self.proven_context,
+            )
+            if binding and binding[0] == MODULE_BINDING:
+                self._protect_binding(binding)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if isinstance(node.ctx, ast.Load):
+            if node.attr in _DYNAMIC_ATTRIBUTES:
+                self._opaque()
+            binding = self.index.resolve(node, self.module, self.local)
+            self.graph.record(
+                self.index,
+                self.module,
+                node,
+                node.attr,
+                binding,
+                owner=self.owner,
+                proven=self.proven_context,
+            )
+        # Looking up a resolved module attribute does not itself pass the
+        # module object to unknown code. A standalone module value does.
+        if isinstance(node.value, ast.Name):
+            base = self.index.resolve(node.value, self.module, self.local)
+            if base and base[0] == MODULE_BINDING:
+                return
+        self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            binding = import_bindings(node, self.module).get(
+                alias.asname or alias.name.split(".")[0]
+            )
+            self.graph.record(
+                self.index,
+                self.module,
+                alias,
+                alias.name,
+                binding,
+                owner=self.owner,
+                import_only=True,
+            )
+            if self._binding_is_ambiguous(alias.asname or alias.name.split(".")[0]):
+                self._protect_binding(binding)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if any(alias.name == "*" for alias in node.names):
+            self._opaque()
+        bindings = import_bindings(node, self.module)
+        for alias in node.names:
+            self._visit_import_alias(node, alias, bindings)
+
+    def _visit_import_alias(
+        self, node: ast.ImportFrom, alias: ast.alias, bindings: Bindings
+    ) -> None:
+        if node.module in {"builtins", "importlib"} and alias.name in (
+            _DYNAMIC_NAMES | _DYNAMIC_ATTRIBUTES
+        ):
+            self._opaque()
+        binding = bindings.get(alias.asname or alias.name)
+        if binding and binding[0] == "qualified":
+            binding = self.index.qualified(binding[1])
+        self.graph.record(
+            self.index,
+            self.module,
+            alias,
+            alias.name,
+            binding,
+            owner=self.owner,
+            import_only=binding is not None,
+        )
+        if self._binding_is_ambiguous(alias.asname or alias.name):
+            self._protect_binding(binding)
+
+    def _opaque(self) -> None:
+        if self.owner is None:
+            self.graph.uncertain_roots.update(self.index.candidates)
+        else:
+            self.graph.opaque_owners.add(self.owner)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == _EXPORT_LIST
+            and not all(
+                isinstance(argument, ast.Constant) and isinstance(argument.value, str)
+                for argument in node.args
+            )
+        ):
+            for identity in self.module.names:
+                self._protect_binding((MODULE_BINDING, identity))
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if any(
+            isinstance(target, ast.Name) and target.id == _EXPORT_LIST
+            for target in node.targets
+        ):
+            self._check_exports(node.value)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign | ast.AugAssign) -> None:
+        if isinstance(node.target, ast.Name) and node.target.id == _EXPORT_LIST:
+            self._check_exports(node.value)
+        self.generic_visit(node)
+
+    visit_AugAssign = visit_AnnAssign
+
+    def _check_exports(self, expression: ast.AST | None) -> None:
+        if not (
+            isinstance(expression, (ast.List, ast.Tuple, ast.Set))
+            and all(
+                isinstance(item, ast.Constant) and isinstance(item.value, str)
+                for item in expression.elts
+            )
+        ):
+            for identity in self.module.names:
+                self._protect_binding((MODULE_BINDING, identity))
+
+    def visit_FunctionDef(self, node: FunctionNode) -> None:
+        self._visit_function_header(node)
+        previous = self.owner, self.local, self.proven_context
+        self.owner = self.module.functions.get(node.lineno)
+        self.proven_context = self.owner is not None
+        bindings, scope_writes = function_bindings(node, self.module)
+        self.local = {**self.local, **bindings}
+        if scope_writes:
+            self._opaque()
+        for statement in node.body:
+            self.visit(statement)
+        self.owner, self.local, self.proven_context = previous
+
+    def _visit_function_header(self, node: FunctionNode) -> None:
+        expressions = [*node.decorator_list, *default_expressions(node.args)]
+        expressions.extend(
+            arg.annotation
+            for arg in argument_nodes(node.args)
+            if arg.annotation is not None
+        )
+        if node.returns is not None:
+            expressions.append(node.returns)
+        for expression in expressions:
+            self.visit(expression)
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for expression in [
+            *node.decorator_list,
+            *node.bases,
+            *(item.value for item in node.keywords),
+        ]:
+            self.visit(expression)
+        previous = self.local
+        self.local = {
+            **previous,
+            **{name: None for name in bound_names(node.body).counts},
+        }
+        for statement in node.body:
+            self.visit(statement)
+        self.local = previous
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        for expression in default_expressions(node.args):
+            self.visit(expression)
+        previous = self.owner, self.local, self.proven_context
+        self.owner = None
+        self.proven_context = False
+        self.local = {
+            **self.local,
+            **dict.fromkeys(arg.arg for arg in argument_nodes(node.args)),
+        }
+        self.visit(node.body)
+        self.owner, self.local, self.proven_context = previous

--- a/skylos/deadcode/evidence.py
+++ b/skylos/deadcode/evidence.py
@@ -25,6 +25,7 @@ class EvidenceKind(str, Enum):
     VALIDATION_FAIL = "validation_fail"
     UNCERTAINTY = "uncertainty"
     NO_STATIC_REFERENCES = "no_static_references"
+    NO_REACHABLE_CALLERS = "no_reachable_callers"
     NOT_EXPORTED = "not_exported"
     NO_ENTRYPOINT = "no_entrypoint"
     CONFIDENCE_GATE = "confidence_gate"
@@ -61,6 +62,7 @@ ENTRYPOINT_EVIDENCE_KINDS = {
 
 DEAD_EVIDENCE_KINDS = {
     EvidenceKind.NO_STATIC_REFERENCES,
+    EvidenceKind.NO_REACHABLE_CALLERS,
     EvidenceKind.NOT_EXPORTED,
     EvidenceKind.NO_ENTRYPOINT,
     EvidenceKind.CONFIDENCE_GATE,
@@ -80,6 +82,7 @@ DECISION_REASON_LABELS = {
     "trace_hit": "Trace hit",
     "grep_rescue": "Grep verification found usage",
     "no_refs": "No static references",
+    "no_reachable_callers": "No reachable caller in the analyzed project",
     "not_exported": "Not exported",
     "no_entrypoint": "No entrypoint evidence",
     "confidence_ge_threshold": "Confidence meets threshold",
@@ -131,10 +134,7 @@ class SymbolKey:
     def repo_relative_file(self, root: str | Path) -> str:
         try:
             return (
-                Path(self.file)
-                .resolve()
-                .relative_to(Path(root).resolve())
-                .as_posix()
+                Path(self.file).resolve().relative_to(Path(root).resolve()).as_posix()
             )
         except Exception:
             return Path(self.file).as_posix()
@@ -461,7 +461,18 @@ def _add_deadness_evidence(
     if references > 0:
         return
 
-    if references <= 0:
+    unreachable_group = "unreachable_group" in dict(_iter_heuristic_refs(definition))
+    if unreachable_group:
+        ledger.add(
+            symbol,
+            EvidenceEvent(
+                kind=EvidenceKind.NO_REACHABLE_CALLERS,
+                reason="references are confined to unreachable functions in the analyzed project",
+                source="python_reachability",
+                details={"callers": sorted(getattr(definition, "called_by", ()))},
+            ),
+        )
+    elif references <= 0:
         ledger.add(
             symbol,
             EvidenceEvent(
@@ -737,7 +748,9 @@ def _dead_reason_tags(
     definition: Any | None,
 ) -> list[str]:
     tags: list[str] = []
-    if _has_no_static_refs(events, definition):
+    if _has_event_kind(events, EvidenceKind.NO_REACHABLE_CALLERS):
+        tags.append("no_reachable_callers")
+    elif _has_no_static_refs(events, definition):
         tags.append("no_refs")
     if _is_not_exported(events, definition):
         tags.append("not_exported")
@@ -794,8 +807,7 @@ def _primary_reason(
     classification: CandidateClassification,
 ) -> str:
     labels = [
-        DECISION_REASON_LABELS.get(tag, tag.replace("_", " "))
-        for tag in reason_tags
+        DECISION_REASON_LABELS.get(tag, tag.replace("_", " ")) for tag in reason_tags
     ]
     if labels:
         return "; ".join(labels[:3])

--- a/skylos/deadcode/reachability.py
+++ b/skylos/deadcode/reachability.py
@@ -1,0 +1,381 @@
+"""Conservative source ownership for ordinary Python function reachability.
+
+References are edges, not roots. Unknown bindings, unsupported owners and real
+external-use evidence remain conservative. No target modules are imported.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from skylos.core.grep_verify_common import _grep_line_number, _grep_line_path
+from skylos.deadcode._reachability_bindings import (
+    FUNCTION_NODES,
+    FunctionNode,
+    ModuleInfo,
+    bound_names,
+    import_bindings,
+)
+from skylos.deadcode._reachability_graph import (
+    ReferenceGraph,
+    SourceIndex,
+    SourceReference,
+)
+from skylos.deadcode._reachability_visitor import SourceVisitor
+from skylos.deadcode.python_ast import ParsedPythonFile, parse_python_files
+
+if TYPE_CHECKING:
+    from skylos.visitors.base import Definition
+
+_ROOT_MARKERS = {
+    "framework_root",
+    "package_entrypoint",
+    "test_entrypoint",
+    "top_level_execution",
+    "coverage_hit",
+    "trace_hit",
+    "grep_verify",
+    "reachable_from_root",
+}
+_EXTERNAL_EVIDENCE = (
+    "is_exported",
+    "decorators",
+    "dynamic_signals",
+    "framework_signals",
+    "is_closure",
+    "is_lambda",
+)
+_MAX_FILES = 4096
+_MAX_NODES = 2_000_000
+_UNREACHABLE_REASON = (
+    "No reachable entrypoint or unresolved external use; references occur only "
+    "within unreachable Python function groups."
+)
+DefinitionLocations = dict[tuple[Path, int, str], list[tuple[str, "Definition"]]]
+
+
+def _path(value: str | Path, root: Path) -> Path:
+    path = Path(value)
+    return (root / path if not path.is_absolute() else path).resolve()
+
+
+def _source_reference_count(definition: Definition) -> int:
+    """Exclude the analyzer's tracked global simple-name attribute hints."""
+    return max(
+        0,
+        getattr(definition, "references", 0)
+        - getattr(definition, "_attr_name_ref_count", 0),
+    )
+
+
+class PythonReachabilityReport:
+    def __init__(self, definitions: Mapping[str, Definition], root: Path) -> None:
+        self.project_root = root
+        self.complete = True
+        self.incomplete_reasons: list[str] = []
+        self.unreachable_keys: set[str] = set()
+        self.reachable_keys: set[str] = set()
+        self.proven_reachable_keys: set[str] = set()
+        self.reasons: dict[str, str] = {}
+        self._definitions = definitions
+        self.index = SourceIndex()
+        self.graph = ReferenceGraph()
+
+    def refresh(
+        self,
+        definitions: Mapping[str, Definition] | None = None,
+        *,
+        additional_roots: Iterable[str] = (),
+    ) -> PythonReachabilityReport:
+        """Recompute callback or grep roots while retaining the source graph."""
+        if definitions is not None:
+            self._definitions = definitions
+        roots, proven_roots = self._current_roots(additional_roots)
+        candidates = self.index.candidates.keys()
+        reached = self.graph.traverse(roots, candidates, uncertainty=True)
+        self.reachable_keys = reached.intersection(candidates)
+        self.proven_reachable_keys = self.graph.traverse(
+            proven_roots,
+            candidates,
+            uncertainty=False,
+        ).intersection(candidates)
+        self.unreachable_keys = set(candidates) - reached if self.complete else set()
+        self.reasons = {key: _UNREACHABLE_REASON for key in self.unreachable_keys}
+        return self
+
+    def _current_roots(self, additional: Iterable[str]) -> tuple[set[str], set[str]]:
+        proven = self.graph.roots | set(additional)
+        roots = proven | self.graph.uncertain_roots
+        for key, original in self.index.candidates.items():
+            definition = self._definitions.get(key, original)
+            markers = getattr(definition, "heuristic_refs", {}) or {}
+            if _ROOT_MARKERS.intersection(markers):
+                proven.add(key)
+            if self._needs_conservative_root(key, definition, markers):
+                roots.add(key)
+        return roots | proven, proven
+
+    def _needs_conservative_root(
+        self,
+        key: str,
+        definition: Definition,
+        markers: Mapping[str, float],
+    ) -> bool:
+        external = any(getattr(definition, attr, False) for attr in _EXTERNAL_EVIDENCE)
+        callback = any(name.startswith("dead_code_liveness:") for name in markers)
+        return external or callback or self._unaccounted_reference(key, definition)
+
+    def _unaccounted_reference(self, key: str, definition: Definition) -> bool:
+        references = max(
+            self.index.initial_references.get(key, 0),
+            _source_reference_count(definition),
+        )
+        unknown_caller = any(
+            len(self.index.by_name.get(caller, ())) != 1
+            for caller in getattr(definition, "called_by", ())
+        )
+        return references > self.graph.observed[key] or unknown_caller
+
+    def filter_grep_results(
+        self,
+        finding: Mapping[str, Any],
+        raw_results: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Discard source matches only for candidates proved unreachable."""
+        target = self._finding_target(finding)
+        if target is None:
+            return raw_results
+        name = self.index.candidates[target].simple_name
+        return {
+            strategy: [
+                value for value in values if self._relevant_hit(value, name, target)
+            ]
+            if isinstance(values, list)
+            else values
+            for strategy, values in raw_results.items()
+        }
+
+    def _finding_target(self, finding: Mapping[str, Any]) -> str | None:
+        try:
+            file = _path(finding.get("file", ""), self.project_root)
+        except (ValueError, OSError, RuntimeError):
+            return None
+        target = self.index.by_location.get((file, finding.get("line")))
+        return target if target in self.unreachable_keys else None
+
+    def _relevant_hit(self, value: Any, name: str, target: str) -> bool:
+        references = self._hit_references(value, name, target)
+        return not references or not all(
+            ref.target is not None
+            and (ref.target != target or ref.owner in self.unreachable_keys)
+            for ref in references
+        )
+
+    def _hit_references(
+        self, value: Any, name: str, target: str
+    ) -> list[SourceReference] | None:
+        if not isinstance(value, str):
+            return None
+        source, line = _grep_line_path(value), _grep_line_number(value)
+        if not source or not line:
+            return None
+        try:
+            path = _path(source, self.project_root)
+        except (ValueError, OSError, RuntimeError):
+            return None
+        return [
+            ref
+            for ref in self.graph.references.get((path, line), ())
+            if ref.name in {name, "*"} or ref.target == target
+        ]
+
+
+def _source_paths(files: Iterable[str | Path], root: Path) -> tuple[list[Path], bool]:
+    selected = []
+    complete = True
+    for value in files:
+        path = Path(value)
+        if path.suffix != ".py":
+            continue
+        try:
+            if path.is_symlink():
+                raise ValueError("symlink source")
+            path = path.resolve()
+            path.relative_to(root)
+            selected.append(path)
+        except (OSError, ValueError, RuntimeError):
+            complete = False
+    return sorted(set(selected)), complete
+
+
+def _canonical_modules(
+    module_names: Mapping[str | Path, str] | None,
+    root: Path,
+) -> dict[Path, str] | None:
+    if module_names is None:
+        return None
+    canonical = {}
+    for path, identity in module_names.items():
+        if not isinstance(identity, str):
+            continue
+        try:
+            canonical[_path(path, root)] = identity
+        except (OSError, ValueError, RuntimeError):
+            continue
+    return canonical
+
+
+def _definition_module_identity(
+    module: ModuleInfo,
+    locations: DefinitionLocations,
+) -> str | None:
+    identities = set()
+    for node in module.tree.body:
+        if not isinstance(node, FUNCTION_NODES):
+            continue
+        matches = locations.get((module.path, node.lineno, node.name), ())
+        if len(matches) == 1:
+            identity, separator, _name = matches[0][1].name.rpartition(".")
+            if separator:
+                identities.add(identity)
+    return next(iter(identities)) if len(identities) == 1 else None
+
+
+def _load_modules(
+    report: PythonReachabilityReport,
+    parsed: list[ParsedPythonFile],
+    locations: DefinitionLocations,
+    module_names: dict[Path, str] | None,
+) -> bool:
+    node_count = 0
+    missing_identity = False
+    for source in parsed:
+        node_count += sum(1 for _ in ast.walk(source.tree))
+        if node_count > _MAX_NODES:
+            _incomplete(report, "Python reachability AST limit exceeded")
+            return False
+        module = ModuleInfo(source.path, source.tree)
+        identity = (
+            _definition_module_identity(module, locations)
+            if module_names is None
+            else module_names.get(source.path)
+        )
+        if identity is not None:
+            module.names.add(identity)
+        else:
+            missing_identity = True
+        report.index.modules[source.path] = module
+    if missing_identity:
+        _incomplete(
+            report,
+            "Python reachability has sources without canonical module identities",
+        )
+    return True
+
+
+def _definition_locations(
+    definitions: Mapping[str, Definition], root: Path
+) -> DefinitionLocations:
+    indexed: DefinitionLocations = defaultdict(list)
+    for key, definition in definitions.items():
+        if getattr(definition, "type", "") != "function":
+            continue
+        try:
+            file = _path(definition.filename, root)
+        except (ValueError, OSError, RuntimeError):
+            continue
+        indexed[file, definition.line, definition.simple_name].append((key, definition))
+    return indexed
+
+
+def _bind_function(
+    report: PythonReachabilityReport,
+    module: ModuleInfo,
+    node: FunctionNode,
+    counts: Counter[str],
+    locations: DefinitionLocations,
+) -> None:
+    matches = locations.get((module.path, node.lineno, node.name), ())
+    if len(matches) != 1 or counts[node.name] != 1:
+        return
+    key, definition = matches[0]
+    index = report.index
+    index.candidates[key] = definition
+    index.by_location[module.path, node.lineno] = key
+    index.by_name[definition.name].append(key)
+    index.by_simple_name[definition.simple_name].add(key)
+    index.initial_references[key] = _source_reference_count(definition)
+    module.functions[node.lineno] = key
+    module.bindings[node.name] = ("symbol", key)
+    if node.decorator_list or node.name in {"__getattr__", "__dir__"}:
+        report.graph.uncertain_roots.add(key)
+
+
+def _bind_module_imports(module: ModuleInfo, counts: Counter[str]) -> None:
+    for node in module.tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            module.bindings.update(
+                {
+                    name: binding
+                    for name, binding in import_bindings(node, module).items()
+                    if counts[name] == 1
+                }
+            )
+
+
+def _bind_module(
+    report: PythonReachabilityReport, module: ModuleInfo, locations: DefinitionLocations
+) -> None:
+    counts = bound_names(module.tree.body).counts
+    for node in module.tree.body:
+        if isinstance(node, FUNCTION_NODES):
+            _bind_function(report, module, node, counts, locations)
+    for name in counts:
+        module.bindings.setdefault(name, None)
+    _bind_module_imports(module, counts)
+    for name in module.names:
+        if name:
+            report.index.module_names[name].append(module)
+
+
+def _incomplete(report: PythonReachabilityReport, reason: str) -> None:
+    report.complete = False
+    report.incomplete_reasons.append(reason)
+
+
+def analyze_python_reachability(
+    definitions: Mapping[str, Definition],
+    files: Iterable[str | Path],
+    project_root: str | Path,
+    *,
+    module_names: Mapping[str | Path, str] | None = None,
+) -> PythonReachabilityReport:
+    """Resolve function groups using analyzer identities or Definition metadata.
+
+    Missing module identities disable negative conclusions. This pass does not
+    independently infer source roots from directory names.
+    """
+    root = Path(project_root).resolve()
+    if root.is_file():
+        root = root.parent
+    report = PythonReachabilityReport(definitions, root)
+    selected, report.complete = _source_paths(files, root)
+    if len(selected) > _MAX_FILES:
+        _incomplete(report, "Python reachability source limit exceeded")
+        return report
+    parsed = parse_python_files(selected)
+    if len(parsed) != len(selected):
+        _incomplete(report, "Python reachability has unreadable or unparsed sources")
+    locations = _definition_locations(definitions, root)
+    canonical = _canonical_modules(module_names, root)
+    if not _load_modules(report, parsed, locations, canonical):
+        return report
+    for module in report.index.modules.values():
+        _bind_module(report, module, locations)
+    for module in report.index.modules.values():
+        SourceVisitor(report.index, report.graph, module).visit(module.tree)
+    return report.refresh()

--- a/skylos/ui/dead_code_evidence.py
+++ b/skylos/ui/dead_code_evidence.py
@@ -13,6 +13,7 @@ CLASSIFICATION_LABELS = {
 
 REASON_TAG_LABELS = {
     "no_refs": "no refs",
+    "no_reachable_callers": "no reachable callers",
     "not_exported": "not exported",
     "no_entrypoint": "no entrypoint",
     "static_reference": "has refs",

--- a/test/test_grep_reachability_filter.py
+++ b/test/test_grep_reachability_filter.py
@@ -1,0 +1,208 @@
+"""Ownership decisions must apply to every grep path, including cached evidence."""
+
+from unittest.mock import patch
+
+import pytest
+
+from skylos.core.grep_verify import grep_verify_findings
+from skylos.core.safe_cache_io import write_text_no_symlink
+
+
+class MemoryCache:
+    repository_fingerprint = "fixed-test-snapshot"
+
+    def __init__(self):
+        self.values = {}
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def put(self, key, value):
+        self.values[key] = value
+
+
+def candidate(tmp_path):
+    source = tmp_path / "worker.py"
+    assert write_text_no_symlink(source, "def calculate_payload():\n    return 1\n")
+    return {
+        "file": str(source),
+        "line": 1,
+        "name": "calculate_payload",
+        "simple_name": "calculate_payload",
+        "full_name": "worker.calculate_payload",
+        "type": "function",
+    }
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_filter_rechecks_raw_cached_evidence_when_ownership_changes(tmp_path, parallel):
+    finding = candidate(tmp_path)
+    cache = MemoryCache()
+    allow = False
+
+    def ownership_filter(_finding, results):
+        return results if allow else {}
+
+    with patch(
+        "skylos.core.grep_verify.multi_strategy_search",
+        return_value={"references": ["caller.py:1:calculate_payload()"]},
+    ) as search:
+        first = grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            parallel=parallel,
+            cache=cache,
+            evidence_filter=ownership_filter,
+        )
+        assert first.complete
+        assert not first
+        allow = True
+        second = grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            parallel=parallel,
+            cache=cache,
+            evidence_filter=ownership_filter,
+        )
+        assert second.complete
+        assert second[finding["full_name"]].alive
+        assert search.call_count == 1
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_filter_failure_marks_verification_incomplete(tmp_path, parallel):
+    finding = candidate(tmp_path)
+
+    def failing_filter(_finding, _results):
+        raise ValueError("source ownership unavailable")
+
+    with patch(
+        "skylos.core.grep_verify.multi_strategy_search",
+        return_value={"references": ["caller.py:1:calculate_payload()"]},
+    ):
+        result = grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            parallel=parallel,
+            evidence_filter=failing_filter,
+        )
+    assert not result.complete
+    assert result.incomplete_reason == "verification_incomplete"
+    assert not result
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_complete_search_does_not_reuse_an_early_exit_cache(tmp_path, parallel):
+    finding = candidate(tmp_path)
+    cache = MemoryCache()
+    with patch(
+        "skylos.core.grep_verify.multi_strategy_search",
+        return_value={"references": ["caller.py:1:calculate_payload()"]},
+    ) as search:
+        before = grep_verify_findings(
+            [finding], str(tmp_path), parallel=parallel, cache=cache
+        )
+        assert before[finding["full_name"]].alive
+        after = grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            parallel=parallel,
+            cache=cache,
+            evidence_filter=lambda _finding, _results: {},
+        )
+        assert after.complete
+        assert not after
+        assert search.call_count == 2
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_rejected_source_hits_do_not_hide_later_config_evidence(tmp_path, parallel):
+    finding = candidate(tmp_path)
+    assert write_text_no_symlink(
+        tmp_path / "caller.py", "def uncalled():\n" + "    calculate_payload()\n" * 6
+    )
+    assert write_text_no_symlink(
+        tmp_path / "settings.yaml", "callback: worker.py:calculate_payload\n"
+    )
+
+    def source_filter(_finding, results):
+        # Model six source references accounted for by an unreachable caller.
+        # The config registration remains independent evidence.
+        return {
+            key: [line for line in lines if "caller.py:" not in line]
+            for key, lines in results.items()
+        }
+
+    result = grep_verify_findings(
+        [finding],
+        str(tmp_path),
+        parallel=parallel,
+        evidence_filter=source_filter,
+    )
+    assert result.complete
+    verdict = result[finding["full_name"]]
+    assert verdict.alive
+    assert any("settings.yaml" in line for line in verdict.evidence)
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_real_source_search_respects_filter(tmp_path, parallel):
+    finding = candidate(tmp_path)
+    assert write_text_no_symlink(
+        tmp_path / "caller.py", "def uncalled():\n    calculate_payload()\n"
+    )
+    result = grep_verify_findings(
+        [finding],
+        str(tmp_path),
+        parallel=parallel,
+        evidence_filter=lambda _finding, _results: {},
+    )
+    assert result.complete
+    assert not result
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.parametrize("reverse_entries", [False, True])
+def test_same_named_import_and_function_receive_their_own_cached_verdict(
+    tmp_path, parallel, reverse_entries
+):
+    from skylos.analyzer import (
+        _apply_grep_verify_verdicts,
+        _collect_grep_verify_candidates,
+    )
+    from skylos.visitors.base import Definition
+
+    finding = candidate(tmp_path)
+    importer = tmp_path / "consumer.py"
+    assert write_text_no_symlink(importer, "from worker import calculate_payload\n")
+    function = Definition(finding["full_name"], "function", finding["file"], 1)
+    imported = Definition(finding["full_name"], "import", importer, 1)
+    function.confidence = imported.confidence = 80
+    entries = [("function", function), ("import", imported)]
+    if reverse_entries:
+        entries.reverse()
+    candidates, definitions = _collect_grep_verify_candidates(dict(entries))
+    assert {item["full_name"] for item in candidates} == {finding["full_name"]}
+    assert len(definitions) == 2
+    cache = MemoryCache()
+
+    def raw_evidence(item, _root, **_options):
+        if item["type"] == "function":
+            return {
+                "references": [f"{importer}:1:from worker import calculate_payload"]
+            }
+        return {}
+
+    with patch(
+        "skylos.core.grep_verify.multi_strategy_search", side_effect=raw_evidence
+    ) as search:
+        for _ in range(2):
+            function.references = imported.references = 0
+            result = grep_verify_findings(
+                candidates, str(tmp_path), parallel=parallel, cache=cache
+            )
+            assert result.complete
+            assert _apply_grep_verify_verdicts(definitions, result) == 1
+            assert function.references == 1
+            assert imported.references == 0
+        assert search.call_count == 2

--- a/test/test_grep_search_completeness_qa.py
+++ b/test/test_grep_search_completeness_qa.py
@@ -1,0 +1,309 @@
+"""Real searches must not turn clipped, rejected hits into complete absence."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from skylos.core.grep_cache import GrepCache
+from skylos.core.grep_verify import grep_verify_findings
+from skylos.core.grep_verify_common import _grep_line_number, _grep_line_path
+from skylos.core.safe_cache_io import write_text_no_symlink
+
+
+class _ObservedCache(GrepCache):
+    def __init__(self):
+        super().__init__()
+        self.hits = 0
+
+    def get(self, key):
+        value = super().get(key)
+        self.hits += value is not None
+        return value
+
+
+def _fixture(root, dead_hit_count, stub_name="z_contract.pyi"):
+    source = root / "worker.py"
+    body = (
+        "def calculate_payload():\n    return 42\n\n\n\n\n"
+        "def obsolete_calls():\n" + "    calculate_payload()\n" * dead_hit_count
+    )
+    assert write_text_no_symlink(source, body)
+    # This external type-stub import is in the SAME references strategy as
+    # the dead calls. The ordinary imports strategy searches only *.py.
+    stub = root / stub_name
+    assert write_text_no_symlink(stub, "from worker import calculate_payload\n")
+    obsolete = ast.parse(body).body[1]
+    dead_lines = set(range(obsolete.body[0].lineno, obsolete.end_lineno + 1))
+
+    def ownership_filter(_finding, results):
+        def relevant(hit):
+            path = _grep_line_path(hit)
+            line = _grep_line_number(hit)
+            if not path or line is None:
+                return True
+            path = Path(path)
+            if not path.is_absolute():
+                path = root / path
+            # obsolete_calls has no caller or escape in this source. Its
+            # body cannot independently establish usage of calculate_payload.
+            return path.resolve() != source.resolve() or line not in dead_lines
+
+        return {
+            name: [hit for hit in hits if relevant(hit)]
+            for name, hits in results.items()
+        }
+
+    finding = {
+        "file": str(source),
+        "line": 1,
+        "type": "function",
+        "name": "calculate_payload",
+        "simple_name": "calculate_payload",
+        "full_name": "worker.calculate_payload",
+    }
+    return finding, ownership_filter
+
+
+@pytest.mark.parametrize("dead_hit_count", [6, 12, 300])
+@pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.parametrize("cached", [False, True])
+def test_later_stub_reference_is_rescued_or_search_abstains(
+    tmp_path, dead_hit_count, parallel, cached
+):
+    finding, ownership_filter = _fixture(tmp_path, dead_hit_count)
+    cache = _ObservedCache() if cached else None
+    results = [
+        grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            parallel=parallel,
+            cache=cache,
+            evidence_filter=ownership_filter,
+        )
+        for _ in range(2 if cached else 1)
+    ]
+
+    for result in results:
+        verdict = result.get(finding["full_name"])
+        assert (verdict is not None and verdict.alive) or not result.complete, (
+            "Later conservative evidence exists in z_contract.pyi; rejecting "
+            "the clipped dead-caller prefix cannot establish a complete search."
+        )
+        if verdict is not None and verdict.alive:
+            assert any("z_contract.pyi:" in hit for hit in verdict.evidence)
+        else:
+            assert result.incomplete_reason
+    if cached:
+        assert cache.hits > 0
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_unclipped_stub_reference_remains_a_positive_control(tmp_path, parallel):
+    finding, ownership_filter = _fixture(tmp_path, 1)
+    result = grep_verify_findings(
+        [finding],
+        str(tmp_path),
+        parallel=parallel,
+        evidence_filter=ownership_filter,
+    )
+
+    assert result.complete
+    assert result[finding["full_name"]].alive
+    assert any(
+        "z_contract.pyi:" in hit for hit in result[finding["full_name"]].evidence
+    )
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.parametrize("cached", [False, True])
+def test_retained_positive_evidence_can_rescue_despite_a_search_cap(
+    tmp_path, parallel, cached
+):
+    finding, ownership_filter = _fixture(tmp_path, 300, "a_contract.pyi")
+    cache = _ObservedCache() if cached else None
+
+    for _ in range(2 if cached else 1):
+        result = grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            parallel=parallel,
+            cache=cache,
+            evidence_filter=ownership_filter,
+        )
+        assert result.complete
+        verdict = result[finding["full_name"]]
+        assert verdict.alive
+        assert any("a_contract.pyi:" in hit for hit in verdict.evidence)
+    if cached:
+        assert cache.hits > 0
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.parametrize("cached", [False, True])
+def test_overlapping_module_aliases_do_not_invent_evidence_loss(
+    tmp_path, parallel, cached
+):
+    source = tmp_path / "src" / "pkg" / "worker.py"
+    source.parent.mkdir(parents=True)
+    assert write_text_no_symlink(source, "def calculate_payload():\n    return 42\n")
+    assert write_text_no_symlink(
+        tmp_path / "notes.py",
+        "def obsolete_notes():\n" + "    'src.pkg.worker'\n" * 3,
+    )
+    finding = {
+        "file": str(source),
+        "line": 1,
+        "type": "function",
+        "name": "calculate_payload",
+        "simple_name": "calculate_payload",
+        "full_name": "pkg.worker.calculate_payload",
+    }
+    cache = _ObservedCache() if cached else None
+
+    for _ in range(2 if cached else 1):
+        result = grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            parallel=parallel,
+            cache=cache,
+            evidence_filter=lambda _finding, _results: {},
+        )
+        # src.pkg.worker and pkg.worker match the same three note lines.
+        # Duplicate matches cannot imply that a sixth unique hit was lost.
+        assert result.complete
+        assert not result
+    if cached:
+        assert cache.hits > 0
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.parametrize("cached", [False, True])
+def test_irrelevant_module_substrings_do_not_block_a_complete_search(
+    tmp_path, parallel, cached
+):
+    source = tmp_path / "app.py"
+    assert write_text_no_symlink(source, "RESULT = 42\n")
+    assert write_text_no_symlink(
+        tmp_path / "models.py",
+        "".join(f"mapped_column_{index} = None\n" for index in range(12)),
+    )
+    finding = {
+        "file": str(source),
+        "line": 1,
+        "type": "variable",
+        "name": "RESULT",
+        "simple_name": "RESULT",
+        "full_name": "app.RESULT",
+    }
+    cache = _ObservedCache() if cached else None
+
+    for _ in range(2 if cached else 1):
+        result = grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            parallel=parallel,
+            cache=cache,
+            evidence_filter=lambda _finding, results: results,
+        )
+        # The module-name substring "app" occurs in "mapped_column". These
+        # weak hints cannot establish usage of RESULT even without a cap.
+        assert result.complete
+        assert not result
+    if cached:
+        assert cache.hits > 0
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.parametrize("cached", [False, True])
+def test_overlapping_dispatch_patterns_count_physical_lines_once(
+    tmp_path, parallel, cached
+):
+    source = tmp_path / "worker.py"
+    assert write_text_no_symlink(source, "def calculate_payload():\n    return 42\n")
+    assert write_text_no_symlink(
+        tmp_path / "notes.py",
+        "def obsolete_notes(receiver, registry):\n"
+        + '    getattr(receiver, "calculate_payload"); registry["calculate_payload"]\n'
+        * 3,
+    )
+    finding = {
+        "file": str(source),
+        "line": 1,
+        "type": "function",
+        "name": "calculate_payload",
+        "simple_name": "calculate_payload",
+        "full_name": "worker.calculate_payload",
+    }
+    cache = _ObservedCache() if cached else None
+
+    for _ in range(2 if cached else 1):
+        result = grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            parallel=parallel,
+            cache=cache,
+            evidence_filter=lambda _finding, _results: {},
+        )
+        # getattr and registry lookup both match each unreachable source line.
+        # Three unique lines fit the cap even though there are six matches.
+        assert result.complete
+        assert not result
+    if cached:
+        assert cache.hits > 0
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.parametrize("cached", [False, True])
+def test_later_protocol_cast_cannot_be_lost_as_a_weak_type_hint(
+    tmp_path, parallel, cached
+):
+    source = tmp_path / "worker.py"
+    assert write_text_no_symlink(
+        source, "class Receiver:\n    def calculate_payload(self):\n        return 42\n"
+    )
+    cast_source = tmp_path / "usage.py"
+    assert write_text_no_symlink(
+        cast_source,
+        "def obsolete_casts():\n"
+        + "    cast(Protocol, Receiver())\n" * 5
+        + "live_receiver = cast(Protocol, Receiver())\n",
+    )
+    finding = {
+        "file": str(source),
+        "line": 2,
+        "type": "method",
+        "name": "calculate_payload",
+        "simple_name": "calculate_payload",
+        "full_name": "worker.Receiver.calculate_payload",
+    }
+
+    def ownership_filter(_finding, results):
+        return {
+            key: [
+                hit
+                for hit in hits
+                if not (
+                    _grep_line_path(hit) == str(cast_source)
+                    and _grep_line_number(hit) in range(2, 7)
+                )
+            ]
+            for key, hits in results.items()
+        }
+
+    cache = _ObservedCache() if cached else None
+    for _ in range(2 if cached else 1):
+        result = grep_verify_findings(
+            [finding],
+            str(tmp_path),
+            parallel=parallel,
+            cache=cache,
+            evidence_filter=ownership_filter,
+        )
+        # The sixth cast is a module-level use. Method protocol casts can
+        # establish usage, so discarding it must prevent a negative verdict.
+        assert not result.complete
+        assert result.incomplete_reason
+        assert not result
+    if cached:
+        assert cache.hits > 0

--- a/test/test_python_reachability.py
+++ b/test/test_python_reachability.py
@@ -1,0 +1,714 @@
+"""Source-only reachability proofs and conservative boundaries; fixtures never run."""
+
+import ast
+import json
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from skylos.core.safe_cache_io import write_text_no_symlink
+from skylos.deadcode.reachability import analyze_python_reachability
+from skylos.visitors.base import Definition
+
+
+def _fixture_module_names(files, root):
+    names = {}
+    for path in files:
+        parts = list(path.relative_to(root).with_suffix("").parts)
+        if parts[-1] == "__init__":
+            parts.pop()
+        names[path] = ".".join(parts)
+    return names
+
+
+def _analyze(definitions, files, root):
+    return analyze_python_reachability(
+        definitions, files, root, module_names=_fixture_module_names(files, root)
+    )
+
+
+def _project(tmp_path, sources):
+    definitions = {}
+    files = []
+    for filename, source in sources.items():
+        path = tmp_path / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        source = textwrap.dedent(source).lstrip()
+        assert write_text_no_symlink(path, source)
+        files.append(path)
+        module = filename.removesuffix(".py").replace("/", ".")
+        for node in ast.parse(source).body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                key = f"{module}.{node.name}"
+                definitions[key] = Definition(key, "function", path, node.lineno, node)
+    return definitions, files
+
+
+def _report(tmp_path, sources):
+    definitions, files = _project(tmp_path, sources)
+    return _analyze(definitions, files, tmp_path)
+
+
+@pytest.mark.parametrize("live", [False, True])
+def test_recursive_group_and_dead_call_chain(tmp_path, live):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": textwrap.dedent("""
+        def alpha():
+            return beta()
+        def beta():
+            return alpha()
+        def entry():
+            return alpha()
+        """)
+            + ("\nentry()\n" if live else "")
+        },
+    )
+    expected = {"worker.alpha", "worker.beta", "worker.entry"}
+    assert report.unreachable_keys == (set() if live else expected)
+    assert report.proven_reachable_keys == (expected if live else set())
+
+
+@pytest.mark.parametrize("live", [False, True])
+@pytest.mark.parametrize(
+    "import_line,call",
+    [
+        ("from worker import beta as alias", "alias()"),
+        ("import worker as alias", "alias.beta()"),
+    ],
+)
+def test_cross_module_aliases_have_caller_ownership(tmp_path, live, import_line, call):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": "def beta(): return 1\n",
+            "app.py": f"{import_line}\ndef alpha(): return {call}\n"
+            + ("alpha()\n" if live else ""),
+        },
+    )
+    assert report.unreachable_keys == (set() if live else {"worker.beta", "app.alpha"})
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "def receiver(value=leaf()): return value",
+        "def receiver(value: leaf()): return value",
+        "def receiver() -> leaf(): return None",
+        "class Container:\n    value = leaf()",
+        "@leaf()\ndef receiver(): return None",
+        "register(leaf)",
+    ],
+)
+def test_definition_time_and_callback_roots_are_positive(tmp_path, expression):
+    report = _report(
+        tmp_path, {"worker.py": "def leaf(): return int\n" + expression + "\n"}
+    )
+    assert "worker.leaf" in report.proven_reachable_keys
+    assert "worker.leaf" not in report.unreachable_keys
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "class Container:\n    def method(self): return leaf()",
+        "def outer():\n    def inner(): return leaf()\n    return inner",
+        "callback = lambda: leaf()",
+    ],
+)
+def test_unsupported_owners_protect_without_positive_execution_claim(tmp_path, body):
+    report = _report(tmp_path, {"worker.py": "def leaf(): return 1\n" + body + "\n"})
+    assert "worker.leaf" not in report.unreachable_keys
+    assert "worker.leaf" not in report.proven_reachable_keys
+
+
+@pytest.mark.parametrize(
+    "root_attribute,root_value",
+    [
+        ("is_exported", True),
+        ("decorators", ["framework.route"]),
+        ("dynamic_signals", ["unknown callback"]),
+        ("framework_signals", ["route"]),
+        ("heuristic_refs", {"package_entrypoint": 1.0}),
+        ("heuristic_refs", {"coverage_hit": 1.0}),
+        ("heuristic_refs", {"dead_code_liveness:callback": 1.0}),
+    ],
+)
+def test_existing_external_evidence_roots_preserve_descendants(
+    tmp_path, root_attribute, root_value
+):
+    definitions, files = _project(
+        tmp_path, {"worker.py": "def leaf(): return 1\ndef entry(): return leaf()\n"}
+    )
+    setattr(definitions["worker.entry"], root_attribute, root_value)
+    report = _analyze(definitions, files, tmp_path)
+    assert report.unreachable_keys == set()
+
+
+def test_unattributed_reference_and_unknown_caller_stay_conservative(tmp_path):
+    definitions, files = _project(
+        tmp_path, {"worker.py": "def first(): return 1\ndef second(): return 2\n"}
+    )
+    definitions["worker.first"].references = 1
+    definitions["worker.second"].called_by.add("unknown.registered_callback")
+    report = _analyze(definitions, files, tmp_path)
+    assert report.unreachable_keys == set()
+    assert report.proven_reachable_keys == set()
+
+
+def test_counted_recursive_references_are_edges_not_roots(tmp_path):
+    definitions, files = _project(
+        tmp_path,
+        {"worker.py": "def first(): return second()\ndef second(): return first()\n"},
+    )
+    for key, definition in definitions.items():
+        definition.references = 1
+        definition.called_by.add(
+            "worker.second" if key.endswith("first") else "worker.first"
+        )
+    report = _analyze(definitions, files, tmp_path)
+    assert report.unreachable_keys == set(definitions)
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "getattr(worker, requested)()",
+        "vars(worker)",
+        "globals()[requested]()",
+        "external(worker)",
+    ],
+)
+def test_reflection_and_module_escape_are_uncertain_roots(tmp_path, expression):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": "def leaf(): return 1\n",
+            "app.py": "import worker\n" + expression + "\n",
+        },
+    )
+    assert "worker.leaf" not in report.unreachable_keys
+    assert "worker.leaf" not in report.proven_reachable_keys
+
+
+def test_dead_reflection_is_not_itself_a_live_root(tmp_path):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": "def leaf(): return 1\ndef caller(name): return globals()[name]()\n"
+        },
+    )
+    assert report.unreachable_keys == {"worker.leaf", "worker.caller"}
+
+
+def test_shadowed_unknown_reference_does_not_create_new_negative(tmp_path):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": "def leaf(): return 1\ndef caller(leaf): return leaf()\ncaller(external)\n"
+        },
+    )
+    assert "worker.leaf" not in report.unreachable_keys
+    assert "worker.leaf" not in report.proven_reachable_keys
+
+
+def test_rebinding_is_excluded_from_supported_negative_scope(tmp_path):
+    report = _report(
+        tmp_path, {"worker.py": "def leaf(): return 1\nleaf = register(leaf)\n"}
+    )
+    assert report.unreachable_keys == set()
+
+
+def test_refresh_revives_only_resolved_descendants_without_reparse(
+    tmp_path, monkeypatch
+):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": "def leaf(): return 1\ndef entry(): return leaf()\ndef spare(): return 2\n"
+        },
+    )
+
+    def no_parse(_):
+        pytest.fail("refresh must reuse the source graph")
+
+    monkeypatch.setattr("skylos.deadcode.reachability.parse_python_files", no_parse)
+    for definition in report._definitions.values():
+        definition.heuristic_refs["unreachable_group"] = 1.0
+    report.refresh()
+    assert len(report.unreachable_keys) == 3
+    report.refresh(additional_roots={"worker.entry"})
+    assert report.unreachable_keys == {"worker.spare"}
+    assert report.proven_reachable_keys == {"worker.entry", "worker.leaf"}
+
+
+def test_incomplete_parse_never_proves_unreachable(tmp_path):
+    definitions, files = _project(tmp_path, {"worker.py": "def leaf(): return 1\n"})
+    broken = tmp_path / "broken.py"
+    assert write_text_no_symlink(broken, "def broken(\n")
+    report = _analyze(definitions, [*files, broken], tmp_path)
+    assert not report.complete
+    assert report.unreachable_keys == set()
+    assert report.incomplete_reasons
+
+
+def test_grep_discards_dead_owner_but_keeps_configuration_and_unknown_hits(tmp_path):
+    report = _report(
+        tmp_path, {"worker.py": "def leaf(): return 1\ndef caller(): return leaf()\n"}
+    )
+    finding = report._definitions["worker.leaf"].to_dict()
+    dead = f"{tmp_path / 'worker.py'}:2:def caller(): return leaf()"
+    config = f"{tmp_path / 'setup.cfg'}:8:callback=worker.leaf"
+    unknown = f"{tmp_path / 'worker.py'}:20:leaf()"
+    raw = {"function_calls": [dead, config, unknown], "other": 3}
+    assert report.filter_grep_results(finding, raw) == {
+        "function_calls": [config, unknown],
+        "other": 3,
+    }
+    assert raw["function_calls"] == [dead, config, unknown]
+    report.refresh(additional_roots={"worker.caller"})
+    assert report.filter_grep_results(finding, raw) == raw
+
+
+def test_uncertain_candidate_keeps_all_existing_grep_evidence(tmp_path):
+    definitions, files = _project(
+        tmp_path,
+        {
+            "worker.py": "def leaf(): return 1\ndef caller(): return leaf()\n",
+        },
+    )
+    definitions["worker.leaf"].dynamic_signals = ["unresolved callback"]
+    report = _analyze(definitions, files, tmp_path)
+    raw = {
+        "function_calls": [f"{tmp_path / 'worker.py'}:2:def caller(): return leaf()"]
+    }
+    assert "worker.caller" in report.unreachable_keys
+    assert "worker.leaf" not in report.proven_reachable_keys
+    assert report.filter_grep_results(definitions["worker.leaf"].to_dict(), raw) == raw
+
+
+def test_grep_same_name_resolution_uses_definition_identity(tmp_path):
+    report = _report(
+        tmp_path,
+        {
+            "alpha.py": "def read_record(): return 1\n",
+            "beta.py": "def read_record(): return 2\n",
+            "app.py": "from beta import read_record\nread_record()\n",
+        },
+    )
+    raw = {"function_calls": [f"{tmp_path / 'app.py'}:2:read_record()"]}
+    assert report.unreachable_keys == {"alpha.read_record"}
+    assert report.filter_grep_results(
+        report._definitions["alpha.read_record"].to_dict(), raw
+    ) == {
+        "function_calls": [],
+    }
+    assert (
+        report.filter_grep_results(
+            report._definitions["beta.read_record"].to_dict(), raw
+        )
+        == raw
+    )
+
+
+def test_grep_keeps_mixed_unknown_and_resolved_matches_on_same_line(tmp_path):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": "def leaf(): return 1\ndef caller(obj): return leaf() + obj.leaf()\n"
+        },
+    )
+    raw = {
+        "function_calls": [
+            f"{tmp_path / 'worker.py'}:2:def caller(obj): return leaf() + obj.leaf()"
+        ]
+    }
+    assert (
+        report.filter_grep_results(report._definitions["worker.leaf"].to_dict(), raw)
+        == raw
+    )
+
+
+def test_string_callback_and_other_symbol_on_one_line_keep_uncertainty(tmp_path):
+    report = _report(
+        tmp_path,
+        {
+            "alpha.py": "def leaf(): return 1\n",
+            "beta.py": "def leaf(): return 2\n",
+            "app.py": "import beta\nregister('alpha.leaf'); beta.leaf()\n",
+        },
+    )
+    raw = {
+        "function_calls": [
+            f"{tmp_path / 'app.py'}:2:register('alpha.leaf'); beta.leaf()"
+        ]
+    }
+    assert "alpha.leaf" not in report.unreachable_keys
+    assert "alpha.leaf" not in report.proven_reachable_keys
+    assert (
+        report.filter_grep_results(report._definitions["alpha.leaf"].to_dict(), raw)
+        == raw
+    )
+
+
+@pytest.mark.parametrize("scope", ["module", "live-function", "dead-function"])
+def test_rebound_import_alias_keeps_its_original_possible_target(tmp_path, scope):
+    body = "from worker import leaf as alias\nalias = register(alias)\nalias()\n"
+    if scope != "module":
+        body = "def entry():\n" + textwrap.indent(body, "    ")
+        if scope == "live-function":
+            body += "entry()\n"
+    report = _report(tmp_path, {"worker.py": "def leaf(): return 1\n", "app.py": body})
+    assert ("worker.leaf" in report.unreachable_keys) == (scope == "dead-function")
+    assert "worker.leaf" not in report.proven_reachable_keys
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "if condition:\n    from worker import leaf as alias\nalias()\n",
+        "from missing_package.worker import leaf as alias\nalias()\n",
+    ],
+)
+def test_unresolved_or_conditional_import_alias_remains_uncertain(tmp_path, body):
+    report = _report(tmp_path, {"worker.py": "def leaf(): return 1\n", "app.py": body})
+    assert "worker.leaf" not in report.unreachable_keys
+    assert "worker.leaf" not in report.proven_reachable_keys
+
+
+def test_escaping_facade_module_protects_reexported_functions(tmp_path):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": "def leaf(): return 1\n",
+            "facade.py": "from worker import leaf\n",
+            "app.py": "import facade\nregister(facade)\n",
+        },
+    )
+    assert "worker.leaf" not in report.unreachable_keys
+    assert "worker.leaf" not in report.proven_reachable_keys
+
+
+@pytest.mark.parametrize(
+    "exports",
+    [
+        "__all__ = computed_names",
+        "__all__ = []; __all__.extend(names)",
+        "__all__: list[str] = names",
+        "__all__ = []; __all__ += names",
+    ],
+)
+def test_dynamic_export_list_stays_conservative(tmp_path, exports):
+    report = _report(tmp_path, {"worker.py": "def leaf(): return 1\n" + exports + "\n"})
+    assert "worker.leaf" not in report.unreachable_keys
+    assert "worker.leaf" not in report.proven_reachable_keys
+
+
+def test_static_export_list_does_not_protect_unrelated_private_group(tmp_path):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": "def public(): return 1\ndef private(): return 2\n__all__ = ['public']\n"
+        },
+    )
+    assert report.unreachable_keys == {"worker.private"}
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "lookup = getattr\nlookup(module, requested)()",
+        "from builtins import getattr as lookup\nlookup(module, requested)()",
+        "from importlib import import_module as lookup\nlookup(requested)",
+        "namespace = callback.__globals__\nnamespace[requested]()",
+        "namespace = __builtins__\nnamespace[requested](module, member)()",
+    ],
+)
+def test_reflection_aliases_remain_uncertain(tmp_path, body):
+    report = _report(tmp_path, {"worker.py": "def leaf(): return 1\n" + body + "\n"})
+    assert "worker.leaf" not in report.unreachable_keys
+    assert "worker.leaf" not in report.proven_reachable_keys
+
+
+def test_dynamic_module_attribute_preserves_its_returned_function(tmp_path):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": "def leaf(): return 1\ndef __getattr__(name): return leaf\n",
+            "app.py": "from worker import dynamic_alias\ndynamic_alias()\n",
+        },
+    )
+    assert "worker.leaf" not in report.unreachable_keys
+    assert "worker.leaf" not in report.proven_reachable_keys
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "values = [leaf for leaf in providers]\n    return leaf()",
+        "if (leaf := provider):\n        return leaf()",
+        "match payload:\n        case {'item': item, **leaf}:\n            return leaf()",
+    ],
+)
+def test_unsupported_binding_scopes_never_create_new_negative(tmp_path, body):
+    report = _report(
+        tmp_path,
+        {
+            "worker.py": "def leaf(): return 1\ndef entry():\n    "
+            + body
+            + "\nentry()\n"
+        },
+    )
+    assert "worker.leaf" not in report.unreachable_keys
+    assert "worker.leaf" not in report.proven_reachable_keys
+
+
+@pytest.mark.parametrize("resolved", [True, False])
+def test_global_attribute_name_credit_does_not_override_source_identity(
+    tmp_path, resolved
+):
+    definitions, files = _project(
+        tmp_path,
+        {
+            "north/tasks.py": "def decode_packet(): return 1\n",
+            "south/tasks.py": "def decode_packet(): return 2\n",
+            "app.py": "import north.tasks as selected\nselected.decode_packet()\n"
+            if resolved
+            else "receiver.decode_packet()\n",
+        },
+    )
+    for definition in definitions.values():
+        definition.references = 1
+        definition._attr_name_ref_count = 1
+    report = _analyze(definitions, files, tmp_path)
+    assert report.unreachable_keys == (
+        {"south.tasks.decode_packet"} if resolved else set()
+    )
+    assert report.proven_reachable_keys == (
+        {"north.tasks.decode_packet"} if resolved else set()
+    )
+
+
+def test_genuine_reference_gap_survives_attribute_credit_discount(tmp_path):
+    definitions, files = _project(tmp_path, {"worker.py": "def leaf(): return 1\n"})
+    definitions["worker.leaf"].references = 2
+    definitions["worker.leaf"]._attr_name_ref_count = 1
+    report = _analyze(definitions, files, tmp_path)
+    assert report.unreachable_keys == set()
+    assert report.proven_reachable_keys == set()
+
+
+def test_grep_header_reference_is_owned_by_module_execution(tmp_path):
+    report = _report(
+        tmp_path,
+        {"worker.py": "def leaf(): return 1\ndef caller(value=leaf()): return value\n"},
+    )
+    raw = {
+        "function_calls": [
+            f"{tmp_path / 'worker.py'}:2:def caller(value=leaf()): return value"
+        ]
+    }
+    assert "worker.caller" in report.unreachable_keys
+    assert (
+        report.filter_grep_results(report._definitions["worker.leaf"].to_dict(), raw)
+        == raw
+    )
+
+
+def test_standalone_identity_comes_from_definition_metadata(tmp_path):
+    definitions, files = _project(
+        tmp_path,
+        {
+            "unusual_sources/worker.py": "def leaf(): return 1\ndef caller(): return leaf()\n",
+        },
+    )
+    for definition in definitions.values():
+        definition.name = f"application.backend.{definition.simple_name}"
+    report = analyze_python_reachability(definitions, files, tmp_path)
+    assert report.complete
+    assert report.index.modules[files[0]].names == {"application.backend"}
+    assert report.unreachable_keys == set(definitions)
+
+
+def test_standalone_missing_identity_disables_negative_conclusions(tmp_path):
+    definitions, files = _project(
+        tmp_path,
+        {
+            "worker.py": "def leaf(): return 1\n",
+            "facade.py": "from worker import leaf\n",
+            "app.py": "import facade\nregister(facade)\n",
+        },
+    )
+    report = analyze_python_reachability(definitions, files, tmp_path)
+    assert not report.complete
+    assert report.unreachable_keys == set()
+    assert any(
+        "canonical module identities" in reason for reason in report.incomplete_reasons
+    )
+
+
+def test_explicit_missing_map_entry_does_not_fall_back_to_names(tmp_path):
+    definitions, files = _project(tmp_path, {"worker.py": "def leaf(): return 1\n"})
+    report = analyze_python_reachability(definitions, files, tmp_path, module_names={})
+    assert not report.complete
+    assert report.unreachable_keys == set()
+
+
+def test_explicit_empty_root_module_identity_is_valid(tmp_path):
+    definitions, files = _project(
+        tmp_path,
+        {
+            "__init__.py": "",
+            "worker.py": "def leaf(): return 1\n",
+        },
+    )
+    report = _analyze(definitions, files, tmp_path)
+    assert report.complete
+    assert report.index.modules[tmp_path / "__init__.py"].names == {""}
+    assert report.unreachable_keys == {"worker.leaf"}
+
+
+@pytest.mark.parametrize("live", [False, True])
+def test_authoritative_names_resolve_nonstandard_source_layout(tmp_path, live):
+    definitions, files = _project(
+        tmp_path,
+        {
+            "deployment/plugins/worker.py": "def leaf(): return 1\n",
+            "deployment/plugins/entry.py": "from .worker import leaf as callback\ndef launch(): return callback()\n"
+            + ("launch()\n" if live else ""),
+        },
+    )
+    identities = {
+        files[0]: "application.worker",
+        files[1]: "application.entry",
+    }
+    report = analyze_python_reachability(
+        definitions, files, tmp_path, module_names=identities
+    )
+    assert report.complete
+    assert report.index.modules[files[0]].names == {"application.worker"}
+    assert report.index.modules[files[1]].names == {"application.entry"}
+    assert report.unreachable_keys == (set() if live else set(definitions))
+    assert report.proven_reachable_keys == (set(definitions) if live else set())
+
+
+@pytest.mark.parametrize("live", [False, True])
+def test_duplicate_canonical_module_names_keep_import_resolution_uncertain(
+    tmp_path, live
+):
+    definitions, files = _project(
+        tmp_path,
+        {
+            "north/worker.py": "def leaf(): return 1\n",
+            "south/worker.py": "def leaf(): return 2\n",
+            "app.py": "def launch():\n    from shared.worker import leaf as callback\n    return callback()\n"
+            + ("launch()\n" if live else ""),
+        },
+    )
+    report = analyze_python_reachability(
+        definitions,
+        files,
+        tmp_path,
+        module_names={
+            files[0]: "shared.worker",
+            files[1]: "shared.worker",
+            files[2]: "app",
+        },
+    )
+    assert report.complete
+    assert report.unreachable_keys == (set() if live else set(definitions))
+    assert report.proven_reachable_keys == ({"app.launch"} if live else set())
+
+
+def _write_package_name_control(root, package, second_live):
+    main = "import worker\nprint(worker.render_report(2))\n"
+    if second_live:
+        main += f"import {package}.worker\nprint({package}.worker.render_report(2))\n"
+    _project(
+        root,
+        {
+            "worker.py": "def render_report(value): return value + 1\n",
+            f"{package}/__init__.py": "",
+            f"{package}/worker.py": "def render_report(value): return value - 1\n",
+            "main.py": main,
+        },
+    )
+
+
+@pytest.mark.parametrize("package", ["src", "lib", "python", "warehouse"])
+@pytest.mark.parametrize("second_live", [False, True])
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_analyzer_preserves_real_package_names(
+    tmp_path, package, second_live, grep_verify
+):
+    from skylos.analyzer import Skylos
+
+    _write_package_name_control(tmp_path, package, second_live)
+    scanner = Skylos()
+    result = json.loads(
+        scanner.analyze(
+            str(tmp_path), trace_file=False, grep_verify=grep_verify, grep_cache=False
+        )
+    )
+    report = scanner._python_reachability_report
+    assert report.complete
+    assert report.index.modules[tmp_path / package / "worker.py"].names == {
+        f"{package}.worker"
+    }
+    unused = {row["full_name"] for row in result.get("unused_functions", [])}
+    assert "worker.render_report" not in unused
+    assert (f"{package}.worker.render_report" in unused) is (not second_live)
+
+
+@pytest.mark.parametrize("live", [False, True])
+def test_actual_analyzer_uses_nonstandard_package_root(tmp_path, live):
+    from skylos.analyzer import Skylos
+
+    root = tmp_path / "application_core"
+    _project(
+        root,
+        {
+            "__init__.py": "",
+            "worker.py": "def leaf(): return 1\n",
+            "entry.py": "from .worker import leaf as callback\ndef launch(): return callback()\n"
+            + ("launch()\n" if live else ""),
+        },
+    )
+    scanner = Skylos()
+    scanner.analyze(str(root), trace_file=False, grep_verify=False, grep_cache=False)
+    report = scanner._python_reachability_report
+    assert report.complete
+    assert report.index.modules[root / "worker.py"].names == {"application_core.worker"}
+    assert report.index.modules[root / "entry.py"].names == {"application_core.entry"}
+    expected = {"application_core.worker.leaf", "application_core.entry.launch"}
+    assert report.unreachable_keys & expected == (set() if live else expected)
+    assert report.proven_reachable_keys & expected == (expected if live else set())
+
+
+@pytest.mark.parametrize("package", ["src", "warehouse"])
+def test_cli_keeps_real_package_and_top_level_module_distinct(tmp_path, package):
+    _write_package_name_control(tmp_path, package, False)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from skylos.cli import main; main()",
+            str(tmp_path),
+            "--format",
+            "json",
+            "--no-upload",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(completed.stdout)
+    unused = {row["full_name"] for row in result.get("unused_functions", [])}
+    assert "worker.render_report" not in unused
+    assert f"{package}.worker.render_report" in unused

--- a/test/test_reachability_integration_qa.py
+++ b/test/test_reachability_integration_qa.py
@@ -1,0 +1,408 @@
+"""Independent public-output checks for Python dead-code reachability.
+
+Fixture modules are parsed by Skylos, never imported or executed. Expectations
+come from visible application roots and references in each fixture.
+"""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from skylos.analyzer import analyze
+from skylos.core.safe_cache_io import write_text_no_symlink
+
+
+def _write(path, source):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    assert write_text_no_symlink(path, textwrap.dedent(source).lstrip())
+
+
+def _scan(path, **options):
+    return json.loads(analyze(str(path.resolve()), trace_file=False, **options))
+
+
+def _unused(result):
+    return {item["full_name"] for item in result.get("unused_functions", [])}
+
+
+def _cycle_source(*, live=False):
+    return textwrap.dedent(
+        """
+        def obsolete_alpha(value):
+            if value <= 0:
+                return 0
+            return obsolete_beta(value - 1)
+
+        def obsolete_beta(value):
+            if value <= 0:
+                return 0
+            return obsolete_alpha(value - 1)
+
+        def obsolete_entry():
+            return obsolete_alpha(2)
+        """
+    ) + ("\nprint(obsolete_entry())\n" if live else "\nprint('ready')\n")
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("live", [False, True])
+def test_recursive_group_requires_a_reachable_caller(tmp_path, grep_verify, live):
+    _write(tmp_path / "worker.py", _cycle_source(live=live))
+
+    unused = _unused(_scan(tmp_path, grep_verify=grep_verify))
+
+    expected = {
+        "worker.obsolete_alpha",
+        "worker.obsolete_beta",
+        "worker.obsolete_entry",
+    }
+    assert unused & expected == (set() if live else expected)
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("call_style", ["inline", "multiline", "parenthesized"])
+@pytest.mark.parametrize("live", [False, True])
+def test_dead_chain_is_independent_of_call_whitespace(
+    tmp_path, grep_verify, call_style, live
+):
+    call = {
+        "inline": "def obsolete_alpha(value): return obsolete_beta(value)\n",
+        "multiline": "def obsolete_alpha(value):\n    return obsolete_beta(value)\n",
+        "parenthesized": (
+            "def obsolete_alpha(value):\n"
+            "    return (obsolete_beta) (\n        value\n    )\n"
+        ),
+    }[call_style]
+    _write(
+        tmp_path / "worker.py",
+        "def obsolete_beta(value):\n    return value + 1\n\n"
+        + call
+        + "\ndef obsolete_entry():\n    return obsolete_alpha(2)\n\n"
+        + ("print(obsolete_entry())\n" if live else "print('ready')\n"),
+    )
+
+    unused = _unused(_scan(tmp_path, grep_verify=grep_verify))
+
+    expected = {
+        "worker.obsolete_alpha",
+        "worker.obsolete_beta",
+        "worker.obsolete_entry",
+    }
+    assert unused & expected == (set() if live else expected)
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("second_is_live", [False, True])
+def test_resolved_import_does_not_rescue_other_module_same_name(
+    tmp_path, grep_verify, second_is_live
+):
+    _write(tmp_path / "alpha.py", "def read_record(): return 'alpha'\n")
+    _write(tmp_path / "beta.py", "def read_record(): return 'beta'\n")
+    main = "from alpha import read_record\nprint(read_record())\n"
+    if second_is_live:
+        main += "from beta import read_record as read_other\nprint(read_other())\n"
+    _write(tmp_path / "main.py", main)
+
+    unused = _unused(_scan(tmp_path, grep_verify=grep_verify))
+
+    assert "alpha.read_record" not in unused
+    assert ("beta.read_record" in unused) is (not second_is_live)
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("root_kind", ["callback", "export", "entrypoint"])
+def test_external_entry_and_callback_roots_keep_transitive_helpers_live(
+    tmp_path, grep_verify, root_kind
+):
+    source = """
+        def process_leaf():
+            return 1
+
+        def run_public():
+            return process_leaf()
+    """
+    if root_kind == "callback":
+        source = textwrap.dedent(source) + (
+            "\nimport atexit\natexit.register(run_public)\n"
+        )
+    elif root_kind == "export":
+        source = textwrap.dedent(source) + "\n__all__ = ['run_public']\n"
+    else:
+        _write(
+            tmp_path / "pyproject.toml",
+            """
+            [project]
+            name = "reachability-fixture"
+            version = "0.0.0"
+            [project.scripts]
+            reachability-fixture = "worker:run_public"
+            """,
+        )
+    _write(tmp_path / "worker.py", source)
+
+    unused = _unused(_scan(tmp_path, grep_verify=grep_verify))
+
+    assert "worker.run_public" not in unused
+    assert "worker.process_leaf" not in unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize(
+    "definition_site",
+    [
+        "def unused_receiver(value=live_helper()): return value\n",
+        "class UnusedContainer:\n    value = live_helper()\n",
+        "def unused_receiver(value: live_helper()): return value\n",
+        (
+            "def attach(value):\n    return lambda func: func\n\n"
+            "@attach(live_helper())\ndef unused_receiver(): return None\n"
+        ),
+    ],
+    ids=["default", "class-body", "annotation", "decorator"],
+)
+def test_definition_time_expression_is_live_even_when_body_is_dead(
+    tmp_path, grep_verify, definition_site
+):
+    _write(
+        tmp_path / "worker.py",
+        "def live_helper():\n    return int\n\n" + definition_site,
+    )
+
+    assert "worker.live_helper" not in _unused(_scan(tmp_path, grep_verify=grep_verify))
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("selection", ["file", "changed-file", "excluded-directory"])
+def test_partial_scope_does_not_invent_an_unreachable_group(
+    tmp_path, grep_verify, selection
+):
+    worker = tmp_path / "worker.py"
+    _write(worker, _cycle_source())
+    _write(
+        tmp_path / "consumers" / "main.py",
+        "from worker import obsolete_entry\nprint(obsolete_entry())\n",
+    )
+    if selection == "file":
+        result = _scan(worker, grep_verify=grep_verify)
+    elif selection == "changed-file":
+        result = _scan(
+            tmp_path,
+            grep_verify=grep_verify,
+            changed_files={str(worker.resolve())},
+        )
+    else:
+        result = _scan(tmp_path, grep_verify=grep_verify, exclude_folders=["consumers"])
+
+    # A focused scan must preserve recursive members whose external caller is
+    # outside the selected file; it has no closed-world proof they are dead.
+    assert not {"worker.obsolete_alpha", "worker.obsolete_beta"} & _unused(result)
+
+
+def test_grep_cache_observes_adding_and_removing_a_real_caller(tmp_path):
+    _write(tmp_path / "worker.py", _cycle_source())
+    caller = tmp_path / "main.py"
+    states = [
+        "print('ready')\n",
+        "from worker import obsolete_entry\nprint(obsolete_entry())\n",
+        "print('ready')\n",
+    ]
+    expected = {
+        "worker.obsolete_alpha",
+        "worker.obsolete_beta",
+        "worker.obsolete_entry",
+    }
+    for index, source in enumerate(states):
+        _write(caller, source)
+        cold = _unused(_scan(tmp_path, grep_cache=False)) & expected
+        cached = _unused(_scan(tmp_path, grep_cache=True)) & expected
+        repeated = _unused(_scan(tmp_path, grep_cache=True)) & expected
+        assert cold == cached == repeated == (set() if index == 1 else expected)
+
+
+def test_real_cli_reports_dead_cycle_and_keeps_live_variant(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(repo_root)
+    expected = {
+        "worker.obsolete_alpha",
+        "worker.obsolete_beta",
+        "worker.obsolete_entry",
+    }
+    for live in (False, True):
+        _write(tmp_path / "worker.py", _cycle_source(live=live))
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from skylos.cli import main; main()",
+                str(tmp_path.resolve()),
+                "--format",
+                "json",
+                "--no-upload",
+            ],
+            cwd=repo_root,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert completed.returncode == 0, completed.stderr
+        result = json.loads(completed.stdout)
+        assert _unused(result) & expected == (set() if live else expected)
+
+
+def test_external_configuration_rescue_revives_callees_in_the_same_scan(tmp_path):
+    _write(
+        tmp_path / "helpers.py",
+        "def prepare_record():\n    return 42\n",
+    )
+    _write(
+        tmp_path / "workflow.py",
+        "def queue_task():\n"
+        "    from helpers import prepare_record\n"
+        "    return prepare_record()\n",
+    )
+    _write(tmp_path / "jobs.yaml", "handler_module: workflow.py\n")
+
+    first = _scan(tmp_path, grep_cache=True)
+    repeated = _scan(tmp_path, grep_cache=True)
+
+    expected = {"workflow.queue_task", "helpers.prepare_record"}
+    assert not _unused(first) & expected
+    assert not _unused(repeated) & expected
+    symbols = {
+        item["qualified_name"]: item for item in first["dead_code_evidence"]["symbols"]
+    }
+    helper_kinds = {
+        event["kind"] for event in symbols["helpers.prepare_record"]["evidence"]
+    }
+    assert "reachable_from_root" in helper_kinds
+    assert "grep_rescue" not in helper_kinds
+    assert first["analysis_summary"]["grep_verify"]["rescued_count"] == 1
+
+
+def test_group_evidence_distinguishes_unreachable_calls_from_no_references(tmp_path):
+    _write(tmp_path / "worker.py", _cycle_source())
+
+    result = _scan(tmp_path)
+    by_name = {
+        item["qualified_name"]: item for item in result["dead_code_evidence"]["symbols"]
+    }
+
+    for name in ("worker.obsolete_alpha", "worker.obsolete_beta"):
+        entry = by_name[name]
+        assert "no_reachable_callers" in entry["decision"]["reason_tags"]
+        assert "no_refs" not in entry["decision"]["reason_tags"]
+        kinds = {event["kind"] for event in entry["evidence"]}
+        assert "no_reachable_callers" in kinds
+        assert "no_static_references" not in kinds
+    assert "no_refs" in by_name["worker.obsolete_entry"]["decision"]["reason_tags"]
+
+
+def _write_duplicate_basename_modules(root):
+    for package, operator in (("north", "+"), ("south", "-")):
+        _write(root / package / "__init__.py", "")
+        _write(
+            root / package / "tasks.py",
+            f"def decode_packet(value):\n    return value {operator} 1\n",
+        )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("second_is_live", [False, True])
+def test_qualified_calls_distinguish_duplicate_module_basenames(
+    tmp_path, grep_verify, second_is_live
+):
+    _write_duplicate_basename_modules(tmp_path)
+    main = "import north.tasks\nprint(north.tasks.decode_packet(2))\n"
+    if second_is_live:
+        main += "import south.tasks\nprint(south.tasks.decode_packet(2))\n"
+    _write(tmp_path / "main.py", main)
+
+    result = _scan(tmp_path, grep_verify=grep_verify)
+    unused = _unused(result)
+
+    assert "north.tasks.decode_packet" not in unused
+    assert ("south.tasks.decode_packet" in unused) is (not second_is_live)
+    if not second_is_live:
+        entries = {
+            item["qualified_name"]: item
+            for item in result["dead_code_evidence"]["symbols"]
+        }
+        reasons = entries["south.tasks.decode_packet"]["decision"]["reason_tags"]
+        assert "no_refs" in reasons
+        assert "no_reachable_callers" not in reasons
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_unresolved_receiver_preserves_same_named_function_candidates(
+    tmp_path, grep_verify
+):
+    _write_duplicate_basename_modules(tmp_path)
+    _write(
+        tmp_path / "gateway.py",
+        """
+        __all__ = ["dispatch"]
+
+        def dispatch(backend):
+            return backend.decode_packet(2)
+        """,
+    )
+
+    # The public callback accepts an unknown backend. Either package module
+    # can satisfy that interface; the attribute hint cannot be discarded as
+    # though it resolved to a different, known symbol.
+    unused = _unused(_scan(tmp_path, grep_verify=grep_verify))
+    protected = {
+        "gateway.dispatch",
+        "north.tasks.decode_packet",
+        "south.tasks.decode_packet",
+    }
+    assert not protected & unused
+
+
+def test_unused_import_does_not_share_its_function_grep_verdict(tmp_path):
+    _write(
+        tmp_path / "worker.py",
+        "def calculate_payload():\n    return 42\n",
+    )
+    _write(
+        tmp_path / "importer.py",
+        "from worker import calculate_payload\nprint('ready')\n",
+    )
+    repo_root = Path(__file__).resolve().parents[1]
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(repo_root)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from skylos.cli import main; main()",
+            str(tmp_path.resolve()),
+            "--format",
+            "json",
+            "--no-upload",
+        ],
+        cwd=repo_root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    for result in (_scan(tmp_path), json.loads(completed.stdout)):
+        # Importing the function protects its public definition under the
+        # existing grep policy. The unused local import binding remains a
+        # separate finding despite sharing the function's qualified name.
+        assert "worker.calculate_payload" not in _unused(result)
+        assert any(
+            Path(item["file"]).name == "importer.py"
+            and item["simple_name"] == "calculate_payload"
+            for item in result.get("unused_imports", [])
+        )


### PR DESCRIPTION
## Summary

  - Detect unreachable python function chains and recursive groups using resolved symbol identities and caller reachability.
  - Prevent grep evidence from dead callers from incorrectly rescuing findings.
  - Explain "no reachable callers" through CLI evidence. No new flags.

  ## Tests

  - `pytest`
