### PR TITLE
feat(deadcode): detect unreachable python methods using receiver resolution

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>1092</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>12526</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>1095</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>12568</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>33</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1267,8 +1267,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode" rel="noopener noreferrer">skylos/deadcode</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 17</span>
-          <span class="pill"><strong>symbols</strong> 230</span>
+          <span class="pill"><strong>files</strong> 18</span>
+          <span class="pill"><strong>symbols</strong> 237</span>
         </div>
       </div>
       <p>Dead-code specific analysis, framework liveness, and evidence support.</p>
@@ -2049,8 +2049,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 309</span>
-          <span class="pill"><strong>symbols</strong> 5374</span>
+          <span class="pill"><strong>files</strong> 311</span>
+          <span class="pill"><strong>symbols</strong> 5409</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -2030,7 +2030,17 @@ class Skylos:
         self._python_reachability_report = report
         self._apply_python_reachability(report)
 
+    def _retain_receiver_uncertainty(self, report):
+        for key in report.protected_keys:
+            defn = self.defs.get(key)
+            if defn is not None and defn.references <= 0:
+                # Possible dynamic dispatch is retention evidence, not proof
+                # that this callable has an actual reachable invocation.
+                defn.references = 1
+                defn.heuristic_refs["unresolved_receiver"] = 1.0
+
     def _apply_python_reachability(self, report):
+        self._retain_receiver_uncertainty(report)
         for key in report.proven_reachable_keys:
             defn = self.defs.get(key)
             if defn is not None and defn.references <= 0:
@@ -2060,6 +2070,7 @@ class Skylos:
             key for key in previously_unreachable if self.defs[key].references > 0
         }
         report.refresh(self.defs, additional_roots=revived_roots)
+        self._retain_receiver_uncertainty(report)
         # An external callback or a later grep rescue may establish a real
         # caller. Its callees must be restored in this same scan.
         for key in previously_unreachable - report.unreachable_keys:

--- a/skylos/deadcode/_reachability_graph.py
+++ b/skylos/deadcode/_reachability_graph.py
@@ -16,6 +16,12 @@ from skylos.deadcode._reachability_bindings import (
     Bindings,
     ModuleInfo,
 )
+from skylos.deadcode._reachability_receivers import (
+    CLASS_BINDING,
+    INSTANCE_BINDING,
+    RECEIVER_BINDINGS,
+    ClassInfo,
+)
 
 if TYPE_CHECKING:
     from skylos.visitors.base import Definition
@@ -42,6 +48,9 @@ class SourceIndex:
     )
     initial_references: dict[str, int] = field(default_factory=dict)
     binding_targets: dict[Binding | None, frozenset[str]] = field(default_factory=dict)
+    classes: dict[str, ClassInfo] = field(default_factory=dict)
+    class_locations: dict[tuple[Path, int], str] = field(default_factory=dict)
+    method_classes: dict[str, str] = field(default_factory=dict)
 
     def qualified(self, name: str, seen: tuple[str, ...] = ()) -> Binding | None:
         if name in seen or len(seen) >= 24:
@@ -63,12 +72,19 @@ class SourceIndex:
     ) -> Binding | None:
         if end == len(parts):
             return (MODULE_BINDING, name)
-        if end != len(parts) - 1:
-            return None
-        binding = module.bindings.get(parts[-1])
+        binding = module.bindings.get(parts[end])
         if binding and binding[0] == QUALIFIED_BINDING:
             binding = self.qualified(binding[1], (*seen, name))
+        for member in parts[end + 1 :]:
+            binding = self.receiver_member(binding, member)
         return binding
+
+    def receiver_member(self, binding: Binding | None, name: str) -> Binding | None:
+        if binding and binding[0] in RECEIVER_BINDINGS:
+            key = self.classes[binding[1]].methods.get(name)
+            if key is not None:
+                return ("symbol", key)
+        return None
 
     def resolve(
         self, node: ast.AST, module: ModuleInfo, local: Bindings
@@ -84,6 +100,14 @@ class SourceIndex:
             base = self.resolve(node.value, module, local)
             if base and base[0] == MODULE_BINDING:
                 binding = self.qualified(f"{base[1]}.{node.attr}")
+            else:
+                binding = self.receiver_member(base, node.attr)
+                if base and base[0] == INSTANCE_BINDING and node.attr == "__class__":
+                    binding = (CLASS_BINDING, base[1])
+        elif isinstance(node, ast.Call):
+            constructor = self.resolve(node.func, module, local)
+            if constructor and constructor[0] == CLASS_BINDING:
+                binding = (INSTANCE_BINDING, constructor[1])
         return binding
 
     def escaped_symbols(self, binding: Binding | None) -> frozenset[str]:
@@ -108,6 +132,8 @@ class SourceIndex:
         kind, name = binding
         if kind == "symbol":
             possible.add(name)
+        elif kind in RECEIVER_BINDINGS:
+            possible.update(self.classes[name].methods.values())
         elif kind == QUALIFIED_BINDING:
             todo.append(self.qualified(name))
         elif kind == MODULE_BINDING:
@@ -125,6 +151,10 @@ class ReferenceGraph:
     opaque_owners: set[str] = field(default_factory=set)
     roots: set[str] = field(default_factory=set)
     uncertain_roots: set[str] = field(default_factory=set)
+    receiver_roots: set[str] = field(default_factory=set)
+    receiver_edges: dict[str, set[str]] = field(
+        default_factory=lambda: defaultdict(set)
+    )
     observed: Counter[str] = field(default_factory=Counter)
     references: dict[tuple[Path, int], list[SourceReference]] = field(
         default_factory=lambda: defaultdict(list)

--- a/skylos/deadcode/_reachability_receivers.py
+++ b/skylos/deadcode/_reachability_receivers.py
@@ -1,0 +1,180 @@
+"""Source-defined classes and stable receiver bindings for reachability.
+
+Unknown values stay unknown. Legacy inferred type names are deliberately not
+used as proof of an object's runtime class.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from pathlib import Path
+
+from skylos.deadcode._reachability_bindings import (
+    FUNCTION_NODES,
+    Bindings,
+    ModuleInfo,
+    argument_nodes,
+    bound_names,
+    function_bindings,
+)
+
+if TYPE_CHECKING:
+    from skylos.deadcode._reachability_graph import SourceIndex
+
+CLASS_BINDING = "class"
+INSTANCE_BINDING = "instance"
+RECEIVER_BINDINGS = {CLASS_BINDING, INSTANCE_BINDING}
+
+
+@dataclass
+class ClassInfo:
+    key: str
+    definition: Any
+    node: ast.ClassDef
+    module: ModuleInfo
+    methods: dict[str, str]
+
+
+def _namespace_name(class_name: str, member_name: str) -> str:
+    prefix = class_name.lstrip("_")
+    if prefix and member_name.startswith("__") and not member_name.endswith("__"):
+        return f"_{prefix}{member_name}"
+    return member_name
+
+
+def _plain_class(node: ast.ClassDef) -> bool:
+    if node.bases or node.keywords or node.decorator_list:
+        return False
+    for statement in node.body:
+        if isinstance(statement, FUNCTION_NODES):
+            if statement.decorator_list or statement.name in {
+                "__new__",
+                "__getattr__",
+                "__getattribute__",
+                "__setattr__",
+                "__delattr__",
+            }:
+                return False
+        elif isinstance(statement, ast.Pass):
+            continue
+        elif isinstance(statement, ast.Expr) and isinstance(
+            statement.value, ast.Constant
+        ):
+            continue
+        elif isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            # Executable class namespace expressions can install descriptors or
+            # mutate methods. Literal state has no such execution effects.
+            try:
+                ast.literal_eval(statement.value)
+            except (ValueError, TypeError, SyntaxError, RecursionError):
+                return False
+        else:
+            return False
+    return True
+
+
+def bind_classes(index: SourceIndex, definitions: Any) -> None:
+    locations = {
+        (Path(d.filename).resolve(), d.line, d.simple_name, d.type): (key, d)
+        for key, d in definitions.items()
+        if d.type in {"class", "method"}
+    }
+    for module in index.modules.values():
+        counts = bound_names(module.tree.body).counts
+        for node in module.tree.body:
+            if not isinstance(node, ast.ClassDef) or counts[node.name] != 1:
+                continue
+            _bind_class(index, module, node, locations)
+
+
+def _bind_class(
+    index: SourceIndex, module: ModuleInfo, node: ast.ClassDef, locations: dict
+) -> None:
+    entry = locations.get((module.path, node.lineno, node.name, "class"))
+    if entry is None or not _plain_class(node):
+        return
+    key, definition = entry
+    members = bound_names(node.body).counts
+    namespace: Counter[str] = Counter()
+    for name, count in members.items():
+        namespace[_namespace_name(node.name, name)] += count
+    if any(count > 1 for count in namespace.values()):
+        # Python mangles private names before binding the class
+        # namespace. A raw spelling can overwrite a private method.
+        return
+    methods = {}
+    for member in node.body:
+        if not isinstance(member, FUNCTION_NODES) or members[member.name] != 1:
+            continue
+        match = locations.get((module.path, member.lineno, member.name, "method"))
+        if match is None:
+            continue
+        method_key, method = match
+        methods[member.name] = method_key
+        methods[_namespace_name(node.name, member.name)] = method_key
+        index.candidates[method_key] = method
+        index.by_location[module.path, member.lineno] = method_key
+        index.by_name[method.name].append(method_key)
+        index.by_simple_name[method.simple_name].add(method_key)
+        index.initial_references[method_key] = method.references
+        index.method_classes[method_key] = key
+        module.functions[member.lineno] = method_key
+    index.classes[key] = ClassInfo(key, definition, node, module, methods)
+    index.class_locations[module.path, node.lineno] = key
+    module.bindings[node.name] = (CLASS_BINDING, key)
+
+
+def stable_receivers(
+    index: SourceIndex,
+    module: ModuleInfo,
+    statements: list[ast.stmt],
+    local: Bindings,
+    *,
+    parameters: set[str] | None = None,
+) -> Bindings:
+    """Resolve only unconditional, single-write assignments in this scope.
+
+    A branch, loop, unpacking or reassignment cannot establish a receiver.
+    Unknown RHS values are not filled in using annotations or naming rules.
+    """
+    counts = bound_names(statements).counts
+    protected = parameters or set()
+    result = dict(local)
+    for statement in statements:
+        if isinstance(statement, ast.Assign):
+            targets, value = statement.targets, statement.value
+        elif isinstance(statement, ast.AnnAssign) and statement.value is not None:
+            targets, value = [statement.target], statement.value
+        else:
+            continue
+        binding = index.resolve(value, module, result)
+        if not binding or binding[0] not in RECEIVER_BINDINGS:
+            continue
+        for target in targets:
+            if (
+                isinstance(target, ast.Name)
+                and counts[target.id] == 1
+                and target.id not in protected
+            ):
+                result[target.id] = binding
+    return result
+
+
+def function_receivers(
+    index: SourceIndex, module: ModuleInfo, node: Any
+) -> tuple[Bindings, bool]:
+    local, writes = function_bindings(node, module)
+    parameters = {arg.arg for arg in argument_nodes(node.args)}
+    key = module.functions.get(node.lineno)
+    class_key = index.method_classes.get(key)
+    positional = [*node.args.posonlyargs, *node.args.args]
+    if class_key and positional:
+        receiver = positional[0].arg
+        if receiver not in bound_names(node.body).counts:
+            local[receiver] = (INSTANCE_BINDING, class_key)
+    if not writes:
+        local = stable_receivers(index, module, node.body, local, parameters=parameters)
+    return local, writes

--- a/skylos/deadcode/_reachability_visitor.py
+++ b/skylos/deadcode/_reachability_visitor.py
@@ -12,8 +12,12 @@ from skylos.deadcode._reachability_bindings import (
     argument_nodes,
     bound_names,
     default_expressions,
-    function_bindings,
     import_bindings,
+)
+from skylos.deadcode._reachability_receivers import (
+    CLASS_BINDING,
+    RECEIVER_BINDINGS,
+    function_receivers,
 )
 from skylos.deadcode._reachability_graph import (
     ReferenceGraph,
@@ -55,8 +59,38 @@ class SourceVisitor(ast.NodeVisitor):
         self.owner: str | None = None
         self.proven_context = True
 
-    def _protect_binding(self, binding: Binding | None) -> None:
-        self.graph.protect(self.index.escaped_symbols(binding), self.owner)
+    def _protect_binding(
+        self, binding: Binding | None, *, retain_class: bool = False
+    ) -> None:
+        targets = self.index.escaped_symbols(binding)
+        self.graph.protect(targets, self.owner)
+        if binding and (
+            binding[0] == "instance" or (binding[0] == CLASS_BINDING and retain_class)
+        ):
+            destination = (
+                self.graph.receiver_roots
+                if self.owner is None
+                else self.graph.receiver_edges[self.owner]
+            )
+            destination.update(targets)
+
+    def _protect_value(self, expression: ast.AST, *, retain_class: bool = True) -> None:
+        # Result-carrying expressions can hide instances: conditionals,
+        # comprehensions, boolean expressions, and callbacks all escape their
+        # possible receiver constituents when the whole value escapes.
+        pending = [expression]
+        while pending:
+            part = pending.pop()
+            binding = self.index.resolve(part, self.module, self.local)
+            if binding and binding[0] in RECEIVER_BINDINGS:
+                self._protect_binding(binding, retain_class=retain_class)
+            if isinstance(part, ast.Call):
+                # Calling a method does not by itself pass its receiver as the
+                # returned value. Its body records any actual receiver return.
+                pending.extend(part.args)
+                pending.extend(kw.value for kw in part.keywords)
+            elif not isinstance(part, ast.Attribute):
+                pending.extend(ast.iter_child_nodes(part))
 
     def _binding_is_ambiguous(self, name: str) -> bool:
         return self.index.resolve(ast.Name(id=name), self.module, self.local) is None
@@ -71,6 +105,9 @@ class SourceVisitor(ast.NodeVisitor):
             )
             return
         for name in set(re.findall(r"\w+", node.value)):
+            binding = self.index.resolve(ast.Name(id=name), self.module, self.local)
+            if binding and binding[0] in RECEIVER_BINDINGS:
+                self._protect_binding(binding)
             if name in self.index.by_simple_name:
                 self.graph.record(
                     self.index, self.module, node, name, None, owner=self.owner
@@ -90,7 +127,7 @@ class SourceVisitor(ast.NodeVisitor):
                 owner=self.owner,
                 proven=self.proven_context,
             )
-            if binding and binding[0] == MODULE_BINDING:
+            if binding and binding[0] in {MODULE_BINDING, *RECEIVER_BINDINGS}:
                 self._protect_binding(binding)
 
     def visit_Attribute(self, node: ast.Attribute) -> None:
@@ -109,11 +146,25 @@ class SourceVisitor(ast.NodeVisitor):
             )
         # Looking up a resolved module attribute does not itself pass the
         # module object to unknown code. A standalone module value does.
-        if isinstance(node.value, ast.Name):
-            base = self.index.resolve(node.value, self.module, self.local)
-            if base and base[0] == MODULE_BINDING:
-                return
+        base = self.index.resolve(node.value, self.module, self.local)
+        if base and base[0] in RECEIVER_BINDINGS:
+            if not isinstance(node.ctx, ast.Load) and (
+                base[0] == CLASS_BINDING
+                or node.attr in self.index.classes[base[1]].methods
+                or node.attr in {"__class__", "__dict__"}
+            ):
+                self._protect_binding(base, retain_class=True)
+            self._visit_receiver_value(node.value)
+            return
+        if isinstance(node.value, ast.Name) and base and base[0] == MODULE_BINDING:
+            return
         self.generic_visit(node)
+
+    def _visit_receiver_value(self, node: ast.AST) -> None:
+        """A resolved receiver lookup/alias doesn't itself expose the object."""
+        if isinstance(node, ast.Name):
+            return
+        self.visit(node)
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
@@ -168,6 +219,12 @@ class SourceVisitor(ast.NodeVisitor):
             self.graph.opaque_owners.add(self.owner)
 
     def visit_Call(self, node: ast.Call) -> None:
+        for argument in [*node.args, *(kw.value for kw in node.keywords)]:
+            self._protect_value(argument)
+        constructor = self.index.resolve(node.func, self.module, self.local)
+        if constructor and constructor[0] == CLASS_BINDING:
+            self._visit_constructor(node, constructor[1])
+            return
         if (
             isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
@@ -181,17 +238,86 @@ class SourceVisitor(ast.NodeVisitor):
                 self._protect_binding((MODULE_BINDING, identity))
         self.generic_visit(node)
 
+    def _visit_constructor(self, node: ast.Call, class_key: str) -> None:
+        info = self.index.classes[class_key]
+        initializer = info.methods.get("__init__")
+        if initializer is not None:
+            self.graph.record(
+                self.index,
+                self.module,
+                node,
+                "__init__",
+                ("symbol", initializer),
+                owner=self.owner,
+                proven=self.proven_context,
+            )
+        self._visit_receiver_value(node.func)
+        for argument in [*node.args, *(kw.value for kw in node.keywords)]:
+            self.visit(argument)
+
+    def visit_Return(self, node: ast.Return | ast.Yield | ast.YieldFrom) -> None:
+        if node.value is not None:
+            self._protect_value(node.value)
+            self.visit(node.value)
+
+    visit_Yield = visit_Return
+    visit_YieldFrom = visit_Return
+
+    def visit_List(self, node: ast.List | ast.Tuple | ast.Set) -> None:
+        for item in node.elts:
+            self._protect_value(item, retain_class=False)
+        self.generic_visit(node)
+
+    visit_Tuple = visit_List
+    visit_Set = visit_List
+
+    def visit_Dict(self, node: ast.Dict) -> None:
+        for item in [*node.keys, *node.values]:
+            if item is not None:
+                self._protect_value(item, retain_class=False)
+        self.generic_visit(node)
+
     def visit_Assign(self, node: ast.Assign) -> None:
         if any(
             isinstance(target, ast.Name) and target.id == _EXPORT_LIST
             for target in node.targets
         ):
             self._check_exports(node.value)
+        if self._receiver_assignment(node.targets, node.value):
+            return
         self.generic_visit(node)
+
+    def _receiver_assignment(
+        self, targets: list[ast.expr], value: ast.expr | None
+    ) -> bool:
+        if value is None:
+            return False
+        binding = self.index.resolve(value, self.module, self.local)
+        if not binding or binding[0] not in RECEIVER_BINDINGS:
+            self._protect_value(value, retain_class=False)
+            return False
+        # Only stable, direct aliases avoid an escape. Container/attribute
+        # storage and unresolved/reassigned targets retain every possible member.
+        if not all(
+            isinstance(target, ast.Name)
+            and self.index.resolve(target, self.module, self.local) == binding
+            for target in targets
+        ):
+            self._protect_binding(binding)
+        self._visit_receiver_value(value)
+        for target in targets:
+            self.visit(target)
+        return True
 
     def visit_AnnAssign(self, node: ast.AnnAssign | ast.AugAssign) -> None:
         if isinstance(node.target, ast.Name) and node.target.id == _EXPORT_LIST:
             self._check_exports(node.value)
+        if isinstance(node, ast.AnnAssign) and self._receiver_assignment(
+            [node.target], node.value
+        ):
+            if node.annotation is not None:
+                self.visit(node.annotation)
+            return
         self.generic_visit(node)
 
     visit_AugAssign = visit_AnnAssign
@@ -212,8 +338,13 @@ class SourceVisitor(ast.NodeVisitor):
         previous = self.owner, self.local, self.proven_context
         self.owner = self.module.functions.get(node.lineno)
         self.proven_context = self.owner is not None
-        bindings, scope_writes = function_bindings(node, self.module)
-        self.local = {**self.local, **bindings}
+        bindings, scope_writes = function_receivers(self.index, self.module, node)
+        # Methods use module globals, not their class's execution namespace.
+        self.local = (
+            bindings
+            if self.owner in self.index.method_classes
+            else {**self.local, **bindings}
+        )
         if scope_writes:
             self._opaque()
         for statement in node.body:

--- a/skylos/deadcode/reachability.py
+++ b/skylos/deadcode/reachability.py
@@ -26,6 +26,7 @@ from skylos.deadcode._reachability_graph import (
     SourceReference,
 )
 from skylos.deadcode._reachability_visitor import SourceVisitor
+from skylos.deadcode._reachability_receivers import bind_classes, stable_receivers
 from skylos.deadcode.python_ast import ParsedPythonFile, parse_python_files
 
 if TYPE_CHECKING:
@@ -80,6 +81,7 @@ class PythonReachabilityReport:
         self.unreachable_keys: set[str] = set()
         self.reachable_keys: set[str] = set()
         self.proven_reachable_keys: set[str] = set()
+        self.protected_keys: set[str] = set()
         self.reasons: dict[str, str] = {}
         self._definitions = definitions
         self.index = SourceIndex()
@@ -103,6 +105,15 @@ class PythonReachabilityReport:
             candidates,
             uncertainty=False,
         ).intersection(candidates)
+        exposed_receivers = set(self.graph.receiver_roots)
+        for owner in reached:
+            exposed_receivers.update(self.graph.receiver_edges.get(owner, ()))
+        self.protected_keys = (
+            self.graph.traverse(
+                exposed_receivers, candidates, uncertainty=True
+            ).intersection(candidates)
+            - self.proven_reachable_keys
+        )
         self.unreachable_keys = set(candidates) - reached if self.complete else set()
         self.reasons = {key: _UNREACHABLE_REASON for key in self.unreachable_keys}
         return self
@@ -126,6 +137,15 @@ class PythonReachabilityReport:
         markers: Mapping[str, float],
     ) -> bool:
         external = any(getattr(definition, attr, False) for attr in _EXTERNAL_EVIDENCE)
+        class_key = self.index.method_classes.get(key)
+        if class_key is not None:
+            owning_class = self.index.classes[class_key].definition
+            external |= any(
+                getattr(owning_class, attr, False) for attr in _EXTERNAL_EVIDENCE
+            )
+            external |= definition.simple_name.startswith(
+                "__"
+            ) and definition.simple_name.endswith("__")
         callback = any(name.startswith("dead_code_liveness:") for name in markers)
         return external or callback or self._unaccounted_reference(key, definition)
 
@@ -376,6 +396,11 @@ def analyze_python_reachability(
         return report
     for module in report.index.modules.values():
         _bind_module(report, module, locations)
+    bind_classes(report.index, definitions)
+    for module in report.index.modules.values():
+        module.bindings = stable_receivers(
+            report.index, module, module.tree.body, module.bindings
+        )
     for module in report.index.modules.values():
         SourceVisitor(report.index, report.graph, module).visit(module.tree)
     return report.refresh()

--- a/test/test_method_reachability.py
+++ b/test/test_method_reachability.py
@@ -1,0 +1,341 @@
+"""Frozen method-reachability acceptance cases; fixture source is never executed."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from skylos.analyzer import analyze
+from skylos.core.safe_cache_io import write_text_no_symlink
+
+
+def _write(root, name, source):
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    assert write_text_no_symlink(path, textwrap.dedent(source).lstrip())
+    return path
+
+
+def _scan(path, **options):
+    return json.loads(analyze(str(path.resolve()), trace_file=False, **options))
+
+
+def _unused(result):
+    return {item["full_name"] for item in result.get("unused_functions", [])}
+
+
+def _pair(first="NorthernCodec", second="SouthernCodec"):
+    return (
+        f"class {first}:\n"
+        "    def encode_payload(self): return 1\n\n"
+        f"class {second}:\n"
+        "    def encode_payload(self): return 2\n\n"
+    )
+
+
+def _cycle():
+    return textwrap.dedent("""
+        class PacketWorker:
+            def advance_phase(self, count):
+                return self.finish_phase(count - 1) if count else 1
+
+            def finish_phase(self, count):
+                return self.advance_phase(count - 1) if count else 2
+
+        worker = PacketWorker()
+    """).lstrip()
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("both_live", [False, True])
+@pytest.mark.parametrize(
+    "first,second",
+    [("NorthernCodec", "SouthernCodec"), ("northern_codec", "southern_codec")],
+    ids=["capitalized", "lowercase"],
+)
+def test_same_name_methods_resolve_to_their_receiver(
+    tmp_path, grep_verify, both_live, first, second
+):
+    source = _pair(first, second)
+    source += f"north = {first}()\nsouth = {second}()\nnorth.encode_payload()\n"
+    if both_live:
+        source += "south.encode_payload()\n"
+    _write(tmp_path, "worker.py", source)
+
+    result = _scan(tmp_path, grep_verify=grep_verify)
+    expected = {f"worker.{first}.encode_payload", f"worker.{second}.encode_payload"}
+    assert _unused(result) & expected == (
+        set() if both_live else {f"worker.{second}.encode_payload"}
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize(
+    "usage",
+    [
+        "north = NorthernCodec()\nalias = north\nalias.encode_payload()\n",
+        "Factory = NorthernCodec\nnorth = Factory()\nnorth.encode_payload()\n",
+        (
+            "def launch():\n"
+            "    north = NorthernCodec()\n"
+            "    alias = north\n"
+            "    return alias.encode_payload()\n"
+            "launch()\n"
+        ),
+    ],
+    ids=["module-receiver-alias", "constructor-alias", "local-receiver-alias"],
+)
+def test_receiver_aliases_keep_only_the_resolved_method(tmp_path, grep_verify, usage):
+    _write(tmp_path, "worker.py", _pair() + "south = SouthernCodec()\n" + usage)
+
+    unused = _unused(_scan(tmp_path, grep_verify=grep_verify))
+
+    assert "worker.NorthernCodec.encode_payload" not in unused
+    assert "worker.SouthernCodec.encode_payload" in unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize(
+    "binding,constructor",
+    [
+        ("from codecs_local import NorthernCodec as Factory", "Factory"),
+        ("import codecs_local as local", "local.NorthernCodec"),
+    ],
+    ids=["imported-class-alias", "module-alias"],
+)
+def test_import_aliases_preserve_class_identity(
+    tmp_path, grep_verify, binding, constructor
+):
+    _write(tmp_path, "codecs_local.py", _pair())
+    _write(
+        tmp_path,
+        "main.py",
+        f"{binding}\nfrom codecs_local import SouthernCodec\n"
+        f"north = {constructor}()\nsouth = SouthernCodec()\n"
+        "north.encode_payload()\n",
+    )
+
+    unused = _unused(_scan(tmp_path, grep_verify=grep_verify))
+
+    assert "codecs_local.NorthernCodec.encode_payload" not in unused
+    assert "codecs_local.SouthernCodec.encode_payload" in unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("live", [False, True])
+@pytest.mark.parametrize("recursive", [False, True], ids=["chain", "cycle"])
+def test_self_method_groups_require_a_reachable_caller(
+    tmp_path, grep_verify, live, recursive
+):
+    source = _cycle()
+    if not recursive:
+        source = source.replace("self.advance_phase(count - 1) if count else 2", "2")
+    if live:
+        source += "worker.advance_phase(3)\n"
+    _write(tmp_path, "worker.py", source)
+
+    expected = {"worker.PacketWorker.advance_phase", "worker.PacketWorker.finish_phase"}
+    assert _unused(_scan(tmp_path, grep_verify=grep_verify)) & expected == (
+        set() if live else expected
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("keyword", [False, True], ids=["positional", "keyword"])
+def test_local_argument_flow_does_not_lose_a_live_method(
+    tmp_path, grep_verify, keyword
+):
+    source = _pair() + textwrap.dedent("""
+        def dispatch(codec):
+            return codec.encode_payload()
+
+        north = NorthernCodec()
+        south = SouthernCodec()
+    """)
+    source += "dispatch(codec=north)\n" if keyword else "dispatch(north)\n"
+    _write(tmp_path, "worker.py", source)
+
+    unused = _unused(_scan(tmp_path, grep_verify=grep_verify))
+
+    # Precision for the unused southern method can stay conservative in this
+    # first pass, but passing a known receiver must never lose its live method.
+    assert "worker.NorthernCodec.encode_payload" not in unused
+
+
+@pytest.mark.parametrize(
+    "usage",
+    [
+        (
+            "codec = NorthernCodec()\ncodec.encode_payload()\n"
+            "codec = SouthernCodec()\ncodec.encode_payload()\n"
+        ),
+        (
+            "from external import choose\n"
+            "if choose():\n    codec = NorthernCodec()\n"
+            "else:\n    codec = SouthernCodec()\ncodec.encode_payload()\n"
+        ),
+        (
+            "from external import choose\n"
+            "codec = NorthernCodec() if choose() else SouthernCodec()\n"
+            "codec.encode_payload()\n"
+        ),
+    ],
+    ids=["receiver-reassignment", "branch-join", "conditional-expression"],
+)
+def test_multiple_possible_receivers_preserve_live_methods(tmp_path, usage):
+    _write(tmp_path, "worker.py", _pair() + usage)
+
+    unused = _unused(_scan(tmp_path))
+
+    assert (
+        not {
+            "worker.NorthernCodec.encode_payload",
+            "worker.SouthernCodec.encode_payload",
+        }
+        & unused
+    )
+
+
+@pytest.mark.parametrize(
+    "source,protected",
+    [
+        (
+            _cycle() + "class Child(PacketWorker): pass\nChild().advance_phase(3)\n",
+            {"PacketWorker.advance_phase", "PacketWorker.finish_phase"},
+        ),
+        (
+            "class Descriptor:\n"
+            "    def __get__(self, instance, owner): return instance.finish_phase\n"
+            "class PacketWorker:\n"
+            "    advance_phase = Descriptor()\n"
+            "    def finish_phase(self): return 1\n"
+            "PacketWorker().advance_phase()\n",
+            {"PacketWorker.finish_phase"},
+        ),
+        (
+            "from external import register\n"
+            "class Registry(type):\n"
+            "    def __new__(mcls, name, bases, namespace):\n"
+            "        register(namespace)\n"
+            "        return super().__new__(mcls, name, bases, namespace)\n"
+            "class PacketWorker(metaclass=Registry):\n"
+            "    def advance_phase(self): return self.finish_phase()\n"
+            "    def finish_phase(self): return self.advance_phase()\n"
+            "worker = PacketWorker()\n",
+            {"PacketWorker.advance_phase", "PacketWorker.finish_phase"},
+        ),
+        (
+            _pair() + "north = NorthernCodec()\nsouth = SouthernCodec()\n"
+            "north.encode_payload = south.encode_payload\nnorth.encode_payload()\n",
+            {"SouthernCodec.encode_payload"},
+        ),
+        (
+            "from external import register\n" + _cycle() + "register(worker)\n",
+            {"PacketWorker.advance_phase", "PacketWorker.finish_phase"},
+        ),
+        (
+            "from external import register\n"
+            + _cycle()
+            + "register(worker.advance_phase)\n",
+            {"PacketWorker.advance_phase", "PacketWorker.finish_phase"},
+        ),
+    ],
+    ids=["inheritance", "descriptor", "metaclass", "monkeypatch", "escape", "callback"],
+)
+def test_dynamic_class_boundaries_preserve_possible_entry_methods(
+    tmp_path, source, protected
+):
+    _write(tmp_path, "worker.py", source)
+
+    unused = _unused(_scan(tmp_path))
+
+    assert not {f"worker.{name}" for name in protected} & unused
+
+
+@pytest.mark.parametrize("scope", ["file", "changed-file", "excluded-directory"])
+def test_partial_scan_does_not_prove_method_cycles_dead(tmp_path, scope):
+    worker = _write(tmp_path, "worker.py", _cycle())
+    _write(
+        tmp_path,
+        "consumers/main.py",
+        "from worker import worker\nworker.advance_phase(3)\n",
+    )
+    if scope == "file":
+        result = _scan(worker)
+    elif scope == "changed-file":
+        result = _scan(tmp_path, changed_files={str(worker.resolve())})
+    else:
+        result = _scan(tmp_path, exclude_folders=["consumers"])
+
+    assert not {
+        "worker.PacketWorker.advance_phase",
+        "worker.PacketWorker.finish_phase",
+    } & _unused(result)
+
+
+def test_cache_tracks_adding_and_removing_method_roots(tmp_path):
+    expected = {"worker.PacketWorker.advance_phase", "worker.PacketWorker.finish_phase"}
+    for live in (False, True, False):
+        source = _cycle() + ("worker.advance_phase(3)\n" if live else "")
+        _write(tmp_path, "worker.py", source)
+        expected_unused = set() if live else expected
+        for cache_enabled in (False, True, True):
+            result = _scan(tmp_path, grep_cache=cache_enabled)
+            assert _unused(result) & expected == expected_unused
+
+
+@pytest.mark.parametrize("case", ["same-name", "cycle"])
+def test_default_cli_reports_methods_and_explains_unreachable_groups(tmp_path, case):
+    repo_root = Path(__file__).resolve().parents[1]
+    environment = os.environ.copy()
+    environment["PYTHONPATH"] = str(repo_root)
+    for live in (False, True):
+        if case == "cycle":
+            source = _cycle() + ("worker.advance_phase(3)\n" if live else "")
+            expected = {
+                "worker.PacketWorker.advance_phase",
+                "worker.PacketWorker.finish_phase",
+            }
+        else:
+            source = (
+                _pair()
+                + (
+                    "north = NorthernCodec()\nsouth = SouthernCodec()\n"
+                    "north.encode_payload()\n"
+                )
+                + ("south.encode_payload()\n" if live else "")
+            )
+            expected = {"worker.SouthernCodec.encode_payload"}
+        _write(tmp_path, "worker.py", source)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from skylos.cli import main; main()",
+                str(tmp_path.resolve()),
+                "--format",
+                "json",
+                "--no-upload",
+            ],
+            cwd=repo_root,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert completed.returncode == 0, completed.stderr
+        result = json.loads(completed.stdout)
+        assert _unused(result) & expected == (set() if live else expected)
+        if case == "cycle" and not live:
+            symbols = {
+                item["qualified_name"]: item
+                for item in result["dead_code_evidence"]["symbols"]
+            }
+            for name in expected:
+                assert (
+                    "no_reachable_callers" in symbols[name]["decision"]["reason_tags"]
+                )

--- a/test/test_method_reachability_safety.py
+++ b/test/test_method_reachability_safety.py
@@ -1,0 +1,483 @@
+"""Live method controls, derived from Python semantics; fixture code never runs."""
+
+import json
+import textwrap
+
+import pytest
+
+from skylos.analyzer import analyze
+from skylos.core.safe_cache_io import write_text_no_symlink
+
+
+def _assert_live(tmp_path, source, *targets, grep_verify=False):
+    path = tmp_path / "worker.py"
+    assert write_text_no_symlink(path, textwrap.dedent(source).lstrip())
+    result = json.loads(
+        analyze(str(tmp_path.resolve()), trace_file=False, grep_verify=grep_verify)
+    )
+    assert not result.get("analysis_errors")
+    unused = {item["full_name"] for item in result.get("unused_functions", [])}
+    assert not {f"worker.{target}" for target in targets} & unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_custom_new_can_return_an_unrelated_receiver(tmp_path, grep_verify):
+    _assert_live(
+        tmp_path,
+        """
+        class Requested:
+            def __new__(cls):
+                return Actual()
+            def deliver(self):
+                return 0
+
+        class Actual:
+            def deliver(self):
+                return 1
+
+        Requested().deliver()
+        """,
+        "Actual.deliver",
+        grep_verify=grep_verify,
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_inherited_method_dispatches_to_child_override(tmp_path, grep_verify):
+    _assert_live(
+        tmp_path,
+        """
+        def finish_child_work():
+            return 1
+
+        class Parent:
+            def run(self):
+                return self.step()
+            def step(self):
+                return 0
+
+        class Child(Parent):
+            def step(self):
+                return finish_child_work()
+
+        Child().run()
+        """,
+        "Parent.run",
+        "Child.step",
+        "finish_child_work",
+        grep_verify=grep_verify,
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_constructor_reaches_helpers_with_arbitrary_receiver_name(
+    tmp_path, grep_verify
+):
+    _assert_live(
+        tmp_path,
+        """
+        def finish_setup():
+            return 1
+
+        class Service:
+            def __init__(instance):
+                instance.prepare()
+            def prepare(instance):
+                return instance.finish()
+            def finish(instance):
+                return finish_setup()
+
+        Service()
+        """,
+        "Service.prepare",
+        "Service.finish",
+        "finish_setup",
+        grep_verify=grep_verify,
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_constructor_can_replace_method_through_receiver_alias(tmp_path, grep_verify):
+    _assert_live(
+        tmp_path,
+        """
+        class Replacement:
+            def perform(self):
+                return 1
+
+        class Service:
+            def __init__(self):
+                alias = self
+                alias.perform = Replacement().perform
+            def perform(self):
+                return 0
+
+        Service().perform()
+        """,
+        "Replacement.perform",
+        grep_verify=grep_verify,
+    )
+
+
+def test_method_global_lookup_does_not_use_the_class_namespace(tmp_path):
+    _assert_live(
+        tmp_path,
+        """
+        def operation():
+            return 1
+
+        class Service:
+            operation = None
+            def run(self):
+                return operation()
+
+        Service().run()
+        """,
+        "operation",
+        "Service.run",
+    )
+
+
+def test_method_default_is_evaluated_in_class_namespace(tmp_path):
+    _assert_live(
+        tmp_path,
+        """
+        def initialize_option():
+            return 1
+
+        class Service:
+            provider = initialize_option
+            def run(self, value=provider()):
+                return value
+        """,
+        "initialize_option",
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_exported_factory_keeps_returned_instance_methods_possible(
+    tmp_path, grep_verify
+):
+    _assert_live(
+        tmp_path,
+        """
+        __all__ = ["make_service"]
+
+        class Service:
+            def run(self):
+                return self.finish()
+            def finish(self):
+                return 1
+
+        def make_service():
+            return Service()
+        """,
+        "Service.run",
+        "Service.finish",
+        grep_verify=grep_verify,
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_callback_escape_does_not_close_its_argument_types(tmp_path, grep_verify):
+    _assert_live(
+        tmp_path,
+        """
+        from external import register
+
+        class Local:
+            def accept(self):
+                return 0
+
+        class Remote:
+            def accept(self):
+                return 1
+
+        def dispatch(receiver):
+            return receiver.accept()
+
+        dispatch(Local())
+        register(dispatch, Remote())
+        """,
+        "Remote.accept",
+        grep_verify=grep_verify,
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize(
+    "unpacked_call", ["dispatch(*(Remote(),))", "dispatch(**{'receiver': Remote()})"]
+)
+def test_unpacked_argument_is_not_removed_from_receiver_candidates(
+    tmp_path, grep_verify, unpacked_call
+):
+    source = """
+        class Local:
+            def accept(self):
+                return 0
+
+        class Remote:
+            def accept(self):
+                return 1
+
+        def dispatch(receiver):
+            return receiver.accept()
+
+        dispatch(Local())
+    """
+    _assert_live(
+        tmp_path,
+        textwrap.dedent(source) + unpacked_call + "\n",
+        "Local.accept",
+        "Remote.accept",
+        grep_verify=grep_verify,
+    )
+
+
+def test_bound_method_alias_keeps_transitive_helpers(tmp_path):
+    _assert_live(
+        tmp_path,
+        """
+        class Service:
+            def run(self):
+                return self.finish()
+            def finish(self):
+                return 1
+
+        callback = Service().run
+        callback()
+        """,
+        "Service.run",
+        "Service.finish",
+    )
+
+
+def test_property_result_is_not_an_instance_of_its_owner(tmp_path):
+    _assert_live(
+        tmp_path,
+        """
+        class Payload:
+            def deliver(self):
+                return 1
+
+        class Envelope:
+            @property
+            def payload(self):
+                return Payload()
+            def deliver(self):
+                return 0
+
+        Envelope().payload.deliver()
+        """,
+        "Payload.deliver",
+    )
+
+
+def test_receiver_reassignment_does_not_change_an_earlier_alias(tmp_path):
+    _assert_live(
+        tmp_path,
+        """
+        class First:
+            def run(self):
+                return 1
+
+        class Second:
+            def run(self):
+                return 2
+
+        receiver = First()
+        original = receiver
+        receiver = Second()
+        original.run()
+        receiver.run()
+        """,
+        "First.run",
+        "Second.run",
+    )
+
+
+def test_loop_receiver_keeps_each_possible_method(tmp_path):
+    _assert_live(
+        tmp_path,
+        """
+        class First:
+            def run(self):
+                return 1
+
+        class Second:
+            def run(self):
+                return 2
+
+        for receiver in (First(), Second()):
+            receiver.run()
+        """,
+        "First.run",
+        "Second.run",
+    )
+
+
+def test_explicit_unbound_call_uses_the_passed_receiver(tmp_path):
+    _assert_live(
+        tmp_path,
+        """
+        class First:
+            def run(instance):
+                return instance.finish()
+            def finish(instance):
+                return 1
+
+        class Second:
+            def finish(instance):
+                return 2
+
+        First.run(Second())
+        """,
+        "First.run",
+        "Second.finish",
+    )
+
+
+@pytest.mark.parametrize(
+    "escape",
+    [
+        "from external import accept\naccept([Worker() for item in (1,)])\n",
+        "from external import accept\naccept(Worker() for item in (1,))\n",
+        "__all__ = ['factory']\ndef factory(flag):\n"
+        "    return Worker() if flag else None\n",
+        "from external import accept, choose\naccept(Worker() if choose() else None)\n",
+        "from external import accept\naccept(Worker() or None)\n",
+        "__all__ = ['factory']\ndef factory():\n"
+        "    return [Worker() for item in (1,)]\n",
+    ],
+    ids=[
+        "list-comprehension",
+        "generator-expression",
+        "conditional-return",
+        "conditional-argument",
+        "boolean-argument",
+        "comprehension-return",
+    ],
+)
+def test_receiver_escapes_through_compound_expressions(tmp_path, escape):
+    source = """
+        class Worker:
+            def start(self):
+                return self.finish()
+            def finish(self):
+                return self.start()
+
+    """
+    _assert_live(
+        tmp_path,
+        textwrap.dedent(source) + escape,
+        "Worker.start",
+        "Worker.finish",
+        grep_verify=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "extension",
+    [
+        "from external import invoke\nAlias.invoke = invoke\nWorker().invoke()\n",
+        "from external import Descriptor\n"
+        "Alias.action = Descriptor()\nWorker().action()\n",
+    ],
+    ids=["foreign-method", "foreign-descriptor"],
+)
+def test_new_class_member_can_pass_receiver_to_external_code(tmp_path, extension):
+    source = """
+        class Worker:
+            def start(self):
+                return self.finish()
+            def finish(self):
+                return self.start()
+
+        Alias = Worker
+    """
+    _assert_live(
+        tmp_path,
+        textwrap.dedent(source) + extension,
+        "Worker.start",
+        "Worker.finish",
+        grep_verify=True,
+    )
+
+
+def test_explicit_mangled_method_name_reaches_private_group(tmp_path):
+    _assert_live(
+        tmp_path,
+        """
+        class Worker:
+            def __start(self):
+                return self.__finish()
+            def __finish(self):
+                return self.__start()
+
+        Worker()._Worker__start()
+        """,
+        "Worker.__start",
+        "Worker.__finish",
+        grep_verify=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "source,method",
+    [
+        (
+            """
+            class Worker:
+                def __start(self):
+                    return 0
+                def _Worker__start(self):
+                    return self.finish()
+                def finish(self):
+                    return self._Worker__start()
+                def run(self):
+                    return self.__start()
+
+            Worker().run()
+            """,
+            "Worker._Worker__start",
+        ),
+        (
+            """
+            class Worker:
+                _Worker__start = None
+                def __start(self):
+                    return self.finish()
+                def finish(self):
+                    return self.__start()
+                def run(self):
+                    return self._Worker__start()
+
+            Worker().run()
+            """,
+            "Worker.__start",
+        ),
+    ],
+    ids=["method-replaces-private-method", "private-method-replaces-assignment"],
+)
+def test_mangled_namespace_collision_keeps_actual_method_live(tmp_path, source, method):
+    _assert_live(tmp_path, source, method, "Worker.finish", grep_verify=True)
+
+
+def test_instance_class_attribute_exposes_its_class(tmp_path):
+    _assert_live(
+        tmp_path,
+        """
+        from external import register
+
+        class Worker:
+            def start(self):
+                return self.finish()
+            def finish(self):
+                return self.start()
+
+        register(Worker().__class__)
+        """,
+        "Worker.start",
+        "Worker.finish",
+        grep_verify=True,
+    )


### PR DESCRIPTION
## Summary

  - Resolve methods against their owning classes.
  - Detect unreachable method chains and cycles, supporting stable receiver aliases, imports, constructor calls
  - Retain potentially used methods when receivers escape

## Tests

pytest test/test_method_reachability.py test/test_method_reachability_safety.py test/test_reachability_integration_qa.py \
    test/test_analyzer.py