### PR TITLE
fix(circular): make cycle selection independent of iteration order

### DIFF
--- a/rust/src/cycles.rs
+++ b/rust/src/cycles.rs
@@ -22,6 +22,14 @@ pub fn find_cycles(
     for (from, to) in &edges {
         deps.entry(from.clone()).or_default().push(to.clone());
     }
+    // Sorted traversal: the result is a function of the graph, not of the
+    // order in which the caller happened to enumerate edges and modules.
+    for neighbors in deps.values_mut() {
+        neighbors.sort();
+        neighbors.dedup();
+    }
+    let mut modules = modules;
+    modules.sort();
 
     let mut all_cycles: Vec<Vec<String>> = Vec::new();
 

--- a/rust/src/cycles.rs
+++ b/rust/src/cycles.rs
@@ -4,7 +4,11 @@
 use pyo3::prelude::*;
 use std::collections::{HashMap, HashSet};
 
-/// Find all circular dependency cycles using DFS (matches Python's find_simple_cycles exactly).
+/// Find circular dependency cycles using DFS (matches Python's find_simple_cycles exactly).
+///
+/// Like the Python finder this reports one cycle per back edge of a pruned
+/// traversal, not every elementary cycle; the sorted traversal only makes
+/// that selection a deterministic function of the graph.
 ///
 /// Args:
 ///     edges: List of (from_module, to_module) import edges.

--- a/rust/src/cycles.rs
+++ b/rust/src/cycles.rs
@@ -8,7 +8,9 @@ use std::collections::{HashMap, HashSet};
 ///
 /// Args:
 ///     edges: List of (from_module, to_module) import edges.
-///     modules: List of module names (iteration order matters for determinism).
+///     modules: List of module names. Edge and module order do not affect the
+///         result: both are sorted internally so the output is a function of the
+///         graph alone.
 ///
 /// Returns:
 ///     List of cycles, where each cycle is a normalized list of module names.

--- a/skylos/analysis/circular_deps.py
+++ b/skylos/analysis/circular_deps.py
@@ -251,6 +251,11 @@ class CircularDependencyAnalyzer:
         """Pure Python DFS cycle detection."""
         cycles = []
         visited = set()
+        # Sorted once up front: the traversal is then a pure function of the
+        # graph rather than of set iteration order (PYTHONHASHSEED).
+        adjacency = {
+            node: sorted(neighbors) for node, neighbors in self.dependencies.items()
+        }
 
         def dfs(node, path, path_set):
             if node in path_set:
@@ -267,7 +272,7 @@ class CircularDependencyAnalyzer:
             path.append(node)
             path_set.add(node)
 
-            for neighbor in sorted(self.dependencies.get(node, ())):
+            for neighbor in adjacency.get(node, ()):
                 found_cycles.extend(dfs(neighbor, path, path_set))
 
             path.pop()
@@ -276,6 +281,7 @@ class CircularDependencyAnalyzer:
 
             return found_cycles
 
+        # Roots sorted too, so file discovery order cannot change the result.
         for node in sorted(self.modules):
             visited.clear()
             found = dfs(node, [], set())

--- a/skylos/analysis/circular_deps.py
+++ b/skylos/analysis/circular_deps.py
@@ -239,11 +239,12 @@ class CircularDependencyAnalyzer:
 
     def _find_cycles_fast(self) -> List[List[str]]:
         """Rust-accelerated cycle detection."""
-        edges = []
-        for frm, tos in self.dependencies.items():
-            for to in tos:
-                edges.append((frm, to))
-        modules = list(self.modules.keys())
+        # Sorted so the traversal is a pure function of the graph rather than
+        # of set iteration order (PYTHONHASHSEED) or file discovery order.
+        edges = sorted(
+            (frm, to) for frm, tos in self.dependencies.items() for to in tos
+        )
+        modules = sorted(self.modules)
         return _fast_find_cycles(edges, modules)
 
     def _find_cycles_py(self) -> List[List[str]]:
@@ -266,7 +267,7 @@ class CircularDependencyAnalyzer:
             path.append(node)
             path_set.add(node)
 
-            for neighbor in self.dependencies.get(node, []):
+            for neighbor in sorted(self.dependencies.get(node, ())):
                 found_cycles.extend(dfs(neighbor, path, path_set))
 
             path.pop()
@@ -275,7 +276,7 @@ class CircularDependencyAnalyzer:
 
             return found_cycles
 
-        for node in self.modules:
+        for node in sorted(self.modules):
             visited.clear()
             found = dfs(node, [], set())
             for cycle in found:
@@ -335,7 +336,7 @@ class CircularDependencyAnalyzer:
                 )
             )
 
-        findings.sort(key=lambda f: len(f.cycle))
+        findings.sort(key=lambda f: (len(f.cycle), f.cycle))
 
         return findings
 

--- a/test/test_circular_deps.py
+++ b/test/test_circular_deps.py
@@ -1,5 +1,11 @@
 import ast
 import itertools
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 from skylos.analysis import circular_deps
 from skylos.analysis.architecture import get_architecture_findings
@@ -754,43 +760,168 @@ except ImportError:
         assert len(builder.dependencies) == 2
 
 
+_ORDER_SENSITIVE_EDGES = (
+    ("alpha", "beta"),
+    ("alpha", "gamma"),
+    ("beta", "alpha"),
+    ("beta", "gamma"),
+    ("gamma", "alpha"),
+    ("gamma", "delta"),
+    ("delta", "alpha"),
+)
+_ORDER_SENSITIVE_MODULES = ("alpha", "beta", "gamma", "delta")
+# All five elementary cycles of that graph, in (length, cycle) order. The
+# pruned DFS used to report four or five of them depending on which neighbor
+# it happened to explore first.
+_ORDER_SENSITIVE_CYCLES = [
+    ["alpha", "beta"],
+    ["alpha", "gamma"],
+    ["alpha", "beta", "gamma"],
+    ["alpha", "gamma", "delta"],
+    ["alpha", "beta", "gamma", "delta"],
+]
+# A fully bidirectional triangle has two 3-cycles over the same node set
+# (a->b->c->a and a->c->b->a). Dedup keeps whichever is found first, so this
+# graph is sensitive to root order even once neighbors are sorted.
+_TRIANGLE_EDGES = (
+    ("a", "b"),
+    ("b", "a"),
+    ("b", "c"),
+    ("c", "b"),
+    ("a", "c"),
+    ("c", "a"),
+)
+_TRIANGLE_MODULES = ("a", "b", "c")
+_TRIANGLE_CYCLE_SETS = {("a", "b"), ("a", "c"), ("b", "c"), ("a", "b", "c")}
+
+
+def _adjacency_orderings(edges):
+    """Every combination of neighbor list orders, as plain lists.
+
+    Lists rather than sets so the iteration order is exactly what the test
+    chose, independent of the hash seed the test process happens to run under.
+    """
+    by_source = {}
+    for frm, to in edges:
+        by_source.setdefault(frm, []).append(to)
+    sources = sorted(by_source)
+    for orders in itertools.product(
+        *(itertools.permutations(by_source[source]) for source in sources)
+    ):
+        yield {source: list(order) for source, order in zip(sources, orders)}
+
+
+def _python_cycles(adjacency, module_order):
+    analyzer = CircularDependencyAnalyzer()
+    for module in module_order:
+        analyzer.modules[module] = f"/project/{module}.py"
+    analyzer.dependencies = dict(adjacency)
+    return analyzer._find_cycles_py()
+
+
+@pytest.mark.parametrize(
+    ("edges", "modules", "expected_cycle_sets"),
+    [
+        pytest.param(
+            _ORDER_SENSITIVE_EDGES,
+            _ORDER_SENSITIVE_MODULES,
+            {tuple(sorted(cycle)) for cycle in _ORDER_SENSITIVE_CYCLES},
+            id="pruning-sensitive",
+        ),
+        pytest.param(
+            _TRIANGLE_EDGES,
+            _TRIANGLE_MODULES,
+            _TRIANGLE_CYCLE_SETS,
+            id="bidirectional-triangle",
+        ),
+    ],
+)
+def test_python_cycle_search_is_independent_of_adjacency_and_root_order(
+    edges, modules, expected_cycle_sets
+):
+    """Forced-Python: neither neighbor order nor root order may change the
+    cycles found, their orientation, or the order they are returned in."""
+    reference = _python_cycles(
+        {
+            source: sorted(order)
+            for source, order in next(_adjacency_orderings(edges)).items()
+        },
+        sorted(modules),
+    )
+    assert {tuple(sorted(cycle)) for cycle in reference} == expected_cycle_sets
+    assert len(reference) == len(expected_cycle_sets)
+    for adjacency in _adjacency_orderings(edges):
+        for module_order in itertools.permutations(modules):
+            found = _python_cycles(adjacency, module_order)
+            assert found == reference, (adjacency, module_order, found)
+
+
+def test_findings_are_ordered_by_length_then_cycle():
+    """Display order is canonical, not DFS discovery order within a length."""
+    analyzer = CircularDependencyAnalyzer()
+    for module in _TRIANGLE_MODULES:
+        analyzer.modules[module] = f"/project/{module}.py"
+    for frm, to in _TRIANGLE_EDGES:
+        analyzer.dependencies[frm].add(to)
+    assert [cd.cycle for cd in analyzer.analyze()] == [
+        ["a", "b"],
+        ["a", "c"],
+        ["b", "c"],
+        ["a", "b", "c"],
+    ]
+
+
+_HASH_SEED_PROBE = """
+import json
+from skylos.analysis.circular_deps import CircularDependencyAnalyzer
+edges = {edges!r}
+modules = {modules!r}
+analyzer = CircularDependencyAnalyzer()
+for module in modules:
+    analyzer.modules[module] = f"/project/{{module}}.py"
+for frm, to in edges:
+    analyzer.dependencies[frm].add(to)
+print(json.dumps([cd.to_dict() for cd in analyzer.analyze()]))
+"""
+
+
+@pytest.mark.parametrize("hash_seed", ["0", "1", "2", "6"])
+def test_set_backed_findings_are_identical_across_hash_seeds(hash_seed):
+    """End to end through the real set-backed graph under contrasting seeds.
+
+    Seeds 0 and 6 used to yield five cycles while 1 and 2 yielded four.
+    """
+    env = dict(os.environ, PYTHONHASHSEED=hash_seed)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part
+        for part in (str(Path(__file__).resolve().parents[1]), env.get("PYTHONPATH"))
+        if part
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _HASH_SEED_PROBE.format(
+                edges=list(_ORDER_SENSITIVE_EDGES),
+                modules=list(reversed(_ORDER_SENSITIVE_MODULES)),
+            ),
+        ],
+        capture_output=True,
+        check=True,
+        env=env,
+        text=True,
+        timeout=60,
+    )
+    findings = json.loads(completed.stdout)
+    assert [finding["cycle"] for finding in findings] == _ORDER_SENSITIVE_CYCLES
+    assert [finding["severity"] for finding in findings] == [
+        "LOW",
+        "LOW",
+        "MEDIUM",
+        "MEDIUM",
+        "HIGH",
+    ]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-
-
-def test_cycle_findings_do_not_depend_on_edge_or_module_insertion_order():
-    """Regression: cycle selection used to follow set/dict iteration order.
-
-    alpha -> beta, gamma; beta -> alpha, gamma; gamma -> alpha, delta;
-    delta -> alpha has five elementary cycles, and the pruned DFS reported
-    four or five of them depending on PYTHONHASHSEED.
-    """
-    edges = [
-        ("alpha", "beta"),
-        ("alpha", "gamma"),
-        ("beta", "alpha"),
-        ("beta", "gamma"),
-        ("gamma", "alpha"),
-        ("gamma", "delta"),
-        ("delta", "alpha"),
-    ]
-    modules = ["alpha", "beta", "gamma", "delta"]
-
-    def findings_for(edge_order, module_order):
-        analyzer = CircularDependencyAnalyzer()
-        for module in module_order:
-            analyzer.modules[module] = f"/project/{module}.py"
-        for frm, to in edge_order:
-            analyzer.dependencies[frm].add(to)
-        return [cd.to_dict() for cd in analyzer.analyze()]
-
-    baseline = findings_for(edges, modules)
-    assert [f["cycle"] for f in baseline] == [
-        ["alpha", "beta"],
-        ["alpha", "gamma"],
-        ["alpha", "beta", "gamma"],
-        ["alpha", "gamma", "delta"],
-        ["alpha", "beta", "gamma", "delta"],
-    ]
-    for module_order in itertools.permutations(modules):
-        assert findings_for(reversed(edges), module_order) == baseline

--- a/test/test_circular_deps.py
+++ b/test/test_circular_deps.py
@@ -1,4 +1,5 @@
 import ast
+import itertools
 import pytest
 from skylos.analysis import circular_deps
 from skylos.analysis.architecture import get_architecture_findings
@@ -755,3 +756,41 @@ except ImportError:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_cycle_findings_do_not_depend_on_edge_or_module_insertion_order():
+    """Regression: cycle selection used to follow set/dict iteration order.
+
+    alpha -> beta, gamma; beta -> alpha, gamma; gamma -> alpha, delta;
+    delta -> alpha has five elementary cycles, and the pruned DFS reported
+    four or five of them depending on PYTHONHASHSEED.
+    """
+    edges = [
+        ("alpha", "beta"),
+        ("alpha", "gamma"),
+        ("beta", "alpha"),
+        ("beta", "gamma"),
+        ("gamma", "alpha"),
+        ("gamma", "delta"),
+        ("delta", "alpha"),
+    ]
+    modules = ["alpha", "beta", "gamma", "delta"]
+
+    def findings_for(edge_order, module_order):
+        analyzer = CircularDependencyAnalyzer()
+        for module in module_order:
+            analyzer.modules[module] = f"/project/{module}.py"
+        for frm, to in edge_order:
+            analyzer.dependencies[frm].add(to)
+        return [cd.to_dict() for cd in analyzer.analyze()]
+
+    baseline = findings_for(edges, modules)
+    assert [f["cycle"] for f in baseline] == [
+        ["alpha", "beta"],
+        ["alpha", "gamma"],
+        ["alpha", "beta", "gamma"],
+        ["alpha", "gamma", "delta"],
+        ["alpha", "beta", "gamma", "delta"],
+    ]
+    for module_order in itertools.permutations(modules):
+        assert findings_for(reversed(edges), module_order) == baseline

--- a/test/test_fast_parity.py
+++ b/test/test_fast_parity.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import ast
+import itertools
 import os
 import json
+import random
 import subprocess
 import sys
 import textwrap
@@ -356,8 +358,6 @@ class TestCycleDetectionParity:
     def test_native_result_is_independent_of_input_order(self, name, edges, modules):
         """Exact equality: the native finder sorts internally, so shuffling the
         edge and module lists must not change the cycles or their order."""
-        import random
-
         reference = find_cycles(sorted(edges), sorted(modules))
         rng = random.Random(0)
         for _ in range(20):
@@ -366,10 +366,12 @@ class TestCycleDetectionParity:
             rng.shuffle(shuffled_edges)
             rng.shuffle(shuffled_modules)
             assert find_cycles(shuffled_edges, shuffled_modules) == reference, (
-                shuffled_edges,
-                shuffled_modules,
+                f"Order-dependent native result in '{name}': "
+                f"edges={shuffled_edges} modules={shuffled_modules}"
             )
-        assert _py_find_cycles(edges, modules) == reference
+        assert _py_find_cycles(edges, modules) == reference, (
+            f"Python/native drift in '{name}'"
+        )
 
     ORDER_CASES = (
         (
@@ -406,13 +408,15 @@ class TestCycleDetectionParity:
     def test_native_order_independence_on_order_sensitive_graphs(
         self, name, edges, modules, expected_count
     ):
-        import itertools
-
         reference = find_cycles(edges, modules)
-        assert len(reference) == expected_count
+        assert len(reference) == expected_count, f"{name}: {reference}"
         for module_order in itertools.permutations(modules):
-            assert find_cycles(list(reversed(edges)), list(module_order)) == reference
-        assert _py_find_cycles(edges, modules) == reference
+            assert (
+                find_cycles(list(reversed(edges)), list(module_order)) == reference
+            ), f"Root-order-dependent native result in '{name}': {module_order}"
+        assert _py_find_cycles(edges, modules) == reference, (
+            f"Python/native drift in '{name}'"
+        )
 
 
 class TestCouplingParity:

--- a/test/test_fast_parity.py
+++ b/test/test_fast_parity.py
@@ -352,6 +352,68 @@ class TestCycleDetectionParity:
                     f"Python cycle not normalized: {cycle} (min={min(cycle)})"
                 )
 
+    @pytest.mark.parametrize("name,edges,modules", CASES, ids=[c[0] for c in CASES])
+    def test_native_result_is_independent_of_input_order(self, name, edges, modules):
+        """Exact equality: the native finder sorts internally, so shuffling the
+        edge and module lists must not change the cycles or their order."""
+        import random
+
+        reference = find_cycles(sorted(edges), sorted(modules))
+        rng = random.Random(0)
+        for _ in range(20):
+            shuffled_edges = list(edges)
+            shuffled_modules = list(modules)
+            rng.shuffle(shuffled_edges)
+            rng.shuffle(shuffled_modules)
+            assert find_cycles(shuffled_edges, shuffled_modules) == reference, (
+                shuffled_edges,
+                shuffled_modules,
+            )
+        assert _py_find_cycles(edges, modules) == reference
+
+    ORDER_CASES = (
+        (
+            # The graph from the hash-seed reproduction: the pruned DFS reports
+            # four or five of its five cycles depending on neighbor order.
+            "pruning-sensitive",
+            [
+                ("alpha", "beta"),
+                ("alpha", "gamma"),
+                ("beta", "alpha"),
+                ("beta", "gamma"),
+                ("gamma", "alpha"),
+                ("gamma", "delta"),
+                ("delta", "alpha"),
+            ],
+            ["alpha", "beta", "gamma", "delta"],
+            5,
+        ),
+        (
+            # Two 3-cycles over one node set; which orientation survives dedup
+            # depends on root order unless roots are sorted.
+            "bidirectional-triangle",
+            [("a", "b"), ("b", "a"), ("b", "c"), ("c", "b"), ("a", "c"), ("c", "a")],
+            ["a", "b", "c"],
+            4,
+        ),
+    )
+
+    @pytest.mark.parametrize(
+        "name,edges,modules,expected_count",
+        ORDER_CASES,
+        ids=[c[0] for c in ORDER_CASES],
+    )
+    def test_native_order_independence_on_order_sensitive_graphs(
+        self, name, edges, modules, expected_count
+    ):
+        import itertools
+
+        reference = find_cycles(edges, modules)
+        assert len(reference) == expected_count
+        for module_order in itertools.permutations(modules):
+            assert find_cycles(list(reversed(edges)), list(module_order)) == reference
+        assert _py_find_cycles(edges, modules) == reference
+
 
 class TestCouplingParity:
     SYNTHETIC_SOURCES = {


### PR DESCRIPTION
Closes #837

## Summary

-  Iterate neighbors and roots in sorted order:

   - `_find_cycles_py`: `sorted(...)` on neighbors and roots. 
   - `_find_cycles_fast`: hand the native finder sorted edges and modules.
   -  `rust/src/cycles.rs`: mirror changes so parity tests in `test/test_fast_parity.py` pass.

- sort findings by (len(cycle), cycle) so display order is canonical too.
- I verified `liveness_primer` results are deterministic with this fix, so it will un-block adding SKY-CIRC to `liveness_primer`


Not changed: this does not enumerate all elementary cycles (exponential on dense import SCCs), and it keeps the existing dedup by node set.

Should not have a merge conflict with #834 despite touching the same files, and so could be merged in either order.

## Verification

- Reproduction script before: 4 or 5 cycles depending on seed. After: 24 unseeded runs and seeds 0 through 7 all report the same 5 cycles.
- `ruff check` finding count and `ruff format --check` unchanged from `main` for the touched files.

## AI Use Disclosure
Fixes drafted by Claude Fable 5.1, and reviewed per skylos llm repository review guidelines by Codex GPT-5.6 Sol and Claude Opus 5.0. I reviewed the changes myself, and verified they create the expected deterministic output. 