### PR TITLE
feat(deadcode): detect unreachable nested python functions and closures

### DIFF
--- a/docs/repo-map/index.html
+++ b/docs/repo-map/index.html
@@ -38,8 +38,8 @@
       <h2>Repo Snapshot</h2>
       <p class="lede">Use the route cards first. The folder and symbol sections are there when you need detail.</p>
       <div class="meta-grid">
-        <div class="metric"><strong>1095</strong><span>Python files scanned</span></div>
-        <div class="metric"><strong>12568</strong><span>top-level classes/functions</span></div>
+        <div class="metric"><strong>1098</strong><span>Python files scanned</span></div>
+        <div class="metric"><strong>12590</strong><span>top-level classes/functions</span></div>
         <div class="metric"><strong>33</strong><span>ownership areas</span></div>
         <div class="metric"><strong>12</strong><span>guided routes</span></div>
       </div>
@@ -1263,12 +1263,12 @@
     </article>
 
 
-    <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/evidence.py skylos/deadcode/liveness.py skylos/deadcode/browser_refs.py skylos/deadcode/plugin_registry.py skylos/deadcode/java_fxml_refs.py skylos/deadcode/config_entrypoints.py skylos/deadcode/reachability.py skylos/deadcode/_reachability_bindings.py">
+    <article class="folder-card searchable" data-search="skylos/deadcode dead-code specific analysis, framework liveness, and evidence support. change this for dead-code false positives, framework awareness, and reachability fixes. skylos/deadcode/evidence.py test/test_dead_code.py test/test_dead_code_benchmark.py test/test_dead_code_evidence.py test/test_dead_code_liveness.py test/test_demo_deadcode_benchmark.py skylos/deadcode/evidence.py skylos/deadcode/liveness.py skylos/deadcode/browser_refs.py skylos/deadcode/plugin_registry.py skylos/deadcode/java_fxml_refs.py skylos/deadcode/config_entrypoints.py skylos/deadcode/_reachability_bindings.py skylos/deadcode/reachability.py">
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode" rel="noopener noreferrer">skylos/deadcode</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 18</span>
-          <span class="pill"><strong>symbols</strong> 237</span>
+          <span class="pill"><strong>files</strong> 19</span>
+          <span class="pill"><strong>symbols</strong> 240</span>
         </div>
       </div>
       <p>Dead-code specific analysis, framework liveness, and evidence support.</p>
@@ -1288,8 +1288,8 @@
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/plugin_registry.py" rel="noopener noreferrer">skylos/deadcode/plugin_registry.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/java_fxml_refs.py" rel="noopener noreferrer">skylos/deadcode/java_fxml_refs.py</a></li>
 <li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/config_entrypoints.py" rel="noopener noreferrer">skylos/deadcode/config_entrypoints.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/reachability.py" rel="noopener noreferrer">skylos/deadcode/reachability.py</a></li>
-<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/_reachability_bindings.py" rel="noopener noreferrer">skylos/deadcode/_reachability_bindings.py</a></li></ul>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/_reachability_bindings.py" rel="noopener noreferrer">skylos/deadcode/_reachability_bindings.py</a></li>
+<li><a href="https://github.com/duriantaco/skylos/blob/main/skylos/deadcode/reachability.py" rel="noopener noreferrer">skylos/deadcode/reachability.py</a></li></ul>
       </div>
       <div>
         <div class="mini-label">Key symbols</div>
@@ -2049,8 +2049,8 @@
       <div class="card-head">
         <h3><a href="https://github.com/duriantaco/skylos/blob/main/test" rel="noopener noreferrer">test</a></h3>
         <div class="stat-row">
-          <span class="pill"><strong>files</strong> 311</span>
-          <span class="pill"><strong>symbols</strong> 5409</span>
+          <span class="pill"><strong>files</strong> 313</span>
+          <span class="pill"><strong>symbols</strong> 5428</span>
         </div>
       </div>
       <p>Unit and regression tests covering CLI, analyzer, rules, integrations, and benchmarks.</p>

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -2030,7 +2030,7 @@ class Skylos:
         self._python_reachability_report = report
         self._apply_python_reachability(report)
 
-    def _retain_receiver_uncertainty(self, report):
+    def _retain_reachability_uncertainty(self, report):
         for key in report.protected_keys:
             defn = self.defs.get(key)
             if defn is not None and defn.references <= 0:
@@ -2038,9 +2038,14 @@ class Skylos:
                 # that this callable has an actual reachable invocation.
                 defn.references = 1
                 defn.heuristic_refs["unresolved_receiver"] = 1.0
+        for key in report.protected_callback_keys:
+            defn = self.defs.get(key)
+            if defn is not None and defn.references <= 0:
+                defn.references = 1
+                defn.heuristic_refs["unresolved_callback"] = 1.0
 
     def _apply_python_reachability(self, report):
-        self._retain_receiver_uncertainty(report)
+        self._retain_reachability_uncertainty(report)
         for key in report.proven_reachable_keys:
             defn = self.defs.get(key)
             if defn is not None and defn.references <= 0:
@@ -2070,7 +2075,7 @@ class Skylos:
             key for key in previously_unreachable if self.defs[key].references > 0
         }
         report.refresh(self.defs, additional_roots=revived_roots)
-        self._retain_receiver_uncertainty(report)
+        self._retain_reachability_uncertainty(report)
         # An external callback or a later grep rescue may establish a real
         # caller. Its callees must be restored in this same scan.
         for key in previously_unreachable - report.unreachable_keys:

--- a/skylos/deadcode/_reachability_bindings.py
+++ b/skylos/deadcode/_reachability_bindings.py
@@ -16,6 +16,41 @@ MODULE_BINDING = "module"
 QUALIFIED_BINDING = "qualified"
 
 
+def namespace_name(class_name: str, name: str) -> str:
+    prefix = class_name.lstrip("_")
+    if prefix and name.startswith("__") and not name.endswith("__"):
+        return f"_{prefix}{name}"
+    return name
+
+
+class ScopeBindings(dict):
+    """Bindings in a lexical scope, including Python's class-name mangling."""
+
+    def __init__(self, values=(), *, class_name: str = "") -> None:
+        super().__init__()
+        self.class_name = class_name
+        self.update(values)
+
+    def __contains__(self, name):
+        return super().__contains__(namespace_name(self.class_name, name))
+
+    def __getitem__(self, name):
+        return super().__getitem__(namespace_name(self.class_name, name))
+
+    def __setitem__(self, name, value):
+        super().__setitem__(namespace_name(self.class_name, name), value)
+
+    def get(self, name, default=None):
+        return super().get(namespace_name(self.class_name, name), default)
+
+    def update(self, values):
+        for name, value in dict(values).items():
+            self[name] = value
+
+    def copy(self):
+        return ScopeBindings(self, class_name=self.class_name)
+
+
 @dataclass
 class ModuleInfo:
     path: Path
@@ -34,16 +69,31 @@ class BoundNames(ast.NodeVisitor):
         if isinstance(node.ctx, (ast.Store, ast.Del)):
             self.counts[node.id] += 1
 
-    def visit_FunctionDef(self, node: FunctionNode | ast.ClassDef) -> None:
+    def visit_FunctionDef(self, node: FunctionNode) -> None:
         self.counts[node.name] += 1
+        for expression in [
+            *node.decorator_list,
+            *default_expressions(node.args),
+            *(arg.annotation for arg in argument_nodes(node.args) if arg.annotation),
+            *([node.returns] if node.returns else []),
+        ]:
+            self.visit(expression)
 
     visit_AsyncFunctionDef = visit_FunctionDef
-    visit_ClassDef = visit_FunctionDef
 
-    def visit(self, node: ast.AST) -> None:
-        """Skip lambda bodies, whose assignments have a separate scope."""
-        if not isinstance(node, ast.Lambda):
-            super().visit(node)
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.counts[node.name] += 1
+        for expression in [
+            *node.decorator_list,
+            *node.bases,
+            *(keyword.value for keyword in node.keywords),
+        ]:
+            self.visit(expression)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        # Defaults execute here; assignments in the deferred body do not.
+        for expression in default_expressions(node.args):
+            self.visit(expression)
 
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
@@ -77,10 +127,15 @@ class BoundNames(ast.NodeVisitor):
         self.generic_visit(node)
 
 
-def bound_names(nodes: Iterable[ast.AST]) -> BoundNames:
+def bound_names(nodes: Iterable[ast.AST], *, class_name: str = "") -> BoundNames:
     collector = BoundNames()
     for node in nodes:
         collector.visit(node)
+    if class_name:
+        counts: Counter[str] = Counter()
+        for name, count in collector.counts.items():
+            counts[namespace_name(class_name, name)] += count
+        collector.counts = counts
     return collector
 
 
@@ -140,13 +195,21 @@ def default_expressions(arguments: ast.arguments) -> list[ast.expr]:
     ]
 
 
-def function_bindings(node: FunctionNode, module: ModuleInfo) -> tuple[Bindings, bool]:
-    names = bound_names(node.body)
-    parameters = {arg.arg for arg in argument_nodes(node.args)}
-    local: Bindings = dict.fromkeys(names.counts.keys() | parameters)
+def function_bindings(
+    node: FunctionNode, module: ModuleInfo, *, class_name: str = ""
+) -> tuple[Bindings, bool]:
+    names = bound_names(node.body, class_name=class_name)
+    parameters = {
+        namespace_name(class_name, arg.arg) for arg in argument_nodes(node.args)
+    }
+    local = ScopeBindings(
+        dict.fromkeys(names.counts.keys() | parameters), class_name=class_name
+    )
     for statement in node.body:
         if isinstance(statement, (ast.Import, ast.ImportFrom)):
-            local.update(_stable_imports(statement, module, names.counts, parameters))
+            local.update(
+                _stable_imports(statement, module, names.counts, parameters, class_name)
+            )
     return local, names.scope_writes
 
 
@@ -155,9 +218,11 @@ def _stable_imports(
     module: ModuleInfo,
     counts: Counter[str],
     parameters: set[str],
+    class_name: str = "",
 ) -> Bindings:
     return {
         name: value
         for name, value in import_bindings(statement, module).items()
-        if counts[name] == 1 and name not in parameters
+        if counts[namespace_name(class_name, name)] == 1
+        and namespace_name(class_name, name) not in parameters
     }

--- a/skylos/deadcode/_reachability_graph.py
+++ b/skylos/deadcode/_reachability_graph.py
@@ -14,7 +14,9 @@ from skylos.deadcode._reachability_bindings import (
     QUALIFIED_BINDING,
     Binding,
     Bindings,
+    FunctionNode,
     ModuleInfo,
+    namespace_name,
 )
 from skylos.deadcode._reachability_receivers import (
     CLASS_BINDING,
@@ -51,6 +53,24 @@ class SourceIndex:
     classes: dict[str, ClassInfo] = field(default_factory=dict)
     class_locations: dict[tuple[Path, int], str] = field(default_factory=dict)
     method_classes: dict[str, str] = field(default_factory=dict)
+    nested_parents: dict[str, str] = field(default_factory=dict)
+    uncertain_nested_keys: set[str] = field(default_factory=set)
+    scope_classes: dict[str, str] = field(default_factory=dict)
+    local_functions: dict[str, Bindings] = field(
+        default_factory=lambda: defaultdict(dict)
+    )
+
+    def add_function(
+        self, module: ModuleInfo, node: FunctionNode, key: str, definition: Definition
+    ) -> None:
+        self.candidates[key] = definition
+        self.by_location[module.path, node.lineno] = key
+        self.by_name[definition.name].append(key)
+        self.by_simple_name[definition.simple_name].add(key)
+        self.initial_references[key] = max(
+            0, definition.references - getattr(definition, "_attr_name_ref_count", 0)
+        )
+        module.functions[node.lineno] = key
 
     def qualified(self, name: str, seen: tuple[str, ...] = ()) -> Binding | None:
         if name in seen or len(seen) >= 24:
@@ -90,18 +110,22 @@ class SourceIndex:
         self, node: ast.AST, module: ModuleInfo, local: Bindings
     ) -> Binding | None:
         binding = None
+        class_name = getattr(local, "class_name", "")
         if isinstance(node, ast.Name):
             binding = (
-                local.get(node.id) if node.id in local else module.bindings.get(node.id)
+                local.get(node.id)
+                if node.id in local
+                else module.bindings.get(namespace_name(class_name, node.id))
             )
             if binding and binding[0] == QUALIFIED_BINDING:
                 binding = self.qualified(binding[1])
         elif isinstance(node, ast.Attribute):
             base = self.resolve(node.value, module, local)
+            name = namespace_name(class_name, node.attr)
             if base and base[0] == MODULE_BINDING:
-                binding = self.qualified(f"{base[1]}.{node.attr}")
+                binding = self.qualified(f"{base[1]}.{name}")
             else:
-                binding = self.receiver_member(base, node.attr)
+                binding = self.receiver_member(base, name)
                 if base and base[0] == INSTANCE_BINDING and node.attr == "__class__":
                     binding = (CLASS_BINDING, base[1])
         elif isinstance(node, ast.Call):

--- a/skylos/deadcode/_reachability_receivers.py
+++ b/skylos/deadcode/_reachability_receivers.py
@@ -16,9 +16,11 @@ from skylos.deadcode._reachability_bindings import (
     FUNCTION_NODES,
     Bindings,
     ModuleInfo,
+    ScopeBindings,
     argument_nodes,
     bound_names,
     function_bindings,
+    namespace_name as _namespace_name,
 )
 
 if TYPE_CHECKING:
@@ -36,13 +38,6 @@ class ClassInfo:
     node: ast.ClassDef
     module: ModuleInfo
     methods: dict[str, str]
-
-
-def _namespace_name(class_name: str, member_name: str) -> str:
-    prefix = class_name.lstrip("_")
-    if prefix and member_name.startswith("__") and not member_name.endswith("__"):
-        return f"_{prefix}{member_name}"
-    return member_name
 
 
 def _plain_class(node: ast.ClassDef) -> bool:
@@ -140,9 +135,10 @@ def stable_receivers(
     A branch, loop, unpacking or reassignment cannot establish a receiver.
     Unknown RHS values are not filled in using annotations or naming rules.
     """
-    counts = bound_names(statements).counts
+    class_name = getattr(local, "class_name", "")
+    counts = bound_names(statements, class_name=class_name).counts
     protected = parameters or set()
-    result = dict(local)
+    result = local.copy()
     for statement in statements:
         if isinstance(statement, ast.Assign):
             targets, value = statement.targets, statement.value
@@ -156,24 +152,36 @@ def stable_receivers(
         for target in targets:
             if (
                 isinstance(target, ast.Name)
-                and counts[target.id] == 1
-                and target.id not in protected
+                and counts[_namespace_name(class_name, target.id)] == 1
+                and _namespace_name(class_name, target.id) not in protected
             ):
                 result[target.id] = binding
     return result
 
 
 def function_receivers(
-    index: SourceIndex, module: ModuleInfo, node: Any
+    index: SourceIndex, module: ModuleInfo, node: Any, enclosing: Bindings | None = None
 ) -> tuple[Bindings, bool]:
-    local, writes = function_bindings(node, module)
-    parameters = {arg.arg for arg in argument_nodes(node.args)}
     key = module.functions.get(node.lineno)
     class_key = index.method_classes.get(key)
+    class_name = index.scope_classes.get(key, getattr(enclosing, "class_name", ""))
+    bindings, writes = function_bindings(node, module, class_name=class_name)
+    local = ScopeBindings(
+        enclosing if enclosing is not None and class_key is None else {},
+        class_name=class_name,
+    )
+    local.update(bindings)
+    local.update(index.local_functions.get(key, {}))
+    parameters = {
+        _namespace_name(class_name, arg.arg) for arg in argument_nodes(node.args)
+    }
     positional = [*node.args.posonlyargs, *node.args.args]
     if class_key and positional:
         receiver = positional[0].arg
-        if receiver not in bound_names(node.body).counts:
+        if (
+            _namespace_name(class_name, receiver)
+            not in bound_names(node.body, class_name=class_name).counts
+        ):
             local[receiver] = (INSTANCE_BINDING, class_key)
     if not writes:
         local = stable_receivers(index, module, node.body, local, parameters=parameters)

--- a/skylos/deadcode/_reachability_scopes.py
+++ b/skylos/deadcode/_reachability_scopes.py
@@ -1,0 +1,62 @@
+"""Source identities and lexical parents for stable named nested functions."""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+
+from skylos.deadcode._reachability_bindings import (
+    FUNCTION_NODES,
+    argument_nodes,
+    bound_names,
+    namespace_name,
+)
+
+if TYPE_CHECKING:
+    from skylos.deadcode._reachability_graph import SourceIndex
+
+
+def bind_nested_functions(index: SourceIndex, locations: dict) -> None:
+    for module in index.modules.values():
+        # ast.walk visits parents before children. Unsupported parents never
+        # acquire local bindings or turn their descendants into negative proofs.
+        for node in ast.walk(module.tree):
+            if not isinstance(node, FUNCTION_NODES):
+                continue
+            owner = module.functions.get(node.lineno)
+            if owner is None:
+                continue
+            _bind_scope(index, module, node, owner, locations)
+
+
+def _bind_scope(index, module, node, owner, locations) -> None:
+    class_key = index.method_classes.get(owner)
+    class_name = (
+        index.classes[class_key].node.name
+        if class_key is not None
+        else index.scope_classes.get(owner, "")
+    )
+    index.scope_classes[owner] = class_name
+    names = bound_names(node.body, class_name=class_name)
+    if names.scope_writes:
+        return
+    parameters = {
+        namespace_name(class_name, arg.arg) for arg in argument_nodes(node.args)
+    }
+    for child in node.body:
+        if not isinstance(child, FUNCTION_NODES) or getattr(child, "type_params", ()):
+            continue
+        matches = locations.get((module.path, child.lineno, child.name), ())
+        if len(matches) != 1:
+            continue
+        key, definition = matches[0]
+        name = namespace_name(class_name, child.name)
+        index.add_function(module, child, key, definition)
+        index.nested_parents[key] = owner
+        index.scope_classes[key] = class_name
+        if names.counts[name] == 1 and name not in parameters:
+            index.local_functions[owner][name] = ("symbol", key)
+        else:
+            # Rebinding and private-name collisions cannot justify deletion.
+            # Keep the declarations without choosing a lexical value for them.
+            index.uncertain_nested_keys.add(key)

--- a/skylos/deadcode/_reachability_visitor.py
+++ b/skylos/deadcode/_reachability_visitor.py
@@ -9,10 +9,12 @@ from skylos.deadcode._reachability_bindings import (
     Bindings,
     FunctionNode,
     ModuleInfo,
+    ScopeBindings,
     argument_nodes,
     bound_names,
     default_expressions,
     import_bindings,
+    namespace_name,
 )
 from skylos.deadcode._reachability_receivers import (
     CLASS_BINDING,
@@ -148,9 +150,12 @@ class SourceVisitor(ast.NodeVisitor):
         # module object to unknown code. A standalone module value does.
         base = self.index.resolve(node.value, self.module, self.local)
         if base and base[0] in RECEIVER_BINDINGS:
+            member_name = namespace_name(
+                getattr(self.local, "class_name", ""), node.attr
+            )
             if not isinstance(node.ctx, ast.Load) and (
                 base[0] == CLASS_BINDING
-                or node.attr in self.index.classes[base[1]].methods
+                or member_name in self.index.classes[base[1]].methods
                 or node.attr in {"__class__", "__dict__"}
             ):
                 self._protect_binding(base, retain_class=True)
@@ -338,12 +343,13 @@ class SourceVisitor(ast.NodeVisitor):
         previous = self.owner, self.local, self.proven_context
         self.owner = self.module.functions.get(node.lineno)
         self.proven_context = self.owner is not None
-        bindings, scope_writes = function_receivers(self.index, self.module, node)
-        # Methods use module globals, not their class's execution namespace.
-        self.local = (
-            bindings
-            if self.owner in self.index.method_classes
-            else {**self.local, **bindings}
+        if self.owner in self.index.nested_parents and node.decorator_list:
+            parent = self.index.nested_parents[self.owner]
+            self.graph.protect([self.owner], parent)
+        # Captures are resolved before local receiver aliases; actual methods
+        # discard the class execution namespace inside function_receivers.
+        self.local, scope_writes = function_receivers(
+            self.index, self.module, node, self.local
         )
         if scope_writes:
             self._opaque()
@@ -387,9 +393,9 @@ class SourceVisitor(ast.NodeVisitor):
         previous = self.owner, self.local, self.proven_context
         self.owner = None
         self.proven_context = False
-        self.local = {
-            **self.local,
-            **dict.fromkeys(arg.arg for arg in argument_nodes(node.args)),
-        }
+        self.local = ScopeBindings(
+            self.local, class_name=getattr(self.local, "class_name", "")
+        )
+        self.local.update(dict.fromkeys(arg.arg for arg in argument_nodes(node.args)))
         self.visit(node.body)
         self.owner, self.local, self.proven_context = previous

--- a/skylos/deadcode/reachability.py
+++ b/skylos/deadcode/reachability.py
@@ -27,6 +27,7 @@ from skylos.deadcode._reachability_graph import (
 )
 from skylos.deadcode._reachability_visitor import SourceVisitor
 from skylos.deadcode._reachability_receivers import bind_classes, stable_receivers
+from skylos.deadcode._reachability_scopes import bind_nested_functions
 from skylos.deadcode.python_ast import ParsedPythonFile, parse_python_files
 
 if TYPE_CHECKING:
@@ -82,6 +83,7 @@ class PythonReachabilityReport:
         self.reachable_keys: set[str] = set()
         self.proven_reachable_keys: set[str] = set()
         self.protected_keys: set[str] = set()
+        self.protected_callback_keys: set[str] = set()
         self.reasons: dict[str, str] = {}
         self._definitions = definitions
         self.index = SourceIndex()
@@ -114,6 +116,16 @@ class PythonReachabilityReport:
             ).intersection(candidates)
             - self.proven_reachable_keys
         )
+        # A nested callback can be used by a decorator or an unsupported
+        # deferred owner (for example a lambda) without a proven invocation.
+        callbacks = self.reachable_keys.intersection(self.index.nested_parents)
+        callbacks -= self.proven_reachable_keys
+        self.protected_callback_keys = (
+            self.graph.traverse(callbacks, candidates, uncertainty=True).intersection(
+                candidates
+            )
+            - self.proven_reachable_keys
+        )
         self.unreachable_keys = set(candidates) - reached if self.complete else set()
         self.reasons = {key: _UNREACHABLE_REASON for key in self.unreachable_keys}
         return self
@@ -136,7 +148,12 @@ class PythonReachabilityReport:
         definition: Definition,
         markers: Mapping[str, float],
     ) -> bool:
-        external = any(getattr(definition, attr, False) for attr in _EXTERNAL_EVIDENCE)
+        external = any(
+            getattr(definition, attr, False)
+            for attr in _EXTERNAL_EVIDENCE
+            if key not in self.index.nested_parents
+            or attr not in {"is_closure", "decorators"}
+        )
         class_key = self.index.method_classes.get(key)
         if class_key is not None:
             owning_class = self.index.classes[class_key].definition
@@ -147,7 +164,12 @@ class PythonReachabilityReport:
                 "__"
             ) and definition.simple_name.endswith("__")
         callback = any(name.startswith("dead_code_liveness:") for name in markers)
-        return external or callback or self._unaccounted_reference(key, definition)
+        return (
+            external
+            or callback
+            or key in self.index.uncertain_nested_keys
+            or self._unaccounted_reference(key, definition)
+        )
 
     def _unaccounted_reference(self, key: str, definition: Definition) -> bool:
         references = max(
@@ -302,7 +324,7 @@ def _definition_locations(
 ) -> DefinitionLocations:
     indexed: DefinitionLocations = defaultdict(list)
     for key, definition in definitions.items():
-        if getattr(definition, "type", "") != "function":
+        if getattr(definition, "type", "") not in {"function", "method"}:
             continue
         try:
             file = _path(definition.filename, root)
@@ -324,12 +346,7 @@ def _bind_function(
         return
     key, definition = matches[0]
     index = report.index
-    index.candidates[key] = definition
-    index.by_location[module.path, node.lineno] = key
-    index.by_name[definition.name].append(key)
-    index.by_simple_name[definition.simple_name].add(key)
-    index.initial_references[key] = _source_reference_count(definition)
-    module.functions[node.lineno] = key
+    index.add_function(module, node, key, definition)
     module.bindings[node.name] = ("symbol", key)
     if node.decorator_list or node.name in {"__getattr__", "__dir__"}:
         report.graph.uncertain_roots.add(key)
@@ -397,6 +414,7 @@ def analyze_python_reachability(
     for module in report.index.modules.values():
         _bind_module(report, module, locations)
     bind_classes(report.index, definitions)
+    bind_nested_functions(report.index, locations)
     for module in report.index.modules.values():
         module.bindings = stable_receivers(
             report.index, module, module.tree.body, module.bindings

--- a/test/test_closure_reachability.py
+++ b/test/test_closure_reachability.py
@@ -1,0 +1,579 @@
+"""Frozen closure acceptance cases; fixture modules are parsed, never executed."""
+
+import json
+import textwrap
+
+import pytest
+
+from skylos.analyzer import analyze
+from skylos.core.safe_cache_io import write_text_no_symlink
+
+
+def _write(root, name, source):
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    assert write_text_no_symlink(path, textwrap.dedent(source).lstrip())
+    return path
+
+
+def _unused(root, source, *, grep_verify=True):
+    _write(root, "worker.py", source)
+    result = json.loads(
+        analyze(str(root.resolve()), trace_file=False, grep_verify=grep_verify)
+    )
+    assert not result.get("analysis_errors")
+    return {item["full_name"] for item in result.get("unused_functions", [])}
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("activation", ["none", "outer", "inner"])
+def test_creating_a_nested_function_does_not_execute_its_body(
+    tmp_path, grep_verify, activation
+):
+    source = """
+        def finish_packet():
+            return 17
+
+        def arrange_packet():
+            def process_packet():
+                return finish_packet()
+            PLACEHOLDER
+    """
+    source = source.replace(
+        "PLACEHOLDER",
+        "return process_packet()" if activation == "inner" else "return 0",
+    )
+    if activation != "none":
+        source = textwrap.dedent(source) + "\narrange_packet()\n"
+
+    unused = _unused(tmp_path, source, grep_verify=grep_verify)
+    targets = {
+        "worker.finish_packet",
+        "worker.arrange_packet",
+        "worker.arrange_packet.process_packet",
+    }
+    expected = targets if activation == "none" else targets - {"worker.arrange_packet"}
+    if activation == "inner":
+        expected = set()
+    assert unused & targets == expected
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("live", [False, True])
+def test_returned_callback_only_protects_its_body_when_factory_is_live(
+    tmp_path, grep_verify, live
+):
+    source = textwrap.dedent("""
+        def finish_packet():
+            return 17
+
+        def arrange_packet():
+            def process_packet():
+                return finish_packet()
+            return process_packet
+    """)
+    if live:
+        source += "callback = arrange_packet()\ncallback()\n"
+
+    unused = _unused(tmp_path, source, grep_verify=grep_verify)
+    targets = {
+        "worker.finish_packet",
+        "worker.arrange_packet",
+        "worker.arrange_packet.process_packet",
+    }
+    assert unused & targets == (set() if live else targets)
+
+
+@pytest.mark.parametrize(
+    "use",
+    [
+        "return process_packet",
+        "register(process_packet)",
+        "registry.append(process_packet)",
+        "registry['process'] = process_packet",
+        "return {'callbacks': [process_packet]}",
+    ],
+    ids=["returned", "passed", "appended", "stored", "nested-container"],
+)
+def test_live_owner_keeps_callbacks_that_may_be_invoked_elsewhere(tmp_path, use):
+    source = """
+        from external import register, registry
+
+        def finish_packet():
+            return 17
+
+        def arrange_packet():
+            def process_packet():
+                return finish_packet()
+            PLACEHOLDER
+
+        arrange_packet()
+    """.replace("PLACEHOLDER", use)
+
+    unused = _unused(tmp_path, source)
+
+    assert not {"worker.finish_packet", "worker.arrange_packet.process_packet"} & unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("activation", ["none", "outer", "inner"])
+def test_sibling_recursive_callbacks_need_a_reachable_call(
+    tmp_path, grep_verify, activation
+):
+    source = """
+        def arrange_packet():
+            def first_phase(count):
+                return second_phase(count - 1) if count else 1
+            def second_phase(count):
+                return first_phase(count - 1) if count else 2
+            PLACEHOLDER
+    """.replace(
+        "PLACEHOLDER", "return first_phase(3)" if activation == "inner" else "return 0"
+    )
+    if activation != "none":
+        source = textwrap.dedent(source) + "\narrange_packet()\n"
+
+    unused = _unused(tmp_path, source, grep_verify=grep_verify)
+    targets = {
+        "worker.arrange_packet.first_phase",
+        "worker.arrange_packet.second_phase",
+    }
+    assert unused & targets == (set() if activation == "inner" else targets)
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_same_named_callbacks_in_separate_owners_keep_distinct_identities(
+    tmp_path, grep_verify
+):
+    unused = _unused(
+        tmp_path,
+        """
+        def north_finish():
+            return 1
+        def south_finish():
+            return 2
+
+        def north_factory():
+            def process_packet():
+                return north_finish()
+            return process_packet()
+
+        def south_factory():
+            def process_packet():
+                return south_finish()
+            return process_packet()
+
+        north_factory()
+        """,
+        grep_verify=grep_verify,
+    )
+
+    assert {
+        "worker.south_finish",
+        "worker.south_factory",
+        "worker.south_factory.process_packet",
+    } <= unused
+    assert not {"worker.north_finish", "worker.north_factory.process_packet"} & unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+def test_nested_name_shadows_module_function(tmp_path, grep_verify):
+    unused = _unused(
+        tmp_path,
+        """
+        def process_packet():
+            return 99
+
+        def arrange_packet():
+            def process_packet():
+                return 17
+            return process_packet()
+
+        arrange_packet()
+        """,
+        grep_verify=grep_verify,
+    )
+
+    assert "worker.process_packet" in unused
+    assert "worker.arrange_packet.process_packet" not in unused
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("live", [False, True])
+def test_nested_body_resolves_import_captured_from_enclosing_function(
+    tmp_path, grep_verify, live
+):
+    _write(
+        tmp_path,
+        "packet_ops.py",
+        """
+        def finish_packet():
+            return 17
+        """,
+    )
+    source = """
+        def arrange_packet():
+            import packet_ops as operations
+            def process_packet():
+                return operations.finish_packet()
+            PLACEHOLDER
+
+        arrange_packet()
+    """.replace("PLACEHOLDER", "return process_packet()" if live else "return 0")
+
+    unused = _unused(tmp_path, source, grep_verify=grep_verify)
+    targets = {"packet_ops.finish_packet", "worker.arrange_packet.process_packet"}
+    assert unused & targets == (set() if live else targets)
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize("live", [False, True])
+def test_nested_body_resolves_stable_captured_receiver(tmp_path, grep_verify, live):
+    source = """
+        class PacketCodec:
+            def encode_packet(self):
+                return 17
+
+        def arrange_packet():
+            codec = PacketCodec()
+            def process_packet():
+                return codec.encode_packet()
+            PLACEHOLDER
+
+        arrange_packet()
+    """.replace("PLACEHOLDER", "return process_packet()" if live else "return 0")
+
+    unused = _unused(tmp_path, source, grep_verify=grep_verify)
+    targets = {
+        "worker.PacketCodec.encode_packet",
+        "worker.arrange_packet.process_packet",
+    }
+    assert unused & targets == (set() if live else targets)
+
+
+@pytest.mark.parametrize("activation", ["none", "outer", "inner"])
+def test_nested_defaults_execute_with_owner_and_body_requires_callback_call(
+    tmp_path, activation
+):
+    source = """
+        def prepare_option():
+            return 17
+        def finish_packet():
+            return 19
+
+        def arrange_packet():
+            def process_packet(option=prepare_option()):
+                return finish_packet() + option
+            PLACEHOLDER
+    """.replace(
+        "PLACEHOLDER",
+        "return process_packet()" if activation == "inner" else "return 0",
+    )
+    if activation != "none":
+        source = textwrap.dedent(source) + "\narrange_packet()\n"
+
+    unused = _unused(tmp_path, source)
+
+    assert ("worker.prepare_option" in unused) == (activation == "none")
+    assert ("worker.finish_packet" in unused) == (activation != "inner")
+
+
+@pytest.mark.parametrize("live", [False, True])
+def test_decorating_callback_is_an_owner_time_use_and_can_execute_body(tmp_path, live):
+    source = textwrap.dedent("""
+        def finish_packet():
+            return 17
+
+        def arrange_packet():
+            from external import register
+            @register
+            def process_packet():
+                return finish_packet()
+            return 0
+    """)
+    if live:
+        source += "arrange_packet()\n"
+
+    unused = _unused(tmp_path, source)
+
+    # A decorator can invoke or retain the callback, but cannot run when its
+    # enclosing function is unreachable.
+    assert ("worker.finish_packet" in unused) == (not live)
+
+
+@pytest.mark.parametrize("live", [False, True])
+def test_nested_async_body_keeps_its_own_owner(tmp_path, live):
+    source = """
+        def finish_packet():
+            return 17
+
+        async def arrange_packet():
+            async def process_packet():
+                return finish_packet()
+            PLACEHOLDER
+
+        from external import run
+        run(arrange_packet())
+    """.replace("PLACEHOLDER", "return await process_packet()" if live else "return 0")
+
+    unused = _unused(tmp_path, source)
+    targets = {"worker.finish_packet", "worker.arrange_packet.process_packet"}
+    assert unused & targets == (set() if live else targets)
+
+
+@pytest.mark.parametrize("live", [False, True])
+def test_method_nested_body_can_capture_its_enclosing_receiver(tmp_path, live):
+    source = """
+        class PacketCodec:
+            def encode_packet(codec):
+                return 17
+            def arrange_packet(codec):
+                def process_packet():
+                    return codec.encode_packet()
+                PLACEHOLDER
+
+        PacketCodec().arrange_packet()
+    """.replace("PLACEHOLDER", "return process_packet()" if live else "return 0")
+
+    unused = _unused(tmp_path, source)
+    targets = {
+        "worker.PacketCodec.encode_packet",
+        "worker.PacketCodec.arrange_packet.process_packet",
+    }
+    assert unused & targets == (set() if live else targets)
+
+
+@pytest.mark.parametrize(
+    "source,protected",
+    [
+        (
+            """
+            def first_finish(): return 1
+            def second_finish(): return 2
+            def arrange_packet():
+                finish = first_finish
+                def process_packet():
+                    return finish()
+                finish = second_finish
+                return process_packet()
+            arrange_packet()
+            """,
+            {"second_finish", "arrange_packet.process_packet"},
+        ),
+        (
+            """
+            def first_finish(): return 1
+            def second_finish(): return 2
+            def arrange_packet():
+                finish = first_finish
+                def replace_finish():
+                    nonlocal finish
+                    finish = second_finish
+                def process_packet():
+                    return finish()
+                replace_finish()
+                return process_packet()
+            arrange_packet()
+            """,
+            {
+                "second_finish",
+                "arrange_packet.process_packet",
+                "arrange_packet.replace_finish",
+            },
+        ),
+        (
+            """
+            def finish_packet(): return 1
+            def arrange_packet():
+                finish_packet = None
+                def process_packet():
+                    global finish_packet
+                    return finish_packet()
+                return process_packet()
+            arrange_packet()
+            """,
+            {"finish_packet", "arrange_packet.process_packet"},
+        ),
+        (
+            """
+            from external import choose
+            def first_finish(): return 1
+            def second_finish(): return 2
+            def arrange_packet():
+                if choose():
+                    def process_packet(): return first_finish()
+                else:
+                    def process_packet(): return second_finish()
+                return process_packet()
+            arrange_packet()
+            """,
+            {"first_finish", "second_finish"},
+        ),
+        (
+            """
+            class NorthCodec:
+                def encode_packet(self): return 1
+            class SouthCodec:
+                def encode_packet(self): return 2
+            def arrange_packet():
+                codec = NorthCodec()
+                def process_packet():
+                    return codec.encode_packet()
+                codec = SouthCodec()
+                return process_packet()
+            arrange_packet()
+            """,
+            {"SouthCodec.encode_packet", "arrange_packet.process_packet"},
+        ),
+        (
+            """
+            def finish_packet(): return 1
+            def arrange_packet():
+                def process_packet():
+                    return finish_packet()
+                saved = process_packet
+                process_packet = None
+                return saved()
+            arrange_packet()
+            """,
+            {"finish_packet", "arrange_packet.process_packet"},
+        ),
+        (
+            """
+            from external import choose
+            def first_finish(): return 1
+            def second_finish(): return 2
+            def arrange_packet():
+                def process_packet():
+                    return finish()
+                finish = first_finish if choose() else second_finish
+                return process_packet()
+            arrange_packet()
+            """,
+            {"first_finish", "second_finish", "arrange_packet.process_packet"},
+        ),
+        (
+            """
+            class NorthCodec:
+                def encode_packet(self): return 1
+            class SouthCodec:
+                def encode_packet(self): return 2
+            def arrange_packet():
+                codec = NorthCodec()
+                def process_packet(value=(codec := SouthCodec())):
+                    return codec.encode_packet()
+                return process_packet()
+            arrange_packet()
+            """,
+            {"SouthCodec.encode_packet", "arrange_packet.process_packet"},
+        ),
+    ],
+    ids=[
+        "captured-callable-reassigned",
+        "nonlocal-cell-reassigned",
+        "explicit-global-skips-enclosing-local",
+        "conditional-definitions",
+        "captured-receiver-reassigned",
+        "callback-saved-before-reassignment",
+        "late-bound-conditional-capture",
+        "default-walrus-rebinds-captured-receiver",
+    ],
+)
+def test_mutable_or_conditional_bindings_keep_possible_live_targets(
+    tmp_path, source, protected
+):
+    unused = _unused(tmp_path, source)
+
+    assert not {f"worker.{name}" for name in protected} & unused
+
+
+def test_closure_inside_closure_uses_nearest_lexical_binding(tmp_path):
+    unused = _unused(
+        tmp_path,
+        """
+        def finish_packet(): return 99
+        def arrange_packet():
+            def finish_packet(): return 17
+            def middle_phase():
+                def process_packet():
+                    return finish_packet()
+                return process_packet()
+            return middle_phase()
+        arrange_packet()
+        """,
+    )
+
+    assert "worker.finish_packet" in unused
+    assert (
+        not {
+            "worker.arrange_packet.finish_packet",
+            "worker.arrange_packet.middle_phase",
+            "worker.arrange_packet.middle_phase.process_packet",
+        }
+        & unused
+    )
+
+
+@pytest.mark.parametrize("grep_verify", [False, True])
+@pytest.mark.parametrize(
+    "source,protected",
+    [
+        (
+            """
+            def finish_packet(): return 17
+            class PacketCodec:
+                def arrange_packet(codec):
+                    def __process_packet():
+                        return finish_packet()
+                    return _PacketCodec__process_packet()
+            PacketCodec().arrange_packet()
+            """,
+            {"finish_packet", "PacketCodec.arrange_packet.__process_packet"},
+        ),
+        (
+            """
+            def first_finish(): return 1
+            def second_finish(): return 2
+            class PacketCodec:
+                def arrange_packet(codec):
+                    def __process_packet():
+                        return first_finish()
+                    def _PacketCodec__process_packet():
+                        return second_finish()
+                    return __process_packet()
+            PacketCodec().arrange_packet()
+            """,
+            {
+                "second_finish",
+                "PacketCodec.arrange_packet._PacketCodec__process_packet",
+            },
+        ),
+        (
+            """
+            class NorthCodec:
+                def encode_packet(self): return 1
+            class SouthCodec:
+                def encode_packet(self): return 2
+            class PacketCodec:
+                def arrange_packet(codec):
+                    __receiver = NorthCodec()
+                    def process_packet(__receiver):
+                        return _PacketCodec__receiver.encode_packet()
+                    return process_packet(SouthCodec())
+            PacketCodec().arrange_packet()
+            """,
+            {"SouthCodec.encode_packet", "PacketCodec.arrange_packet.process_packet"},
+        ),
+    ],
+    ids=[
+        "private-local-callback",
+        "mangled-local-collision",
+        "mangled-parameter-shadow",
+    ],
+)
+def test_method_local_name_mangling_preserves_live_callbacks_and_receivers(
+    tmp_path, source, protected, grep_verify
+):
+    unused = _unused(tmp_path, source, grep_verify=grep_verify)
+
+    assert not {f"worker.{name}" for name in protected} & unused

--- a/test/test_closure_reachability_safety.py
+++ b/test/test_closure_reachability_safety.py
@@ -1,0 +1,449 @@
+"""Independent closure safety controls; fixture source is parsed, never executed."""
+
+import json
+import textwrap
+
+import pytest
+
+from skylos.analyzer import analyze
+from skylos.core.safe_cache_io import write_text_no_symlink
+
+
+_PRELUDE = """
+def leaf_north():
+    return 1
+
+def leaf_south():
+    return 2
+
+class NorthernCodec:
+    def encode_packet(codec):
+        return leaf_north()
+
+class SouthernCodec:
+    def encode_packet(codec):
+        return leaf_south()
+
+def identity(value):
+    return value
+"""
+
+
+_CASES = [
+    (
+        "called-nonlocal-receiver-mutator",
+        """
+        def launch():
+            receiver = NorthernCodec()
+            def mutate():
+                nonlocal receiver
+                receiver = SouthernCodec()
+            def invoke():
+                return receiver.encode_packet()
+            mutate()
+            return invoke()
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "escaped-nonlocal-receiver-mutator",
+        """
+        from external import dispatch
+        def launch():
+            receiver = NorthernCodec()
+            def mutate():
+                nonlocal receiver
+                receiver = SouthernCodec()
+            def invoke():
+                return receiver.encode_packet()
+            dispatch(mutate)
+            return invoke()
+        launch()
+        """,
+        {"NorthernCodec.encode_packet", "SouthernCodec.encode_packet"},
+    ),
+    (
+        "global-capture-rebinding",
+        """
+        receiver = NorthernCodec()
+        def launch():
+            def mutate():
+                global receiver
+                receiver = SouthernCodec()
+            def invoke():
+                return receiver.encode_packet()
+            mutate()
+            return invoke()
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "grandchild-nonlocal-rebinding",
+        """
+        def launch():
+            receiver = NorthernCodec()
+            def prepare():
+                def mutate():
+                    nonlocal receiver
+                    receiver = SouthernCodec()
+                mutate()
+            def invoke():
+                return receiver.encode_packet()
+            prepare()
+            return invoke()
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "nonlocal-function-rebinding",
+        """
+        def launch():
+            def callback():
+                return leaf_north()
+            def mutate():
+                nonlocal callback
+                callback = leaf_south
+            mutate()
+            return callback()
+        launch()
+        """,
+        {"leaf_south"},
+    ),
+    (
+        "receiver-bound-after-closure-creation",
+        """
+        def launch():
+            def invoke():
+                return receiver.encode_packet()
+            receiver = SouthernCodec()
+            return invoke()
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "receiver-alias-within-descendant",
+        """
+        def launch():
+            receiver = SouthernCodec()
+            def prepare():
+                alias = receiver
+                def invoke():
+                    return alias.encode_packet()
+                return invoke()
+            return prepare()
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "receiver-reassigned-after-closure-creation",
+        """
+        def launch():
+            receiver = NorthernCodec()
+            def invoke():
+                return receiver.encode_packet()
+            receiver = SouthernCodec()
+            return invoke()
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "conditional-captured-receiver",
+        """
+        from external import choose
+        def launch():
+            if choose():
+                receiver = NorthernCodec()
+            else:
+                receiver = SouthernCodec()
+            def invoke():
+                return receiver.encode_packet()
+            return invoke()
+        launch()
+        """,
+        {"NorthernCodec.encode_packet", "SouthernCodec.encode_packet"},
+    ),
+    (
+        "conditional-nested-definition",
+        """
+        def launch():
+            if True:
+                def callback():
+                    return leaf_south()
+            return callback()
+        launch()
+        """,
+        {"leaf_south"},
+    ),
+    (
+        "repeated-nested-definition",
+        """
+        def launch():
+            def callback():
+                return leaf_north()
+            callback()
+            def callback():
+                return leaf_south()
+            return callback()
+        launch()
+        """,
+        {"leaf_north", "leaf_south"},
+    ),
+    (
+        "finally-nested-definition",
+        """
+        def launch():
+            try:
+                value = 1
+            finally:
+                def callback():
+                    return leaf_south() + value
+            return callback()
+        launch()
+        """,
+        {"leaf_south"},
+    ),
+    (
+        "local-class-namespace-is-not-method-closure",
+        """
+        def launch():
+            def callback():
+                return leaf_south()
+            class Local:
+                callback = None
+                def invoke(instance):
+                    return callback()
+            return Local().invoke()
+        launch()
+        """,
+        {"leaf_south"},
+    ),
+    (
+        "unsupported-static-method-owner",
+        """
+        class Runner:
+            @staticmethod
+            def launch():
+                def callback():
+                    return leaf_south()
+                return callback()
+        Runner.launch()
+        """,
+        {"leaf_south"},
+    ),
+    (
+        "inherited-method-with-closure",
+        """
+        class Runner:
+            def launch(instance):
+                def callback():
+                    return leaf_south()
+                return callback()
+        class Child(Runner):
+            pass
+        Child().launch()
+        """,
+        {"leaf_south"},
+    ),
+    (
+        "lambda-default-mutates-captured-receiver",
+        """
+        def launch():
+            receiver = NorthernCodec()
+            def invoke():
+                return receiver.encode_packet()
+            initialize = lambda value=(receiver := SouthernCodec()): value
+            return invoke(), initialize
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "decorator-expression-mutates-captured-receiver",
+        """
+        def launch():
+            receiver = NorthernCodec()
+            @((receiver := SouthernCodec()) and identity)
+            def invoke():
+                return receiver.encode_packet()
+            return invoke()
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "class-header-mutates-captured-receiver",
+        """
+        def launch():
+            receiver = NorthernCodec()
+            @((receiver := SouthernCodec()) and identity)
+            class Local:
+                pass
+            def invoke():
+                return receiver.encode_packet()
+            return invoke(), Local
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "comprehension-target-shadows-nested-function",
+        """
+        def launch():
+            def callback():
+                return leaf_north()
+            return [callback() for callback in [leaf_south]]
+        launch()
+        """,
+        {"leaf_south"},
+    ),
+    (
+        "escaped-generator-target-shadows-nested-function",
+        """
+        def launch():
+            def callback():
+                return leaf_north()
+            return (callback() for callback in [leaf_south])
+        consume = launch()
+        list(consume)
+        """,
+        {"leaf_south"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "source,protected", [(c[1], c[2]) for c in _CASES], ids=[c[0] for c in _CASES]
+)
+def test_dynamic_closure_boundaries_preserve_live_code(tmp_path, source, protected):
+    path = tmp_path / "worker.py"
+    contents = textwrap.dedent(_PRELUDE).lstrip() + "\n" + textwrap.dedent(source)
+    assert write_text_no_symlink(path, contents)
+
+    result = json.loads(analyze(str(tmp_path.resolve()), trace_file=False))
+    assert not result.get("analysis_errors")
+    unused = {item["full_name"] for item in result.get("unused_functions", [])}
+
+    assert not {f"worker.{name}" for name in protected} & unused
+
+
+# Additional controls identified during implementation review, separate from
+# the original frozen 20-case safety baseline.
+_FOLLOWUP_CASES = [
+    (
+        "class-private-name-module-fallback",
+        """
+        def __dispatch():
+            return leaf_north()
+        def _Envelope__dispatch():
+            return leaf_south()
+        class Envelope:
+            def launch(envelope):
+                def invoke():
+                    return __dispatch()
+                return invoke()
+        Envelope().launch()
+        """,
+        {"_Envelope__dispatch", "leaf_south"},
+    ),
+    (
+        "private-attribute-uses-lexical-class",
+        """
+        class Envelope:
+            def launch(envelope):
+                receiver = Receiver()
+                def invoke():
+                    return receiver.__dispatch()
+                return invoke()
+        class Receiver:
+            def __dispatch(receiver):
+                return leaf_north()
+            def _Envelope__dispatch(receiver):
+                return leaf_south()
+        Envelope().launch()
+        """,
+        {"Receiver._Envelope__dispatch", "leaf_south"},
+    ),
+    (
+        "argument-annotation-mutates-captured-receiver",
+        """
+        def launch():
+            receiver = NorthernCodec()
+            def annotation():
+                nonlocal receiver
+                receiver = SouthernCodec()
+                return int
+            def invoke(value: annotation() = None):
+                return receiver.encode_packet(), value
+            invoke.__annotations__
+            return invoke()
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "return-annotation-mutates-captured-receiver",
+        """
+        def launch():
+            receiver = NorthernCodec()
+            def annotation():
+                nonlocal receiver
+                receiver = SouthernCodec()
+                return int
+            def invoke() -> annotation():
+                return receiver.encode_packet()
+            invoke.__annotations__
+            return invoke()
+        launch()
+        """,
+        {"SouthernCodec.encode_packet", "leaf_south"},
+    ),
+    (
+        "lambda-captures-private-local-function",
+        """
+        class Envelope:
+            def launch(envelope):
+                def __dispatch():
+                    return leaf_south()
+                callback = lambda: _Envelope__dispatch()
+                return callback()
+        Envelope().launch()
+        """,
+        {"Envelope.launch.__dispatch", "leaf_south"},
+    ),
+    (
+        "lambda-private-parameter-shadows-local-function",
+        """
+        class Envelope:
+            def launch(envelope):
+                def __dispatch():
+                    return leaf_north()
+                callback = lambda __dispatch: _Envelope__dispatch()
+                return callback(leaf_south)
+        Envelope().launch()
+        """,
+        {"leaf_south"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "source,protected",
+    [(c[1], c[2]) for c in _FOLLOWUP_CASES],
+    ids=[c[0] for c in _FOLLOWUP_CASES],
+)
+def test_reviewed_header_and_private_scope_boundaries(tmp_path, source, protected):
+    path = tmp_path / "worker.py"
+    contents = textwrap.dedent(_PRELUDE).lstrip() + "\n" + textwrap.dedent(source)
+    assert write_text_no_symlink(path, contents)
+
+    result = json.loads(analyze(str(tmp_path.resolve()), trace_file=False))
+    assert not result.get("analysis_errors")
+    unused = {item["full_name"] for item in result.get("unused_functions", [])}
+
+    assert not {f"worker.{name}" for name in protected} & unused


### PR DESCRIPTION
## Summary

  - Extend python reachability analysis to named nested functions
  - Find unused functions defined inside other functions and keep helper functions that are still used.
  - Avoid incorrectly reporting callbacks or functions affected by reassigned variables.
  - Refresh the generated repo map.

  ## Tests

  - `pytest test/test_closure_reachability.py test/test_closure_reachability_safety.py test/test_python_reachability.py \ test/test_method_reachability.py test/test_method_reachability_safety.py \ test/test_reachability_integration_qa.py test/test_analyzer.py`