### PR TITLE
perf(deadcode): reuse resolved paths within analysis passes

### DIFF
--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -1838,8 +1838,19 @@ class Skylos:
         dead_classes = set()
         defs_by_name_file = defaultdict(list)
         class_key_by_name_file = {}
+        resolved_filenames: dict[Path, str] = {}
+
+        def resolved_filename(filename) -> str:
+            path = Path(filename)
+            cached = resolved_filenames.get(path)
+            if cached is not None:
+                return cached
+            resolved = str(path.resolve())
+            resolved_filenames[path] = resolved
+            return resolved
+
         for key, defn in self.defs.items():
-            filename = str(Path(defn.filename).resolve())
+            filename = resolved_filename(defn.filename)
             defs_by_name_file[(defn.name, filename)].append(key)
             if defn.type in ("class", "type"):
                 class_key_by_name_file[(defn.name, filename)] = key
@@ -1851,7 +1862,7 @@ class Skylos:
         def key_for_caller(caller: str, callee_defn) -> str | None:
             if caller in self.defs:
                 return caller
-            filename = str(Path(callee_defn.filename).resolve())
+            filename = resolved_filename(callee_defn.filename)
             same_file = defs_by_name_file.get((caller, filename), [])
             if len(same_file) == 1:
                 return same_file[0]
@@ -1881,7 +1892,7 @@ class Skylos:
                 return True
             if "." not in caller:
                 return False
-            filename = str(Path(callee_defn.filename).resolve())
+            filename = resolved_filename(callee_defn.filename)
             owner = caller.rsplit(".", 1)[0]
             owner_key = class_key_by_name_file.get((owner, filename))
             return owner_key in dead_classes

--- a/skylos/deadcode/evidence.py
+++ b/skylos/deadcode/evidence.py
@@ -140,6 +140,32 @@ class SymbolKey:
             return Path(self.file).as_posix()
 
 
+def _repo_relative_file_formatter(root: str | Path):
+    """Format repeated symbol paths using a cache owned by one output pass."""
+    missing = object()
+    resolved_root: Path | object = missing
+    resolved_files: dict[str, str] = {}
+
+    def format_file(filename: str) -> str:
+        nonlocal resolved_root
+        cached = resolved_files.get(filename)
+        if cached is not None:
+            return cached
+        try:
+            resolved_file = Path(filename).resolve()
+            if resolved_root is missing:
+                resolved_root = Path(root).resolve()
+            relative = resolved_file.relative_to(resolved_root).as_posix()
+        except Exception:
+            # Preserve SymbolKey.repo_relative_file's lexical fallback. Failed
+            # resolutions are deliberately retried instead of being cached.
+            return Path(filename).as_posix()
+        resolved_files[filename] = relative
+        return relative
+
+    return format_file
+
+
 @dataclass(frozen=True)
 class EvidenceEvent:
     kind: EvidenceKind
@@ -282,8 +308,9 @@ class EvidenceLedger:
     ) -> dict[str, Any]:
         symbols = []
         definitions_by_name = _definitions_by_qualified_name(definitions)
+        format_file = None if root is None else _repo_relative_file_formatter(root)
         for symbol in sorted(self.events_by_symbol):
-            file_name = symbol.file if root is None else symbol.repo_relative_file(root)
+            file_name = symbol.file if format_file is None else format_file(symbol.file)
             decision = self.decision(
                 symbol,
                 definition=definitions_by_name.get(symbol.qualified_name),

--- a/skylos/deadcode/framework_liveness.py
+++ b/skylos/deadcode/framework_liveness.py
@@ -90,6 +90,7 @@ def _module_name(path: Path, root: Path) -> str:
 
 class _DefinitionIndex:
     def __init__(self, definitions, parsed, root):
+        self._resolved_paths: dict[Path, Path] = {}
         self.by_location = {}
         self.by_name = defaultdict(list)
         self.imports = defaultdict(list)
@@ -97,7 +98,7 @@ class _DefinitionIndex:
         self.modules = {}
         self.shadowed = set()
         for module in parsed:
-            path = module.path.resolve()
+            path = self._resolve_path(module.path)
             self.modules[path] = _module_name(path, root)
             relative = path.relative_to(root).parts
             first = (
@@ -112,7 +113,7 @@ class _DefinitionIndex:
                     self.shadowed.add(framework)
         for definition in definitions.values():
             kind = getattr(definition, "type", "")
-            path = Path(definition.filename).resolve()
+            path = self._resolve_path(Path(definition.filename))
             if path not in self.modules:
                 continue
             if kind == "parameter":
@@ -128,29 +129,34 @@ class _DefinitionIndex:
                     self.modules[path] = definition.name.rsplit(".", 1)[0]
         # A dotted setting names the module's final binding, not a stale function.
         for module in parsed:
+            path = self._resolve_path(module.path)
             active = {}
             for statement in module.tree.body:
                 for name in _bound_names(statement):
                     active.pop(name, None)
                 if isinstance(statement, _FUNCTIONS):
-                    definition = self.by_location.get(
-                        (module.path.resolve(), statement.lineno)
-                    )
+                    definition = self.by_location.get((path, statement.lineno))
                     if definition is not None:
                         active[statement.name] = definition
             active_ids = {id(item) for item in active.values()}
             for statement in module.tree.body:
                 if not isinstance(statement, _FUNCTIONS):
                     continue
-                definition = self.by_location.get(
-                    (module.path.resolve(), statement.lineno)
-                )
+                definition = self.by_location.get((path, statement.lineno))
                 if definition is not None and id(definition) not in active_ids:
                     self.by_name[definition.name] = [
                         item
                         for item in self.by_name[definition.name]
                         if item is not definition
                     ]
+
+    def _resolve_path(self, path: Path) -> Path:
+        cached = self._resolved_paths.get(path)
+        if cached is not None:
+            return cached
+        resolved = path.resolve()
+        self._resolved_paths[path] = resolved
+        return resolved
 
     def callable(self, name):
         candidates = self.by_name.get(name, ())
@@ -162,7 +168,7 @@ class _DefinitionIndex:
 class _FrameworkScanner:
     def __init__(self, parsed: ParsedPythonFile, index: _DefinitionIndex):
         self.parsed = parsed
-        self.path = parsed.path.resolve()
+        self.path = index._resolve_path(parsed.path)
         self.index = index
         self.targets = []
         self.routes: dict[str, tuple[ast.AST, dict[str, str | None]]] = {}

--- a/skylos/deadcode/plugin_registry.py
+++ b/skylos/deadcode/plugin_registry.py
@@ -37,18 +37,31 @@ _DefByFileSimple = dict[tuple[str, str], Any]
 _DefByFileLine = dict[tuple[str, int], Any]
 
 
+def _resolved_file(path: Path, cache: dict[Path, str]) -> str:
+    cached = cache.get(path)
+    if cached is not None:
+        return cached
+    resolved = str(path.resolve())
+    cache[path] = resolved
+    return resolved
+
+
 def find_literal_plugin_registry_targets(
     definitions: dict[str, Any],
     parsed_files: Sequence[ParsedPythonFile],
 ) -> list[Any]:
+    resolved_files: dict[Path, str] = {}
     definitions_by_name = _definitions_by_name(definitions)
-    definitions_by_file_simple = _definitions_by_file_simple(definitions)
-    definitions_by_file_line = _definitions_by_file_line(definitions)
+    definitions_by_file_simple = _definitions_by_file_simple(
+        definitions, resolved_files
+    )
+    definitions_by_file_line = _definitions_by_file_line(definitions, resolved_files)
 
     registries = _collect_literal_plugin_registries(
         parsed_files,
         definitions_by_file_simple,
         definitions_by_name,
+        resolved_files,
     )
     if not registries:
         return []
@@ -63,6 +76,7 @@ def find_literal_plugin_registry_targets(
         definitions_by_file_line,
         set(registries),
         reachable_functions,
+        resolved_files,
     )
     if not live_registries:
         return []
@@ -87,14 +101,17 @@ def find_literal_plugin_registry_targets(
 # Definition indexes
 
 
-def _definitions_by_file_simple(definitions: dict[str, Any]) -> _DefByFileSimple:
+def _definitions_by_file_simple(
+    definitions: dict[str, Any], resolved_files: dict[Path, str]
+) -> _DefByFileSimple:
     lookup: _DefByFileSimple = {}
     for defn in definitions.values():
         simple = str(getattr(defn, "simple_name", ""))
         if not simple:
             continue
         try:
-            filename = str(Path(getattr(defn, "filename", "")).resolve())
+            path = Path(getattr(defn, "filename", ""))
+            filename = _resolved_file(path, resolved_files)
         except (OSError, TypeError):
             continue
         key = (filename, simple)
@@ -120,13 +137,16 @@ def _definitions_by_name(definitions: dict[str, Any]) -> _DefByName:
     return lookup
 
 
-def _definitions_by_file_line(definitions: dict[str, Any]) -> _DefByFileLine:
+def _definitions_by_file_line(
+    definitions: dict[str, Any], resolved_files: dict[Path, str]
+) -> _DefByFileLine:
     lookup: _DefByFileLine = {}
     for defn in definitions.values():
         if getattr(defn, "type", None) not in {"function", "method"}:
             continue
         try:
-            filename = str(Path(getattr(defn, "filename", "")).resolve())
+            path = Path(getattr(defn, "filename", ""))
+            filename = _resolved_file(path, resolved_files)
             line = int(getattr(defn, "line", 0) or 0)
         except (OSError, TypeError, ValueError):
             continue
@@ -142,11 +162,12 @@ def _collect_literal_plugin_registries(
     parsed_files: Sequence[ParsedPythonFile],
     definitions_by_file_simple: _DefByFileSimple,
     definitions_by_name: _DefByName,
+    resolved_files: dict[Path, str],
 ) -> dict[str, set[str]]:
     registries: dict[str, set[str]] = {}
     for parsed in parsed_files:
         try:
-            file_key = str(parsed.path.resolve())
+            file_key = _resolved_file(parsed.path, resolved_files)
         except OSError:
             continue
         for stmt in parsed.tree.body:
@@ -220,11 +241,12 @@ def _collect_live_plugin_registry_uses(
     definitions_by_file_line: _DefByFileLine,
     registry_qnames: set[str],
     reachable_functions: set[str],
+    resolved_files: dict[Path, str],
 ) -> set[str]:
     live_registries: set[str] = set()
     for parsed in parsed_files:
         try:
-            file_key = str(parsed.path.resolve())
+            file_key = _resolved_file(parsed.path, resolved_files)
         except OSError:
             continue
         import_ctx = _collect_import_context(parsed.tree)

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from collections.abc import Iterator, Mapping
 from skylos.visitors.test_aware import TestAwareVisitor
 from skylos.visitors.framework_aware import FrameworkAwareVisitor
+from skylos.visitors.base import Definition
 from skylos.analysis.penalties import _check_abstract_overrides, apply_penalties
 from skylos.deadcode.config_entrypoints import configured_entrypoint_reason
 from skylos.engines.go_runner import GoEngineError
@@ -4098,6 +4099,97 @@ function foo() {
         assert ("live.ts", "helper") not in unused_by_file
         assert ("dead.ts", "helper") in unused_by_file
         assert ("dead.ts", "foo") in unused_by_file
+
+    def test_transitive_dead_resolves_each_filename_once_per_pass(
+        self, monkeypatch, tmp_path
+    ):
+        source = tmp_path / "chain.py"
+        dead = Definition("pkg.dead", "function", source, 1)
+        middle = Definition("pkg.middle", "function", source, 2)
+        leaf = Definition("pkg.leaf", "function", source, 3)
+        middle.called_by = {dead.name}
+        leaf.called_by = {middle.name}
+        analyzer = Skylos()
+        analyzer.defs = {"leaf": leaf, "middle": middle, "dead": dead}
+        original_resolve = Path.resolve
+        resolved = []
+
+        def record_resolve(path, *args, **kwargs):
+            resolved.append(path)
+            return original_resolve(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", record_resolve)
+
+        for _ in range(2):
+            dead.references = 0
+            middle.references = 1
+            leaf.references = 1
+            analyzer._propagate_transitive_dead()
+            assert (dead.references, middle.references, leaf.references) == (0, 0, 0)
+
+        assert resolved.count(source) == 2
+
+    def test_transitive_dead_refreshes_symlink_identity_between_passes(
+        self, tmp_path
+    ):
+        dead_dir = tmp_path / "dead"
+        live_dir = tmp_path / "live"
+        dead_dir.mkdir()
+        live_dir.mkdir()
+        dead_path = dead_dir / "module.py"
+        live_path = live_dir / "module.py"
+        alias = tmp_path / "selected.py"
+        try:
+            alias.symlink_to(dead_path)
+        except OSError as error:
+            pytest.skip(f"symlinks unavailable: {error}")
+
+        dead_caller = Definition("pkg.caller", "function", dead_path, 1)
+        live_caller = Definition("pkg.caller", "function", live_path, 1)
+        live_caller.references = 1
+        live_caller.is_exported = True
+        leaf = Definition("pkg.leaf", "function", alias, 2)
+        leaf.references = 1
+        leaf.called_by = {"pkg.caller"}
+        analyzer = Skylos()
+        analyzer.defs = {
+            "dead-caller": dead_caller,
+            "live-caller": live_caller,
+            "leaf": leaf,
+        }
+
+        analyzer._propagate_transitive_dead()
+        assert leaf.references == 0
+
+        alias.unlink()
+        alias.symlink_to(live_path)
+        leaf.references = 1
+        analyzer._propagate_transitive_dead()
+
+        assert leaf.references == 1
+
+    def test_transitive_dead_does_not_swallow_path_errors(self, monkeypatch, tmp_path):
+        analyzer = Skylos()
+        analyzer.defs = {
+            "work": Definition("pkg.work", "function", tmp_path / "app.py", 1)
+        }
+        original_resolve = Path.resolve
+        attempts = 0
+
+        def fail_once(path, *args, **kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise OSError("temporarily unavailable")
+            return original_resolve(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", fail_once)
+
+        with pytest.raises(OSError, match="temporarily unavailable"):
+            analyzer._propagate_transitive_dead()
+        analyzer._propagate_transitive_dead()
+
+        assert attempts == 2
 
     def test_analyze_single_file_skips_project_unused_dependency_rule(self, tmp_path):
         (tmp_path / "pyproject.toml").write_text(

--- a/test/test_dead_code_evidence.py
+++ b/test/test_dead_code_evidence.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 import sqlite3
 from types import SimpleNamespace
 
@@ -36,6 +37,120 @@ def _unused_full_names(result, bucket):
     return {
         item.get("full_name") or item.get("name")
         for item in result.get(bucket, [])
+    }
+
+
+def test_evidence_serialization_resolves_each_filename_once(monkeypatch, tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    source = project / "app.py"
+    source.write_text("pass\n", encoding="utf-8")
+    ledger = EvidenceLedger()
+    for name in ("app.first", "app.second"):
+        ledger.events_by_symbol[SymbolKey(str(source), name, "function", 1)] = []
+
+    original_resolve = Path.resolve
+    resolved = []
+
+    def record_resolve(path, *args, **kwargs):
+        resolved.append(path)
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", record_resolve)
+
+    payload = ledger.to_dict(project)
+
+    assert [entry["file"] for entry in payload["symbols"]] == ["app.py", "app.py"]
+    assert resolved.count(project) == 1
+    assert resolved.count(source) == 1
+
+
+def test_evidence_serialization_cache_does_not_outlive_call(monkeypatch, tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    ledger = EvidenceLedger()
+    ledger.events_by_symbol[SymbolKey("app.py", "app.work", "function", 1)] = []
+
+    monkeypatch.chdir(first)
+    assert ledger.to_dict(tmp_path)["symbols"][0]["file"] == "first/app.py"
+    monkeypatch.chdir(second)
+    assert ledger.to_dict(tmp_path)["symbols"][0]["file"] == "second/app.py"
+
+
+def test_evidence_serialization_does_not_cache_resolution_failure(
+    monkeypatch, tmp_path
+):
+    source = tmp_path / "app.py"
+    source.write_text("pass\n", encoding="utf-8")
+    ledger = EvidenceLedger()
+    for name in ("app.first", "app.second"):
+        ledger.events_by_symbol[SymbolKey(str(source), name, "function", 1)] = []
+    original_resolve = Path.resolve
+    source_attempts = 0
+
+    def fail_first_source_resolution(path, *args, **kwargs):
+        nonlocal source_attempts
+        if path == source:
+            source_attempts += 1
+            if source_attempts == 1:
+                raise OSError("temporarily unavailable")
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", fail_first_source_resolution)
+
+    payload = ledger.to_dict(tmp_path)
+
+    assert [entry["file"] for entry in payload["symbols"]] == [
+        source.as_posix(),
+        "app.py",
+    ]
+    assert source_attempts == 2
+
+
+def test_evidence_serialization_without_root_keeps_raw_path(monkeypatch):
+    ledger = EvidenceLedger()
+    raw_path = "pkg/./module.py"
+    ledger.events_by_symbol[SymbolKey(raw_path, "pkg.work", "function", 1)] = []
+
+    def unexpected_resolve(*args, **kwargs):
+        raise AssertionError("root=None must not resolve symbol paths")
+
+    monkeypatch.setattr(Path, "resolve", unexpected_resolve)
+
+    assert ledger.to_dict()["symbols"][0]["file"] == raw_path
+
+
+def test_evidence_serialization_preserves_path_fallbacks(monkeypatch, tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside.py"
+    broken = project / "broken.py"
+    ledger = EvidenceLedger()
+    ledger.events_by_symbol[SymbolKey(str(outside), "outside.work", "function", 1)] = []
+    ledger.events_by_symbol[SymbolKey(str(broken), "broken.work", "function", 1)] = []
+    original_resolve = Path.resolve
+
+    def fail_one_path(path, *args, **kwargs):
+        if path == broken:
+            raise OSError("unavailable")
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", fail_one_path)
+
+    payload = ledger.to_dict(project)
+    files = {entry["qualified_name"]: entry["file"] for entry in payload["symbols"]}
+
+    assert files == {
+        "broken.work": broken.as_posix(),
+        "outside.work": outside.as_posix(),
+    }
+    assert {
+        entry["qualified_name"]: entry["file"] for entry in ledger.to_dict()["symbols"]
+    } == {
+        "broken.work": str(broken),
+        "outside.work": str(outside),
     }
 
 

--- a/test/test_dead_code_liveness.py
+++ b/test/test_dead_code_liveness.py
@@ -1,8 +1,13 @@
+import ast
 import json
+from pathlib import Path
 import textwrap
 
 from skylos.analyzer import analyze
 from skylos.deadcode import liveness
+from skylos.deadcode.plugin_registry import find_literal_plugin_registry_targets
+from skylos.deadcode.python_ast import ParsedPythonFile
+from skylos.visitors.base import Definition
 
 
 def _write(path, body):
@@ -12,6 +17,92 @@ def _write(path, body):
 
 def _unused_function_names(result):
     return {item["full_name"] for item in result.get("unused_functions", [])}
+
+
+def _plugin_registry_lookup_fixture(tmp_path):
+    sources = {
+        "registry.py": 'HANDLERS = {"pay": "plugins:charge"}\n',
+        "dispatcher.py": """
+            from registry import HANDLERS
+            import importlib
+            def dispatch(event):
+                path = HANDLERS[event]
+                module_name, func_name = path.split(":")
+                handler = getattr(importlib.import_module(module_name), func_name)
+                return handler(event)
+        """,
+        "app.py": """
+            from dispatcher import dispatch
+            def main():
+                return dispatch("pay")
+        """,
+        "plugins.py": """
+            def charge(event):
+                return event
+            def stale(event):
+                return event
+        """,
+    }
+    parsed = []
+    definitions = {}
+    for filename, source in sources.items():
+        path = tmp_path / filename
+        tree = ast.parse(textwrap.dedent(source).lstrip())
+        parsed.append(ParsedPythonFile(path, tree))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            qualified_name = f"{path.stem}.{node.name}"
+            definitions[qualified_name] = Definition(
+                qualified_name, "function", path, node.lineno, node
+            )
+    registry = Definition("registry.HANDLERS", "variable", tmp_path / "registry.py", 1)
+    definitions = {registry.name: registry, **definitions}
+    definitions["app.main"].calls.add("dispatcher.dispatch")
+    return definitions, parsed
+
+
+def test_plugin_registry_resolves_each_path_once_per_lookup(monkeypatch, tmp_path):
+    definitions, parsed = _plugin_registry_lookup_fixture(tmp_path)
+    original_resolve = Path.resolve
+    resolved = []
+
+    def record_resolve(path, *args, **kwargs):
+        resolved.append(path)
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", record_resolve)
+
+    for _ in range(2):
+        targets = find_literal_plugin_registry_targets(definitions, parsed)
+        assert [target.name for target in targets] == ["plugins.charge"]
+
+    for path in {parsed_file.path for parsed_file in parsed}:
+        assert resolved.count(path) == 2
+
+
+def test_plugin_registry_retries_failed_path_resolution(monkeypatch, tmp_path):
+    definitions, parsed = _plugin_registry_lookup_fixture(tmp_path)
+    registry_path = tmp_path / "registry.py"
+    dummy = Definition("registry.IGNORED", "variable", registry_path, 1)
+    definitions = {dummy.name: dummy, **definitions}
+    original_resolve = Path.resolve
+    attempts = 0
+
+    def fail_first_registry_resolution(path, *args, **kwargs):
+        nonlocal attempts
+        if path == registry_path:
+            attempts += 1
+            if attempts == 1:
+                raise OSError("temporarily unavailable")
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", fail_first_registry_resolution)
+
+    targets = find_literal_plugin_registry_targets(definitions, parsed)
+
+    assert [target.name for target in targets] == ["plugins.charge"]
+    assert attempts == 2
 
 
 def test_numba_overload_implementation_is_live(tmp_path):

--- a/test/test_django_celery_entrypoints.py
+++ b/test/test_django_celery_entrypoints.py
@@ -1,11 +1,16 @@
 """Framework fixtures are parsed by Skylos, never imported or executed."""
 
+import ast
 import json
+from pathlib import Path
 import textwrap
 
 import pytest
 
 from skylos.analyzer import analyze
+from skylos.deadcode.framework_liveness import find_framework_entrypoint_targets
+from skylos.deadcode.python_ast import ParsedPythonFile
+from skylos.visitors.base import Definition
 
 
 def _scan(tmp_path, sources):
@@ -19,6 +24,42 @@ def _scan(tmp_path, sources):
 
 def _names(result, bucket):
     return {item["full_name"] for item in result.get(bucket, [])}
+
+
+def test_framework_index_resolves_each_path_once_per_lookup(monkeypatch, tmp_path):
+    source = tmp_path / "migration.py"
+    tree = ast.parse(
+        "from django.db import migrations\n"
+        "def forwards(apps, editor): pass\n"
+        "operation = migrations.RunPython(forwards)\n"
+    )
+    function_node = tree.body[1]
+    definitions = {}
+    for definition in (
+        Definition("migration.forwards", "function", source, 2, function_node),
+        Definition("migration.forwards.apps", "parameter", source, 2),
+        Definition("migration.forwards.editor", "parameter", source, 2),
+    ):
+        definitions[definition.name] = definition
+    parsed = [ParsedPythonFile(source, tree)]
+    original_resolve = Path.resolve
+    resolved = []
+
+    def record_resolve(path, *args, **kwargs):
+        resolved.append(path)
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", record_resolve)
+
+    for _ in range(2):
+        targets = find_framework_entrypoint_targets(definitions, parsed, tmp_path)
+        assert {(target.name, reason) for target, reason in targets} == {
+            ("migration.forwards.apps", "django_migration_callback"),
+            ("migration.forwards.editor", "django_migration_callback"),
+        }
+
+    assert resolved.count(source) == 4
+    assert resolved.count(tmp_path) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

  - Reuse successful file-path resolutions during a single dead-code analysis pass.
  - Apply this to evidence output, framework detection, plugin registries, and dead-code propagation.
  - Clear the resolved paths after every pass and retry failed resolutions.

  ## Tests

  - `pytest test/test_dead_code_evidence.py test/test_django_celery_entrypoints.py \
    test/test_dead_code_liveness.py test/test_duck_typed_callback_liveness.py \ test/test_analyzer.py`