### PR TITLE
feat(review): remember reviewed findings across scans

### DIFF
--- a/skylos/agents/center.py
+++ b/skylos/agents/center.py
@@ -410,6 +410,7 @@ def compose_agent_state(
     changed_files: list[str],
     baseline_present: bool,
     triage: dict[str, dict[str, Any]] | None = None,
+    review_state_revision: str | None = None,
 ) -> dict[str, Any]:
     normalized_triage = normalize_triage_map(triage)
     triage_counts = apply_triage_to_findings(findings, normalized_triage)
@@ -425,10 +426,11 @@ def compose_agent_state(
     return {
         "project_root": str(Path(project_root).resolve()),
         "generated_at": utc_now(),
-        "state_version": 3,
+        "state_version": 4,
         "file_signatures": signatures,
         "changed_files": changed_files,
         "baseline_present": baseline_present,
+        "review_state_revision": review_state_revision,
         "triage": normalized_triage,
         "summary": summary,
         "findings": findings,
@@ -488,6 +490,7 @@ def rebuild_agent_state_from_existing(
         changed_files=list(state.get("changed_files") or []),
         baseline_present=bool(state.get("baseline_present")),
         triage=triage if triage is not None else state.get("triage"),
+        review_state_revision=state.get("review_state_revision"),
     )
 
 
@@ -560,6 +563,7 @@ def _load_refresh_context(
     bool,
     dict[str, dict[str, int]],
     list[str],
+    str | None,
 ]:
     project_root = resolve_project_root(path)
     previous_state = load_agent_state(project_root, state_file=state_file) or {}
@@ -573,6 +577,7 @@ def _load_refresh_context(
     changed_files = detect_changed_files(
         previous_state.get("file_signatures"), signatures
     )
+    review_revision = _current_review_state_revision(project_root)
     return (
         project_root,
         previous_state,
@@ -580,7 +585,19 @@ def _load_refresh_context(
         triage_changed,
         signatures,
         changed_files,
+        review_revision,
     )
+
+
+def _current_review_state_revision(project_root: Path) -> str | None:
+    try:
+        from skylos.core.review_decisions import review_state_revision
+    except ImportError:
+        # Kept for mixed-version embedders while the review-memory module and
+        # command center are upgraded together.
+        return None
+    revision = review_state_revision(project_root)
+    return revision if isinstance(revision, str) and revision else None
 
 
 def _maybe_reuse_previous_state(
@@ -589,11 +606,12 @@ def _maybe_reuse_previous_state(
     previous_state: dict[str, Any],
     changed_files: list[str],
     triage_changed: bool,
+    review_state_changed: bool,
     project_root: Path,
     triage: dict[str, dict[str, Any]],
     state_file: str | Path | None = None,
 ) -> tuple[dict[str, Any], bool] | None:
-    if force or not previous_state or changed_files:
+    if force or not previous_state or changed_files or review_state_changed:
         return None
     if not triage_changed:
         return previous_state, False
@@ -631,19 +649,32 @@ def _run_refresh_analysis(
     changed_files: list[str],
     exclude_folders: list[str] | set[str] | None = None,
 ) -> list[dict[str, Any]]:
-    raw = run_analyze(
-        str(project_root),
-        conf=conf,
-        enable_secrets=enable_secrets,
-        enable_danger=enable_danger,
-        enable_quality=enable_quality,
-        enable_ai_defects=enable_ai_defects,
-        exclude_folders=_resolve_analysis_excludes(
+    from skylos.core.review_decisions import (
+        apply_trusted_review_decisions,
+        review_scan_requirements,
+    )
+
+    options = {
+        "conf": conf,
+        "enable_secrets": enable_secrets,
+        "enable_danger": enable_danger,
+        "enable_quality": enable_quality,
+        "enable_ai_defects": enable_ai_defects,
+        "exclude_folders": _resolve_analysis_excludes(
             project_root,
             exclude_folders=exclude_folders,
         ),
+    }
+    include_review_context, include_review_proofs = review_scan_requirements(
+        project_root
     )
+    if include_review_context:
+        options["include_review_context"] = True
+    if include_review_proofs:
+        options["include_review_proofs"] = True
+    raw = run_analyze(str(project_root), **options)
     result = json.loads(raw) if isinstance(raw, str) else raw
+    result = apply_trusted_review_decisions(result, project_root)
     return normalize_findings(
         result,
         project_root,
@@ -723,6 +754,7 @@ def refresh_agent_state(
         triage_changed,
         signatures,
         changed_files,
+        review_revision,
     ) = _load_refresh_context(
         path,
         state_file=state_file,
@@ -734,6 +766,9 @@ def refresh_agent_state(
         previous_state=previous_state,
         changed_files=changed_files,
         triage_changed=triage_changed,
+        review_state_changed=(
+            previous_state.get("review_state_revision") != review_revision
+        ),
         project_root=project_root,
         triage=triage,
         state_file=state_file,
@@ -775,6 +810,7 @@ def refresh_agent_state(
         changed_files=changed_files,
         baseline_present=bool(baseline or debt_baseline),
         triage=triage,
+        review_state_revision=review_revision,
     )
     save_agent_state(project_root, state, state_file=state_file)
     return state, True

--- a/skylos/analyzer.py
+++ b/skylos/analyzer.py
@@ -66,8 +66,13 @@ from skylos.core.file_discovery import (
     should_exclude_path,
 )
 from skylos.core.git_context import GitContext
+from skylos.core.git_safety import (
+    read_only_git_command,
+    read_only_git_environment,
+)
 from skylos.core.safe_cache_io import read_project_text_no_symlink
 from skylos.core.linter import LinterVisitor
+from skylos.core.review_context import build_analysis_review_context
 from skylos.deadcode.signature_contracts import mark_signature_contract_parameters
 
 from skylos.rules.quality.policy import analyze_repo_policy
@@ -99,6 +104,8 @@ _find_package_boundary_modules = find_package_boundary_modules
 _OPTIONAL_RUN_STATE_ATTRIBUTES = (
     "_sca_coverage",
     "_analysis_scope",
+    "_review_context",
+    "_review_file_configs",
     "_ai_verification_expectations",
     "_ai_verification_checks",
     "_language_engine_reports",
@@ -323,33 +330,21 @@ def _diff_result_has_text(diff_result):
 
 
 def _git_diff_for_changed_file(root, rel_file, diff_base):
-    import subprocess
-
+    context = GitContext.from_path(root)
+    pathspec = f":(literal){rel_file}"
     if diff_base:
-        diff_cmd = ["git", "diff", f"{diff_base}...HEAD", "--", rel_file]
+        diff_cmd = ["diff", f"{diff_base}...HEAD", "--", pathspec]
     else:
-        diff_cmd = ["git", "diff", "HEAD", "--", rel_file]
+        diff_cmd = ["diff", "HEAD", "--", pathspec]
 
-    diff_result = subprocess.run(
-        diff_cmd,
-        capture_output=True,
-        text=True,
-        timeout=10,
-        cwd=str(root),
-    )
+    diff_result = context.run(*diff_cmd)
     if _diff_result_has_text(diff_result):
         return diff_result.stdout
 
     if not diff_base:
         return ""
 
-    fallback_result = subprocess.run(
-        ["git", "diff", "HEAD", "--", rel_file],
-        capture_output=True,
-        text=True,
-        timeout=10,
-        cwd=str(root),
-    )
+    fallback_result = context.run("diff", "HEAD", "--", pathspec)
     if _diff_result_has_text(fallback_result):
         return fallback_result.stdout
 
@@ -615,10 +610,14 @@ def _git_tracking_status(candidate: Path) -> bool | None:
     try:
         relative = candidate.relative_to(git_root).as_posix()
         result = subprocess.run(
-            ["git", "ls-files", "--error-unmatch", "--", relative],
+            read_only_git_command(
+                ["ls-files", "--error-unmatch", "--", relative],
+                literal_pathspecs=True,
+            ),
             cwd=git_root,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
+            env=read_only_git_environment(),
             timeout=_GIT_TRACKING_TIMEOUT_SECONDS,
             check=False,
         )
@@ -2992,6 +2991,8 @@ class Skylos:
         pyproject_entrypoint_modules=None,
         config_file=None,
         analysis_errors=None,
+        include_review_proofs=False,
+        review_config=None,
     ):
         from skylos.reporting.result_builder import build_analysis_result
 
@@ -3024,6 +3025,8 @@ class Skylos:
             pyproject_entrypoint_modules=pyproject_entrypoint_modules,
             config_file=config_file,
             analysis_errors=analysis_errors,
+            include_review_proofs=include_review_proofs,
+            review_config=review_config,
         )
 
     @releases_python_ast_cache
@@ -3049,6 +3052,8 @@ class Skylos:
         required_config_rules=None,
         grep_cache=True,
         dependency_bump_diff_base=None,
+        include_review_proofs=False,
+        include_review_context=False,
     ) -> str:
         if not isinstance(path, (str, list, tuple)):
             raise TypeError(
@@ -3056,6 +3061,10 @@ class Skylos:
             )
         if not (0 <= thr <= 100):
             raise ValueError(f"thr must be 0-100, got {thr}")
+
+        if extra_visitors is not None and not isinstance(extra_visitors, tuple):
+            extra_visitors = tuple(extra_visitors)
+        include_review_context = bool(include_review_context or include_review_proofs)
 
         if self._has_analyzed:
             self._reset_run_state()
@@ -3153,6 +3162,36 @@ class Skylos:
                 project_cfg, project_config_overrides
             )
         project_ignore = set(project_cfg.get("ignore", []))
+        requested_changed_files = changed_files
+
+        def refresh_review_context(effective_changed_files):
+            if not include_review_context:
+                self._review_context = None
+                return
+            self._review_context = build_analysis_review_context(
+                project_root,
+                path,
+                config=project_cfg,
+                threshold=thr,
+                exclude_folders=exclude_folders,
+                requested_changed_files=requested_changed_files,
+                effective_changed_files=effective_changed_files,
+                enable_secrets=enable_secrets,
+                enable_danger=enable_danger,
+                enable_quality=enable_quality,
+                enable_ai_defects=enable_ai_defects,
+                enable_sca=enable_sca,
+                enable_dependency_hallucinations=enable_dependency_hallucinations,
+                grep_verify=grep_verify,
+                trace_file=trace_file,
+                required_config_rules=required_config_rules,
+                dependency_bump_diff_base=dependency_bump_diff_base,
+                custom_rules_data=custom_rules_data,
+                extra_visitors=extra_visitors,
+                analysis_scope=self._analysis_scope,
+            )
+
+        refresh_review_context(changed_files)
 
         if not files:
             logger.warning(f"No supported source files found in {path}")
@@ -3188,6 +3227,10 @@ class Skylos:
                 },
                 "workspaces": workspace_inventory.to_dict(project_root),
             }
+            if isinstance(self._review_context, dict):
+                result["analysis_summary"]["review_context"] = dict(
+                    self._review_context
+                )
             if first_is_symlink and required_config_rules:
                 result["analysis_errors"].append(
                     _analysis_error_payload(
@@ -3396,7 +3439,6 @@ class Skylos:
         global_pattern_tracker.traced_by_file.clear()
         global_pattern_tracker._traced_by_basename.clear()
 
-        requested_changed_files = changed_files
         pyproject_entrypoint_qnames = set()
         pyproject_entrypoint_modules = set()
 
@@ -3457,6 +3499,7 @@ class Skylos:
         all_param_method_refs = defaultdict(list)
         all_call_arg_types = defaultdict(list)
         all_top_level_refs = set()
+        effective_file_configs = {} if include_review_context else None
 
         injected = False
         if custom_rules_data and not os.getenv("SKYLOS_CUSTOM_RULES"):
@@ -3578,6 +3621,14 @@ class Skylos:
                     empty_file_finding,
                     cfg,
                 ) = out[:12]
+                if effective_file_configs is not None:
+                    effective_file_configs[str(Path(file).resolve())] = cfg
+                    for worker_findings in (q_finds, d_finds, pro_finds):
+                        for worker_finding in worker_findings or ():
+                            if isinstance(worker_finding, dict):
+                                worker_finding["_analysis_worker_config"] = cfg
+                    if isinstance(empty_file_finding, dict):
+                        empty_file_finding["_analysis_worker_config"] = cfg
 
                 if file_ignore_lines:
                     per_file_ignore_lines[str(file)] = file_ignore_lines
@@ -4510,8 +4561,6 @@ class Skylos:
 
             if changed_files and "SKY-A101" not in project_ignore:
                 try:
-                    import subprocess
-
                     from skylos.rules.ai_defect.assertion_weakening import (
                         detect_assertion_weakening,
                     )
@@ -4524,32 +4573,14 @@ class Skylos:
                             if Path(cf).is_absolute()
                             else str(cf)
                         )
-                        diff_cmd = (
-                            ["git", "diff", f"{diff_base}...HEAD", "--", rel_cf]
-                            if diff_base
-                            else ["git", "diff", "HEAD", "--", rel_cf]
+                        diff_text = _git_diff_for_changed_file(
+                            root,
+                            rel_cf,
+                            diff_base,
                         )
-                        diff_result = subprocess.run(
-                            diff_cmd,
-                            capture_output=True,
-                            text=True,
-                            timeout=10,
-                            cwd=str(root),
-                        )
-                        if (
-                            diff_result.returncode != 0
-                            or not diff_result.stdout.strip()
-                        ) and diff_base:
-                            diff_result = subprocess.run(
-                                ["git", "diff", "HEAD", "--", rel_cf],
-                                capture_output=True,
-                                text=True,
-                                timeout=10,
-                                cwd=str(root),
-                            )
-                        if diff_result.returncode == 0 and diff_result.stdout.strip():
+                        if diff_text:
                             assertion_findings = detect_assertion_weakening(
-                                diff_result.stdout,
+                                diff_text,
                                 cf,
                             )
                             _extend_unsuppressed_ai_defect_findings(
@@ -4912,6 +4943,8 @@ class Skylos:
             workspace_inventory=workspace_inventory,
         )
 
+        self._review_file_configs = effective_file_configs
+        refresh_review_context(changed_files)
         result = self._build_result(
             files,
             thr,
@@ -4940,6 +4973,8 @@ class Skylos:
             pyproject_entrypoint_modules=pyproject_entrypoint_modules,
             config_file=config_file,
             analysis_errors=analysis_errors,
+            include_review_proofs=include_review_proofs,
+            review_config=project_cfg,
         )
 
         return json.dumps(result, indent=2)
@@ -4997,6 +5032,8 @@ def analyze(
     required_config_rules=None,
     grep_cache=True,
     dependency_bump_diff_base=None,
+    include_review_proofs=False,
+    include_review_context=False,
 ) -> str:
     return Skylos().analyze(
         path,
@@ -5019,6 +5056,8 @@ def analyze(
         project_config_overrides=project_config_overrides,
         required_config_rules=required_config_rules,
         dependency_bump_diff_base=dependency_bump_diff_base,
+        include_review_proofs=include_review_proofs,
+        include_review_context=include_review_context,
     )
 
 

--- a/skylos/api/__init__.py
+++ b/skylos/api/__init__.py
@@ -59,11 +59,15 @@ from skylos.api._urls import (
 
 from skylos.constants import (
     NETWORK_TIMEOUT_SHORT,
-    NETWORK_TIMEOUT_DEFAULT,
     NETWORK_TIMEOUT_LONG,
     SNIPPET_CONTEXT_LINES as SNIPPET_CONTEXT_LINES,
     SUBPROCESS_TIMEOUT,
     UPLOAD_TIMEOUT,
+)
+from skylos.core.git_context import GitContext
+from skylos.core.git_safety import (
+    read_only_git_command,
+    read_only_git_environment,
 )
 from skylos.core.safe_cache_io import read_text_no_symlink
 
@@ -279,15 +283,9 @@ def _read_json(path: Path):
 
 
 def _get_repo_root_for_link():
-    try:
-        out = subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"], stderr=subprocess.DEVNULL
-        )
-        p = out.decode().strip()
-        if p:
-            return Path(p)
-    except (subprocess.SubprocessError, OSError):
-        pass
+    root = get_git_root()
+    if root:
+        return Path(root)
     return Path.cwd()
 
 
@@ -425,13 +423,18 @@ def get_git_root() -> str | None:
     try:
         return (
             subprocess.check_output(
-                ["git", "rev-parse", "--show-toplevel"], stderr=subprocess.DEVNULL
+                read_only_git_command(["rev-parse", "--show-toplevel"]),
+                env=read_only_git_environment(),
+                stderr=subprocess.DEVNULL,
+                timeout=SUBPROCESS_TIMEOUT,
             )
             .decode()
             .strip()
+            or None
         )
     except (subprocess.SubprocessError, OSError):
-        return None
+        pass
+    return None
 
 
 def _resolve_repo_link_path(git_root) -> Path | None:
@@ -529,15 +532,20 @@ def _read_git_head() -> tuple[str | None, str | None]:
     try:
         git_commit = (
             subprocess.check_output(
-                ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL
+                read_only_git_command(["rev-parse", "HEAD"]),
+                env=read_only_git_environment(),
+                stderr=subprocess.DEVNULL,
+                timeout=SUBPROCESS_TIMEOUT,
             )
             .decode()
             .strip()
         )
         git_branch = (
             subprocess.check_output(
-                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                read_only_git_command(["rev-parse", "--abbrev-ref", "HEAD"]),
+                env=read_only_git_environment(),
                 stderr=subprocess.DEVNULL,
+                timeout=SUBPROCESS_TIMEOUT,
             )
             .decode()
             .strip()
@@ -620,17 +628,20 @@ def _collect_finding_lines(findings: list) -> dict:
 
 
 def _get_file_blame_map(git_root: str, file_path: str, lines: set[int]) -> dict:
-    abs_path = os.path.join(git_root, file_path)
-    if not os.path.isfile(abs_path):
+    root = Path(git_root).resolve()
+    candidate = root / file_path
+    if candidate.is_symlink() or not candidate.is_file():
         return {}
 
     try:
-        out = subprocess.check_output(
-            _build_blame_command(file_path, lines),
-            cwd=git_root,
-            stderr=subprocess.DEVNULL,
-            timeout=NETWORK_TIMEOUT_DEFAULT,
-        ).decode("utf-8", errors="ignore")
+        context = GitContext.from_path(root)
+        repo_path = context.relative_path(candidate)
+        if repo_path is None:
+            return {}
+        result = context.run(*_build_blame_command(repo_path, lines)[1:])
+        if result.returncode != 0:
+            return {}
+        out = result.stdout
     except (subprocess.SubprocessError, OSError):
         return {}
     return _parse_blame_output(file_path, out)
@@ -686,7 +697,25 @@ def _prepare_report_upload(
         UPLOAD_FINDING_SPECS,
         git_root,
         extract_metadata=True,
+        analyzer_owned=analyzer_owned,
     )
+    reviewed_findings = (
+        result_json.get("reviewed_findings", []) if analyzer_owned else []
+    )
+    if isinstance(reviewed_findings, list):
+        for reviewed in reviewed_findings:
+            if not isinstance(reviewed, dict):
+                continue
+            category = str(reviewed.get("category") or "QUALITY").upper()
+            all_findings.extend(
+                _normalize_findings(
+                    [reviewed],
+                    category,
+                    git_root,
+                    extract_metadata=True,
+                    analyzer_owned=True,
+                )
+            )
     _annotate_findings_with_blame(all_findings, git_root)
 
     exporter = SarifExporter(

--- a/skylos/api/_ai_detection.py
+++ b/skylos/api/_ai_detection.py
@@ -6,6 +6,10 @@ import subprocess
 from collections.abc import Callable
 
 from skylos.constants import NETWORK_TIMEOUT_SHORT, SUBPROCESS_TIMEOUT
+from skylos.core.git_safety import (
+    read_only_git_command,
+    read_only_git_environment,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,13 +62,15 @@ def detect_ai_code(
 
     try:
         log_output = subprocess.check_output(
-            [
-                "git",
-                "log",
-                "--format=%H|%an|%ae|%s|%(trailers:key=Co-authored-by,valueonly,separator=%x00)",
-                "-50",
-            ],
+            read_only_git_command(
+                [
+                    "log",
+                    "--format=%H|%an|%ae|%s|%(trailers:key=Co-authored-by,valueonly,separator=%x00)",
+                    "-50",
+                ]
+            ),
             cwd=git_root,
+            env=read_only_git_environment(),
             stderr=subprocess.DEVNULL,
             timeout=SUBPROCESS_TIMEOUT,
         ).decode("utf-8", errors="ignore")
@@ -149,18 +155,24 @@ def _append_ai_indicator(
     return False
 
 
-def _collect_ai_commit_files(git_root: str, commit_sha: str, ai_files: set[str]) -> None:
+def _collect_ai_commit_files(
+    git_root: str, commit_sha: str, ai_files: set[str]
+) -> None:
     try:
         diff_output = subprocess.check_output(
-            [
-                "git",
-                "diff-tree",
-                "--no-commit-id",
-                "--name-only",
-                "-r",
-                commit_sha,
-            ],
+            read_only_git_command(
+                [
+                    "diff-tree",
+                    "--no-commit-id",
+                    "--name-only",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "-r",
+                    commit_sha,
+                ]
+            ),
             cwd=git_root,
+            env=read_only_git_environment(),
             stderr=subprocess.DEVNULL,
             timeout=NETWORK_TIMEOUT_SHORT,
         ).decode("utf-8", errors="ignore")

--- a/skylos/api/_findings.py
+++ b/skylos/api/_findings.py
@@ -1,6 +1,7 @@
 import os
 
 from skylos.api._snippets import extract_snippet
+from skylos.core.review_decisions import FINDING_SECTIONS
 
 
 __all__ = [
@@ -11,18 +12,7 @@ __all__ = [
 ]
 
 
-UPLOAD_FINDING_SPECS = (
-    ("ai_defects", "AI_DEFECT", "SKY-AI000"),
-    ("danger", "SECURITY", "SKY-D000"),
-    ("reliability", "RELIABILITY", "SKY-R000"),
-    ("quality", "QUALITY", "SKY-Q000"),
-    ("secrets", "SECRET", "SKY-S000"),
-    ("unused_functions", "DEAD_CODE", "SKY-U001"),
-    ("unused_imports", "DEAD_CODE", "SKY-U002"),
-    ("unused_variables", "DEAD_CODE", "SKY-U003"),
-    ("unused_classes", "DEAD_CODE", "SKY-U004"),
-    ("dependency_vulnerabilities", "DEPENDENCY", "SKY-SCA-000"),
-)
+UPLOAD_FINDING_SPECS = FINDING_SECTIONS
 
 VERIFY_FINDING_SPECS = (
     ("danger", "SECURITY", "SKY-D000"),
@@ -46,6 +36,23 @@ _PRIVATE_METADATA_KEYS = (
     "_review_proof_lines",
 )
 
+_REVIEW_METADATA_KEYS = (
+    "fingerprint_version",
+    "stable_fingerprint",
+    "context_hash",
+    "rule_revision",
+    "language",
+    "symbol",
+    "review_decision",
+)
+_TRUSTED_REVIEW_METADATA_KEYS = (
+    "fingerprint_version",
+    "stable_fingerprint",
+    "context_hash",
+    "rule_revision",
+    "review_decision",
+)
+
 
 def _normalize_findings(
     items,
@@ -55,6 +62,7 @@ def _normalize_findings(
     default_severity=None,
     extract_metadata=False,
     generate_finding_id=False,
+    analyzer_owned=False,
 ) -> list[dict]:
     """Unified finding normalization used by upload and verify paths."""
     _validate_category(category)
@@ -67,6 +75,7 @@ def _normalize_findings(
             default_severity=default_severity,
             extract_metadata=extract_metadata,
             generate_finding_id=generate_finding_id,
+            analyzer_owned=analyzer_owned,
         )
         for item in items or []
     ]
@@ -86,6 +95,7 @@ def _normalize_finding(
     default_severity=None,
     extract_metadata=False,
     generate_finding_id=False,
+    analyzer_owned=False,
 ) -> dict:
     raw_path = finding.get("file_path") or finding.get("file") or ""
     file_abs = os.path.abspath(raw_path) if raw_path else ""
@@ -98,6 +108,7 @@ def _normalize_finding(
     _apply_default_severity(finding, default_severity)
     _apply_default_message(finding, category)
     _apply_snippet(finding, category, file_abs, line, git_root)
+    _copy_review_metadata(finding, analyzer_owned=analyzer_owned)
 
     if extract_metadata:
         _move_private_metadata(finding)
@@ -181,6 +192,34 @@ def _move_private_metadata(finding: dict) -> None:
         finding["metadata"] = metadata
 
 
+def _copy_review_metadata(finding: dict, *, analyzer_owned: bool) -> None:
+    metadata = finding.get("metadata")
+    normalized = dict(metadata) if isinstance(metadata, dict) else {}
+    finding.pop("_analysis_config_hash", None)
+    finding.pop("_analysis_worker_config", None)
+    normalized.pop("_analysis_config_hash", None)
+    normalized.pop("_analysis_worker_config", None)
+    for key in _TRUSTED_REVIEW_METADATA_KEYS:
+        normalized.pop(key, None)
+        if not analyzer_owned:
+            finding.pop(key, None)
+
+    trusted_review = finding.pop("_skylos_trusted_review", None) is True
+    normalized.pop("_skylos_trusted_review", None)
+    for key in _REVIEW_METADATA_KEYS:
+        if key in _TRUSTED_REVIEW_METADATA_KEYS and not analyzer_owned:
+            continue
+        if key == "review_decision" and not trusted_review:
+            continue
+        value = finding.get(key)
+        if value is not None:
+            normalized[key] = value
+    if normalized:
+        finding["metadata"] = normalized
+    else:
+        finding.pop("metadata", None)
+
+
 def _finding_id(finding: dict) -> str:
     return f"{finding['rule_id']}::{finding['file_path']}::{finding['line_number']}"
 
@@ -193,6 +232,7 @@ def _normalize_result_sections(
     default_severity=None,
     extract_metadata=False,
     generate_finding_id=False,
+    analyzer_owned=False,
 ) -> list[dict]:
     findings: list[dict] = []
     for section_name, category, default_rule_id in section_specs:
@@ -205,6 +245,7 @@ def _normalize_result_sections(
                 default_severity=default_severity,
                 extract_metadata=extract_metadata,
                 generate_finding_id=generate_finding_id,
+                analyzer_owned=analyzer_owned,
             )
         )
     return findings

--- a/skylos/api/_payloads.py
+++ b/skylos/api/_payloads.py
@@ -182,6 +182,13 @@ def _compact_finding_metadata(metadata: Any) -> dict[str, Any] | None:
         "affected_range",
         "fixed_version",
         "cvss_score",
+        "fingerprint_version",
+        "stable_fingerprint",
+        "context_hash",
+        "rule_revision",
+        "language",
+        "symbol",
+        "review_decision",
     }
     compact = {key: metadata[key] for key in keep_keys if key in metadata}
     aliases = metadata.get("aliases")

--- a/skylos/cli.py
+++ b/skylos/cli.py
@@ -276,17 +276,23 @@ def _join_phrase(parts: list[str]) -> str:
     return f"{', '.join(parts[:-1])}, {' '.join(('and', parts[-1]))}"
 
 
-def _list_dirty_relevant_paths(project_root: Path, is_relevant_path) -> list[str]:
+def _list_dirty_relevant_paths(
+    project_root: Path, is_relevant_path
+) -> list[str] | None:
     result = subprocess.run(
         ["git", "status", "--porcelain", "--untracked-files=all"],
         capture_output=True,
         text=True,
         cwd=project_root,
     )
-    if result.returncode != 0 or not result.stdout.strip():
+    if result.returncode != 0:
+        return None
+    if not result.stdout:
         return []
     relevant = []
-    for line in result.stdout.strip().splitlines():
+    # Porcelain's leading column distinguishes an unstaged worktree change
+    # (`` M``) from a staged one (``M ``); do not strip it before parsing.
+    for line in result.stdout.splitlines():
         if not line:
             continue
         status = line[:2]
@@ -494,8 +500,11 @@ def _remap_precommit_result_files(
         "danger",
         "reliability",
         "quality",
+        "ai_defects",
         "secrets",
         "custom_rules",
+        "dependency_vulnerabilities",
+        "reviewed_findings",
     ]:
         items = result.get(category, [])
         if not items:
@@ -627,6 +636,59 @@ def _replace_precommit_dependency_bumps(
                     "Staged dependency bump scan failed", exc_info=True
                 )
     result["ai_defects"] = findings
+
+
+def _attach_precommit_manual_review_context(
+    result,
+    *,
+    analysis_root,
+    analysis_targets,
+    project_config,
+    threshold,
+    exclude_folders,
+    staged_dependency_files,
+    snapshot_exact,
+):
+    """Bind manually assembled pre-commit findings to their staged inputs."""
+    from skylos.core.review_context import (
+        REVIEW_CONTEXT_SCHEMA,
+        build_analysis_review_context,
+    )
+
+    summary = result.setdefault("analysis_summary", {})
+    if not snapshot_exact:
+        summary["review_context"] = {
+            "schema": REVIEW_CONTEXT_SCHEMA,
+            "complete": False,
+        }
+        return
+
+    targets = sorted(analysis_targets)
+    summary["review_context"] = build_analysis_review_context(
+        analysis_root,
+        targets,
+        config=project_config,
+        threshold=threshold,
+        exclude_folders=exclude_folders,
+        requested_changed_files=targets,
+        effective_changed_files=targets,
+        enable_secrets=True,
+        enable_danger=False,
+        enable_quality=False,
+        enable_ai_defects=bool(staged_dependency_files),
+        enable_sca=False,
+        enable_dependency_hallucinations=False,
+        grep_verify=False,
+        trace_file=None,
+        required_config_rules=None,
+        dependency_bump_diff_base="staged-index" if staged_dependency_files else None,
+        custom_rules_data=None,
+        extra_visitors=None,
+        analysis_scope={
+            "kind": "precommit_staged_manual",
+            "complete_repository": False,
+        },
+    )
 
 
 def _precommit_finding_targets_report_file(
@@ -1070,7 +1132,7 @@ def _normalize_agent_findings(payload, project_root: Path):
     return out
 
 
-def _agent_findings_to_result_json(findings):
+def _agent_findings_to_result_json(findings, *, review_context=None):
     result = {
         "danger": [],
         "reliability": [],
@@ -1081,7 +1143,10 @@ def _agent_findings_to_result_json(findings):
         "unused_imports": [],
         "unused_variables": [],
         "unused_classes": [],
+        "unused_parameters": [],
     }
+    if isinstance(review_context, dict):
+        result["analysis_summary"] = {"review_context": dict(review_context)}
 
     category_map = {
         "security": "danger",
@@ -1098,6 +1163,7 @@ def _agent_findings_to_result_json(findings):
         "SKY-U002": "unused_imports",
         "SKY-U003": "unused_variables",
         "SKY-U004": "unused_classes",
+        "SKY-U006": "unused_parameters",
     }
 
     for f in findings or []:
@@ -1117,6 +1183,50 @@ def _agent_findings_to_result_json(findings):
             result["quality"].append(item)
 
     return result
+
+
+_AGENT_REVIEW_INDEX = "_skylos_agent_review_index"
+
+
+def _apply_agent_review_memory(
+    findings,
+    project_root: Path,
+    *,
+    include_identities=False,
+    review_context=None,
+):
+    """Project trusted review decisions while retaining an auditable upload set."""
+    tagged = []
+    for index, finding in enumerate(findings or []):
+        if not isinstance(finding, dict):
+            continue
+        item = dict(finding)
+        item[_AGENT_REVIEW_INDEX] = index
+        tagged.append(item)
+
+    from skylos.core.review_decisions import (
+        FINDING_SECTIONS,
+        apply_trusted_review_decisions,
+    )
+
+    projected = apply_trusted_review_decisions(
+        _agent_findings_to_result_json(tagged, review_context=review_context),
+        project_root,
+        include_identities=include_identities,
+    )
+    active = []
+    for section, _category, _default_rule_id in FINDING_SECTIONS:
+        for item in projected.get(section, []) or []:
+            if isinstance(item, dict):
+                active.append(item)
+    active.sort(key=lambda item: int(item.get(_AGENT_REVIEW_INDEX, 0)))
+
+    for item in active:
+        item.pop(_AGENT_REVIEW_INDEX, None)
+    for item in projected.get("reviewed_findings", []) or []:
+        if isinstance(item, dict):
+            item.pop(_AGENT_REVIEW_INDEX, None)
+    return active, projected
 
 
 def _is_tty():
@@ -1618,6 +1728,27 @@ def _apply_display_filters(result, severity=None, category=None, file_filter=Non
 
         filtered[key] = _display_filter_items(items, file_filter, min_rank)
 
+    reviewed_items = result.get("reviewed_findings")
+    if isinstance(reviewed_items, list):
+        reviewed_kept = []
+        for item in reviewed_items:
+            if not isinstance(item, dict):
+                continue
+            reviewed_category = _DISPLAY_FILTER_CATEGORY_MAP.get(
+                str(item.get("section") or "")
+            )
+            if reviewed_category is None:
+                reviewed_category = str(item.get("category") or "").lower()
+            if allowed_cats and reviewed_category not in allowed_cats:
+                continue
+            if not _display_filter_items([item], file_filter, min_rank):
+                continue
+            reviewed_kept.append(item)
+        filtered["reviewed_findings"] = reviewed_kept
+        reviewed_summary = copy.copy(result.get("reviewed_findings_summary") or {})
+        reviewed_summary["suppressed_count"] = len(reviewed_kept)
+        filtered["reviewed_findings_summary"] = reviewed_summary
+
     summary = copy.copy(result.get("analysis_summary") or {})
     incomplete_grep_verify = _incomplete_grep_verify_report(summary)
     summary.pop("by_directory", None)
@@ -1628,6 +1759,8 @@ def _apply_display_filters(result, severity=None, category=None, file_filter=Non
     for key, count_key in _RULE_SELECTION_SUMMARY_COUNTS.items():
         if key in result or count_key in summary:
             summary[count_key] = len(filtered.get(key) or [])
+    if "reviewed_findings_summary" in filtered:
+        summary["reviewed_findings"] = copy.copy(filtered["reviewed_findings_summary"])
     filtered["analysis_summary"] = summary
 
     # These aggregates describe the unfiltered result and must not be emitted
@@ -2103,6 +2236,12 @@ def _run_verify_command(argv):
     from skylos.commands.verify_cmd import run_verify_command
 
     return run_verify_command(argv)
+
+
+def _run_review_command(argv):
+    from skylos.commands.review_cmd import run_review_command
+
+    return run_review_command(argv, console_factory=Console)
 
 
 def _attach_upload_project_context(result: dict, project_root: pathlib.Path) -> None:
@@ -3794,6 +3933,7 @@ def main() -> None:
                 )
                 snapshot_dir = None
                 analysis_root = project_root
+                review_snapshot_exact = True
                 analysis_targets = {
                     str((analysis_root / relpath).resolve())
                     for relpath in staged_changed_files
@@ -3816,11 +3956,11 @@ def main() -> None:
                 has_static_analysis_targets = bool(
                     staged_source_files or staged_contract_files
                 )
-                if has_static_analysis_targets or staged_dependency_files:
+                if staged_changed_files:
                     unstaged_relevant = _list_dirty_relevant_paths(
                         project_root, _is_relevant_analysis_path
                     )
-                    if unstaged_relevant:
+                    if unstaged_relevant is None or unstaged_relevant:
                         snapshot_dir, snapshot_root = _create_precommit_snapshot(
                             project_root
                         )
@@ -3838,6 +3978,7 @@ def main() -> None:
                                 " Using staged git snapshot for exact commit results."
                             )
                         else:
+                            review_snapshot_exact = False
                             snapshot_note = " Exact staged snapshot unavailable; using working tree context."
 
                 if staged_contract_files:
@@ -3853,6 +3994,15 @@ def main() -> None:
                 baseline = load_baseline(project_root)
                 analyzer_logger = logging.getLogger("Skylos")
                 analyzer_logger_level = analyzer_logger.level
+                from skylos.core.review_decisions import (
+                    apply_trusted_review_decisions,
+                    review_scan_requirements,
+                )
+
+                (
+                    include_review_context,
+                    include_review_proofs,
+                ) = review_scan_requirements(project_root)
 
                 try:
                     if agent_args.format != "json":
@@ -3968,17 +4118,24 @@ def main() -> None:
                             )
 
                         analyzer_logger.setLevel(logging.WARNING)
+                        analysis_options = {
+                            "conf": agent_args.conf,
+                            "enable_secrets": True,
+                            "enable_danger": True,
+                            "enable_quality": True,
+                            "enable_ai_defects": True,
+                            "exclude_folders": list(exclude_folders),
+                            "changed_files": analysis_targets,
+                            "grep_verify": False,
+                            "progress_callback": _update_precommit_progress,
+                        }
+                        if include_review_proofs:
+                            analysis_options["include_review_proofs"] = True
+                        if include_review_context:
+                            analysis_options["include_review_context"] = True
                         raw_result = run_analyze(
                             analysis_scan_target,
-                            conf=agent_args.conf,
-                            enable_secrets=True,
-                            enable_danger=True,
-                            enable_quality=True,
-                            enable_ai_defects=True,
-                            exclude_folders=list(exclude_folders),
-                            changed_files=analysis_targets,
-                            grep_verify=False,
-                            progress_callback=_update_precommit_progress,
+                            **analysis_options,
                         )
                         result = (
                             json.loads(raw_result)
@@ -3988,15 +4145,44 @@ def main() -> None:
                         if staged_secret_only_secrets:
                             result["secrets"] = list(result.get("secrets") or [])
                             result["secrets"].extend(staged_secret_only_secrets)
-                        result = _remap_precommit_result_files(
-                            result, analysis_root, project_root
-                        )
                     _replace_precommit_dependency_bumps(
                         result,
                         project_root,
                         staged_dependency_files,
                         list(exclude_folders),
                         project_config,
+                    )
+                    if include_review_context and (
+                        not has_static_analysis_targets or not review_snapshot_exact
+                    ):
+                        _attach_precommit_manual_review_context(
+                            result,
+                            analysis_root=analysis_root,
+                            analysis_targets=analysis_targets,
+                            project_config=project_config,
+                            threshold=agent_args.conf,
+                            exclude_folders=list(exclude_folders),
+                            staged_dependency_files=staged_dependency_files,
+                            snapshot_exact=review_snapshot_exact,
+                        )
+                    # Static analysis already points at ``analysis_root``. The
+                    # staged-only secret and dependency passes point at the
+                    # worktree, so normalize those paths to the same source
+                    # snapshot before creating review identities.
+                    result = _remap_precommit_result_files(
+                        result,
+                        project_root,
+                        analysis_root,
+                    )
+                    result = apply_trusted_review_decisions(
+                        result,
+                        project_root,
+                        analysis_root=analysis_root,
+                    )
+                    result = _remap_precommit_result_files(
+                        result,
+                        analysis_root,
+                        project_root,
                     )
                 finally:
                     analyzer_logger.setLevel(analyzer_logger_level)
@@ -4722,6 +4908,13 @@ def main() -> None:
                 )
                 sys.exit(1 if has_blockers else 0)
 
+            (
+                prompt_templates,
+                prompt_template_root,
+            ) = _explicit_prompt_templates_from_args(agent_args, console)
+            agent_args.prompt_templates = prompt_templates
+            agent_args.prompt_template_root = prompt_template_root
+
             changed_files = None
             if getattr(agent_args, "changed", False):
                 path = pathlib.Path(agent_args.path)
@@ -4761,9 +4954,21 @@ def main() -> None:
                 changed_files=changed_files,
                 exclude_folders=agent_exclude_folders,
                 stats_out=pipeline_stats,
+                provider=provider,
+                base_url=base_url,
+                project_root=project_root,
+                project_config=agent_project_cfg,
             )
 
             merged_findings = _normalize_agent_findings(merged_findings, project_root)
+            raw_finding_count = len(merged_findings)
+            merged_findings, reviewed_result = _apply_agent_review_memory(
+                merged_findings,
+                project_root,
+                include_identities=bool(getattr(agent_args, "upload", False)),
+                review_context=pipeline_stats.get("review_context"),
+            )
+            reviewed_count = len(reviewed_result.get("reviewed_findings", []) or [])
 
             static_only = 0
             llm_only = 0
@@ -4785,6 +4990,10 @@ def main() -> None:
             console.print(
                 f"  [yellow]MEDIUM (LLM only, needs review):[/yellow] {llm_only}"
             )
+            if reviewed_count:
+                console.print(
+                    f"  [dim]Previously reviewed and excluded: {reviewed_count}[/dim]"
+                )
             if pipeline_stats:
                 console.print("[dim]Timings:[/dim]")
                 console.print(
@@ -4835,19 +5044,42 @@ def main() -> None:
                 else:
                     console.print("[good]No issues found![/good]")
 
-            if getattr(agent_args, "upload", False) and merged_findings:
-                result_for_upload = _agent_findings_to_result_json(merged_findings)
-                upload_report(
-                    result_for_upload,
+            cloud_gate_failed = False
+            upload_failed = False
+            if getattr(agent_args, "upload", False) and raw_finding_count:
+                _attach_upload_project_context(reviewed_result, project_root)
+                upload_response = upload_report(
+                    reviewed_result,
                     is_forced=getattr(agent_args, "force", False),
                     strict=getattr(agent_args, "strict", False),
                     analysis_mode="hybrid",
+                    analyzer_owned=True,
                 )
+                if not isinstance(upload_response, dict) or not upload_response.get(
+                    "success"
+                ):
+                    upload_failed = True
+                    if isinstance(upload_response, dict):
+                        _render_upload_failure(console, upload_response)
+                    else:
+                        console.print(
+                            "[bad]Upload failed: invalid Cloud response[/bad]"
+                        )
+                else:
+                    cloud_gate_passed = upload_response.get("quality_gate_passed")
+                    if cloud_gate_passed is None:
+                        cloud_gate_passed = (
+                            upload_response.get("quality_gate") or {}
+                        ).get("passed", True)
+                    cloud_gate_failed = cloud_gate_passed is False and not getattr(
+                        agent_args, "force", False
+                    )
 
             _upload_agent_run_best_effort(
                 "scan",
                 {
                     "total": len(merged_findings),
+                    "reviewed": reviewed_count,
                     "static_only": static_only,
                     "llm_only": llm_only,
                     "both": both,
@@ -4857,6 +5089,8 @@ def main() -> None:
                 duration_seconds=round(_time.time() - _scan_start, 1),
             )
 
+            if upload_failed or cloud_gate_failed:
+                sys.exit(1)
             if merged_findings and getattr(agent_args, "strict", False):
                 sys.exit(1)
             sys.exit(0)

--- a/skylos/cli_core/dispatch.py
+++ b/skylos/cli_core/dispatch.py
@@ -29,6 +29,7 @@ EARLY_COMMAND_HANDLERS = {
     "city": "_run_removed_city_command",
     "suite": "run_suite_command",
     "verify": "_run_verify_command",
+    "review": "_run_review_command",
     "discover": "_run_discover_command",
     "defend": "run_defend_command",
     "debt": "run_debt_command",

--- a/skylos/cloud/sync.py
+++ b/skylos/cloud/sync.py
@@ -706,6 +706,14 @@ def cmd_project_create() -> None:
 
 def cmd_project_unlink() -> None:
     repo_root = _find_repo_root()
+    repo_subpath = _current_repo_subpath(repo_root)
+    project_root = repo_root / repo_subpath if repo_subpath else repo_root
+    from skylos.core.review_decisions import invalidate_trusted_bundle
+
+    invalidate_trusted_bundle(
+        project_root,
+        cache_root=GLOBAL_CREDS_DIR / "reviewed-findings",
+    )
     link_path = _delete_link(repo_root)
     if link_path:
         print(f"✓ Removed repo link: {link_path}")
@@ -722,8 +730,20 @@ def cmd_pull() -> None:
         sys.exit(1)
 
     repo_root = _find_repo_root()
-    skylos_dir = repo_root / SKYLOS_DIR
-    skylos_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        skylos_dir = _ensure_safe_link_path(repo_root, create_dir=True).parent
+    except AuthError as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+    from skylos.core.review_decisions import invalidate_trusted_bundle
+
+    sync_subpath = _current_repo_subpath(repo_root)
+    sync_project_root = repo_root / sync_subpath if sync_subpath else repo_root
+    invalidate_trusted_bundle(
+        sync_project_root,
+        cache_root=GLOBAL_CREDS_DIR / "reviewed-findings",
+    )
 
     try:
         info = api_get(WHOAMI_ENDPOINT, token)
@@ -739,7 +759,35 @@ def cmd_pull() -> None:
 
         print("Pulling suppressions...")
         supp_data = api_get("/api/sync/suppressions", token)
+        if not isinstance(supp_data, dict):
+            raise AuthError("Invalid suppression response")
+        whoami_project = info.get("project") if isinstance(info, dict) else None
+        whoami_project_id = (
+            str(whoami_project.get("id") or "").strip()
+            if isinstance(whoami_project, dict)
+            else ""
+        )
+        suppression_project_id = str(supp_data.get("project_id") or "").strip()
+        if (
+            whoami_project_id
+            and suppression_project_id
+            and whoami_project_id != suppression_project_id
+        ):
+            raise AuthError("Suppression response belongs to a different project")
+        if not suppression_project_id and whoami_project_id:
+            supp_data = {**supp_data, "project_id": whoami_project_id}
         _write_sync_suppressions(skylos_dir, supp_data)
+
+        from skylos.core.review_decisions import write_trusted_bundle
+
+        trusted_path = write_trusted_bundle(
+            sync_project_root,
+            supp_data,
+            cache_root=GLOBAL_CREDS_DIR / "reviewed-findings",
+            service_origin=get_api_url(),
+        )
+        if trusted_path is None:
+            raise AuthError("Could not store trusted suppression state")
 
         print("\n✓ Sync complete!")
 
@@ -764,8 +812,8 @@ def _write_sync_config(skylos_dir: Path, config_data):
 
 def _write_sync_suppressions(skylos_dir: Path, supp_data):
     supp_path = skylos_dir / SUPPRESSIONS_FILE
-    with supp_path.open("w") as f:
-        json.dump(supp_data.get("suppressions", []), f, indent=2)
+    payload = supp_data if isinstance(supp_data, dict) else {}
+    _atomic_write_text(supp_path, json.dumps(payload, indent=2) + "\n")
     print(f"  ✓ {supp_path} ({supp_data.get('count', 0)} suppressions)")
 
 

--- a/skylos/commands/agent_verify_cmd.py
+++ b/skylos/commands/agent_verify_cmd.py
@@ -127,11 +127,23 @@ def run_agent_verify_command(
         console.print(f"[bad]Path not found: {path}[/bad]")
         return 1
 
+    project_root = _project_root_for_path(path)
+    from skylos.core.review_decisions import (
+        apply_trusted_review_decisions,
+        review_scan_requirements,
+    )
+
+    include_review_context, include_review_proofs = review_scan_requirements(
+        project_root
+    )
+
     console.print("[brand]Step 1/2: Running static analysis...[/brand]")
     static_result = _run_static_dead_code_scan(
         path,
         conf=args.conf,
         exclude_folders=exclude_folders,
+        include_review_context=include_review_context,
+        include_review_proofs=include_review_proofs,
     )
     if analysis_result_incomplete(static_result):
         console.print(
@@ -139,8 +151,15 @@ def run_agent_verify_command(
             "generate fixes.[/bad]"
         )
         return 2
+    static_result = apply_trusted_review_decisions(static_result, project_root)
     all_findings = _collect_dead_code_findings(static_result)
-    defs_map = static_result.get("definitions", {})
+    reviewed_dead_code = _reviewed_dead_code_findings(static_result)
+    protected_definitions = _finding_keys(reviewed_dead_code, project_root)
+    defs_map = _without_reviewed_definitions(
+        static_result.get("definitions", {}),
+        protected_definitions,
+        project_root,
+    )
 
     if not all_findings:
         console.print("[good]No dead code findings to verify![/good]")
@@ -175,6 +194,7 @@ def run_agent_verify_command(
             defs_map=defs_map,
             verified=verified,
             new_dead=new_dead,
+            protected_definitions=protected_definitions,
         )
 
     upload_agent_run(
@@ -199,17 +219,23 @@ def _run_static_dead_code_scan(
     *,
     conf: int,
     exclude_folders: list[str],
+    include_review_context: bool = False,
+    include_review_proofs: bool = False,
 ) -> dict[str, Any]:
     from skylos.analyzer import analyze as run_static
 
-    raw = run_static(
-        str(path),
-        conf=conf,
-        enable_danger=False,
-        enable_quality=False,
-        enable_secrets=False,
-        exclude_folders=exclude_folders,
-    )
+    options = {
+        "conf": conf,
+        "enable_danger": False,
+        "enable_quality": False,
+        "enable_secrets": False,
+        "exclude_folders": exclude_folders,
+    }
+    if include_review_proofs:
+        options["include_review_proofs"] = True
+    if include_review_context:
+        options["include_review_context"] = True
+    raw = run_static(str(path), **options)
     return json.loads(raw) if isinstance(raw, str) else raw
 
 
@@ -217,6 +243,70 @@ def _collect_dead_code_findings(static_result: dict[str, Any]) -> list[dict[str,
     from skylos.deadcode.collect import collect_dead_code_findings
 
     return collect_dead_code_findings(static_result)
+
+
+def _reviewed_dead_code_findings(
+    static_result: dict[str, Any],
+) -> list[dict[str, Any]]:
+    return [
+        finding
+        for finding in static_result.get("reviewed_findings", []) or []
+        if isinstance(finding, dict)
+        and str(finding.get("category") or "").upper() == "DEAD_CODE"
+    ]
+
+
+def _finding_key(
+    finding: dict[str, Any],
+    project_root: pathlib.Path,
+) -> tuple[str, str] | None:
+    from skylos.core.review_decisions import normalize_repo_path
+
+    file_path = normalize_repo_path(
+        finding.get("file_path") or finding.get("file"),
+        project_root,
+        allow_absolute=True,
+    )
+    name = str(
+        finding.get("full_name") or finding.get("symbol") or finding.get("name") or ""
+    ).strip()
+    if file_path is None or not name:
+        return None
+    return file_path, name
+
+
+def _finding_keys(
+    findings: list[dict[str, Any]],
+    project_root: pathlib.Path,
+) -> set[tuple[str, str]]:
+    return {
+        key
+        for finding in findings
+        if (key := _finding_key(finding, project_root)) is not None
+    }
+
+
+def _without_reviewed_definitions(
+    defs_map: Any,
+    protected_definitions: set[tuple[str, str]],
+    project_root: pathlib.Path,
+) -> dict[str, Any]:
+    if not isinstance(defs_map, dict) or not protected_definitions:
+        return defs_map if isinstance(defs_map, dict) else {}
+
+    active: dict[str, Any] = {}
+    for name, info in defs_map.items():
+        definition = info if isinstance(info, dict) else {}
+        key = _finding_key(
+            {
+                "file": definition.get("file"),
+                "full_name": name,
+            },
+            project_root,
+        )
+        if key not in protected_definitions:
+            active[name] = info
+    return active
 
 
 def _run_verification_harness(
@@ -257,13 +347,17 @@ def _run_verification_harness(
     return result
 
 
-def _write_or_print_verify_result(args, console: Console, result: dict[str, Any]) -> None:
+def _write_or_print_verify_result(
+    args, console: Console, result: dict[str, Any]
+) -> None:
     if args.format != "json":
         return
 
     output = json.dumps(result, indent=2, default=str)
     if args.output:
-        pathlib.Path(args.output).write_text(  # skylos: ignore[SKY-D215] user-selected CLI output path
+        pathlib.Path(
+            args.output
+        ).write_text(  # skylos: ignore[SKY-D215] user-selected CLI output path
             output,
             encoding="utf-8",
         )
@@ -379,9 +473,7 @@ def _print_entry_points(console: Console, result: dict[str, Any]) -> None:
 
     console.print(f"\n[cyan]Entry points discovered ({len(entry_points)}):[/cyan]")
     for entry_point in entry_points:
-        console.print(
-            f"  - {entry_point['name']} (from {entry_point['source']})"
-        )
+        console.print(f"  - {entry_point['name']} (from {entry_point['source']})")
 
 
 def _print_net_result(console: Console, stats: dict[str, Any]) -> None:
@@ -404,8 +496,16 @@ def _handle_verify_fixes(
     defs_map: dict[str, Any],
     verified: list[dict[str, Any]],
     new_dead: list[dict[str, Any]],
+    protected_definitions: set[tuple[str, str]] | None = None,
 ) -> None:
     dead_findings = _confirmed_dead_findings(verified, new_dead)
+    if protected_definitions:
+        project_root_path = _project_root_for_path(path)
+        dead_findings = [
+            finding
+            for finding in dead_findings
+            if _finding_key(finding, project_root_path) not in protected_definitions
+        ]
     if not dead_findings:
         console.print("\n[dim]No confirmed dead code to fix[/dim]")
         return
@@ -426,7 +526,9 @@ def _confirmed_dead_findings(
     new_dead: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     return [
-        finding for finding in verified if finding.get("_llm_verdict") == "TRUE_POSITIVE"
+        finding
+        for finding in verified
+        if finding.get("_llm_verdict") == "TRUE_POSITIVE"
     ] + (new_dead or [])
 
 

--- a/skylos/commands/agent_verify_cmd.py
+++ b/skylos/commands/agent_verify_cmd.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.table import Table
 
 from skylos.analysis.errors import analysis_result_incomplete
+from skylos.core.safe_cache_io import write_text_no_symlink
 
 
 UploadAgentRun = Callable[..., None]
@@ -182,7 +183,8 @@ def run_agent_verify_command(
     verified = result["verified_findings"]
     new_dead = result["new_dead_code"]
 
-    _write_or_print_verify_result(args, console, result)
+    if not _write_or_print_verify_result(args, console, result):
+        return 2
     _print_verify_summary(args, console, result, stats, verified, new_dead)
     _print_net_result(console, stats)
 
@@ -349,21 +351,22 @@ def _run_verification_harness(
 
 def _write_or_print_verify_result(
     args, console: Console, result: dict[str, Any]
-) -> None:
+) -> bool:
     if args.format != "json":
-        return
+        return True
 
     output = json.dumps(result, indent=2, default=str)
     if args.output:
-        pathlib.Path(
-            args.output
-        ).write_text(  # skylos: ignore[SKY-D215] user-selected CLI output path
-            output,
-            encoding="utf-8",
-        )
+        if not write_text_no_symlink(args.output, output, encoding="utf-8"):
+            console.print(
+                "[bad]Cannot safely write output: use a writable regular file "
+                "with no symlinks or hard links and an existing parent directory.[/bad]"
+            )
+            return False
         console.print(f"[dim]Written to {args.output}[/dim]")
     else:
         print(output)
+    return True
 
 
 def _print_verify_summary(

--- a/skylos/commands/baseline_cmd.py
+++ b/skylos/commands/baseline_cmd.py
@@ -1,25 +1,60 @@
 import json
+from pathlib import Path
 
 from rich.console import Console
 
 from skylos import analyze as run_analyze
+from skylos.config import load_config, resolve_config_file_path
+from skylos.constants import parse_exclude_folders
 from skylos.core.baseline import save_baseline
+
+
+def _baseline_scan_roots(path: str) -> tuple[Path, Path]:
+    target = Path(path).expanduser().resolve()
+    scan_root = target.parent if target.is_file() else target
+    from skylos.core.file_discovery import find_git_root
+
+    return target, find_git_root(scan_root) or scan_root
 
 
 def run_baseline_command(argv: list[str]) -> int:
     path = argv[0] if argv else "."
+    _target, project_root = _baseline_scan_roots(path)
+
+    config_file = resolve_config_file_path()
+    project_config = load_config(project_root, config_file=config_file)
+    exclude_folders = parse_exclude_folders(
+        config_exclude_folders=project_config.get("exclude"),
+    )
+
+    from skylos.core.review_decisions import (
+        apply_trusted_review_decisions,
+        review_scan_requirements,
+    )
+
+    include_review_context, include_review_proofs = review_scan_requirements(
+        project_root
+    )
+    analyze_kwargs = {
+        "enable_danger": True,
+        "enable_quality": True,
+        "enable_secrets": True,
+        "enable_ai_defects": True,
+        "exclude_folders": sorted(exclude_folders),
+    }
+    if config_file is not None:
+        analyze_kwargs["config_file"] = config_file
+    if include_review_context:
+        analyze_kwargs["include_review_context"] = True
+    if include_review_proofs:
+        analyze_kwargs["include_review_proofs"] = True
 
     console = Console()
     console.print(f"[bold]Creating baseline for {path}...[/bold]")
 
-    result = json.loads(
-        run_analyze(
-            path,
-            enable_danger=True,
-            enable_quality=True,
-            enable_secrets=True,
-            enable_ai_defects=True,
-        )
+    result = apply_trusted_review_decisions(
+        json.loads(run_analyze(path, **analyze_kwargs)),
+        project_root,
     )
     baseline_path = save_baseline(path, result)
     total = sum(

--- a/skylos/commands/cicd_cmd.py
+++ b/skylos/commands/cicd_cmd.py
@@ -8,7 +8,7 @@ import subprocess
 REVIEW_SIDECAR_MAX_BYTES = 2 * 1024 * 1024
 
 
-def _cicd_load_results(args, *, console_factory):
+def _cicd_load_results(args, *, console_factory, load_config_func):
     if getattr(args, "input_file", None):
         try:
             with open(args.input_file) as f:
@@ -22,13 +22,40 @@ def _cicd_load_results(args, *, console_factory):
     path = getattr(args, "path", ".")
     try:
         from skylos import analyze
+        from skylos.config import resolve_config_file_path
+        from skylos.constants import parse_exclude_folders
+        from skylos.core.file_discovery import find_git_root
+        from skylos.core.review_decisions import (
+            apply_trusted_review_decisions,
+            review_scan_requirements,
+        )
+
+        target = Path(path).expanduser().resolve()
+        scan_root = target.parent if target.is_file() else target
+        project_root = find_git_root(scan_root) or scan_root
+        config_file = resolve_config_file_path()
+        project_config = load_config_func(project_root)
+        exclude_folders = parse_exclude_folders(
+            config_exclude_folders=project_config.get("exclude"),
+        )
+        include_review_context, include_review_proofs = review_scan_requirements(
+            project_root
+        )
+        analyze_kwargs = {"exclude_folders": sorted(exclude_folders)}
+        if config_file is not None:
+            analyze_kwargs["config_file"] = config_file
+        if include_review_context:
+            analyze_kwargs["include_review_context"] = True
+        if include_review_proofs:
+            analyze_kwargs["include_review_proofs"] = True
 
         previous_diff_base = os.environ.get("SKYLOS_DIFF_BASE")
         diff_base = getattr(args, "diff_base", None)
         try:
             if diff_base:
                 os.environ["SKYLOS_DIFF_BASE"] = diff_base
-            return json.loads(analyze(path)), 0
+            result = json.loads(analyze(path, **analyze_kwargs))
+            return apply_trusted_review_decisions(result, project_root), 0
         finally:
             if diff_base:
                 if previous_diff_base is None:
@@ -98,9 +125,7 @@ def _review_sidecar_path(raw_path: str, *, label: str) -> Path:
     path = Path(raw)
     if not path.is_absolute():
         if path.name != raw:
-            raise ValueError(
-                f"{label} must be a filename in the current directory"
-            )
+            raise ValueError(f"{label} must be a filename in the current directory")
         return path
 
     runner_temp = os.environ.get("RUNNER_TEMP")
@@ -290,7 +315,9 @@ def run_cicd_command(
 
     if cicd_args.cicd_cmd == "gate":
         results, exit_code = _cicd_load_results(
-            cicd_args, console_factory=console_factory
+            cicd_args,
+            console_factory=console_factory,
+            load_config_func=load_config_func,
         )
         if exit_code:
             return exit_code
@@ -321,7 +348,9 @@ def run_cicd_command(
 
     if cicd_args.cicd_cmd == "annotate":
         results, exit_code = _cicd_load_results(
-            cicd_args, console_factory=console_factory
+            cicd_args,
+            console_factory=console_factory,
+            load_config_func=load_config_func,
         )
         if exit_code:
             return exit_code
@@ -337,7 +366,9 @@ def run_cicd_command(
         from skylos.cicd.review import run_pr_review
 
         results, exit_code = _cicd_load_results(
-            cicd_args, console_factory=console_factory
+            cicd_args,
+            console_factory=console_factory,
+            load_config_func=load_config_func,
         )
         if exit_code:
             return exit_code

--- a/skylos/commands/clean_cmd.py
+++ b/skylos/commands/clean_cmd.py
@@ -147,7 +147,25 @@ def _analyze(path, confidence, exclude_folders):
     kwargs = {"exclude_folders": sorted(exclude_folders)}
     if confidence is not None:
         kwargs["conf"] = confidence
-    return json.loads(run_analyze(path, **kwargs))
+    scan_root = Path(path).resolve()
+    if scan_root.is_file():
+        scan_root = scan_root.parent
+    from skylos.core.file_discovery import find_git_root
+    from skylos.core.review_decisions import (
+        apply_trusted_review_decisions,
+        review_scan_requirements,
+    )
+
+    project_root = find_git_root(scan_root) or scan_root
+    include_review_context, include_review_proofs = review_scan_requirements(
+        project_root
+    )
+    if include_review_context:
+        kwargs["include_review_context"] = True
+    if include_review_proofs:
+        kwargs["include_review_proofs"] = True
+    result = json.loads(run_analyze(path, **kwargs))
+    return apply_trusted_review_decisions(result, project_root)
 
 
 def _collect_all_findings(result):

--- a/skylos/commands/review_cmd.py
+++ b/skylos/commands/review_cmd.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from rich.console import Console
+from rich.markup import escape
+from rich.table import Table
+
+from skylos import analyze as run_analyze
+from skylos.cicd.evidence import sanitize_untrusted_text
+from skylos.config import load_config, resolve_config_file_path
+from skylos.constants import parse_exclude_folders
+from skylos.core import review_decisions
+
+
+_FALSE_POSITIVE = "false_positive"
+_RISK_ACCEPTED = "risk_accepted"
+_LOCAL_DISPOSITIONS = {_FALSE_POSITIVE, _RISK_ACCEPTED}
+_MAX_REASON_LENGTH = 2_000
+_MAX_ACCEPTANCE_DAYS = 365
+
+
+def _safe_display(value: Any, maximum: int) -> str:
+    return escape(
+        sanitize_untrusted_text(
+            value,
+            max_length=maximum,
+            preserve_newlines=False,
+            neutralize_mentions=False,
+        )
+    )
+
+
+def _build_list_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="skylos review list",
+        description="List locally reviewed findings for a repository.",
+    )
+    parser.add_argument("path", nargs="?", default=".", help="Repository path")
+    return parser
+
+
+def _build_restore_parser(command: str) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=f"skylos review {command}",
+        description="Restore a finding by revoking its local review decision.",
+    )
+    parser.add_argument("decision_id", help="Decision ID shown by `skylos review list`")
+    parser.add_argument("path", nargs="?", default=".", help="Repository path")
+    return parser
+
+
+def _build_add_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="skylos review",
+        description="Scan a repository and record a local review decision.",
+    )
+    parser.add_argument("path", nargs="?", default=".", help="Path to scan")
+    return parser
+
+
+def _environment(environ: Mapping[str, str] | None) -> dict[str, str]:
+    return dict(os.environ if environ is None else environ)
+
+
+def _is_ci(environ: Mapping[str, str]) -> bool:
+    return review_decisions.is_ci_environment(dict(environ))
+
+
+def _resolve_target(raw_path: str) -> tuple[Path, Path]:
+    target = Path(raw_path).expanduser().resolve(strict=True)
+    scan_root = target.parent if target.is_file() else target
+    from skylos.core.file_discovery import find_git_root
+
+    project_root = find_git_root(scan_root) or scan_root
+    return target, project_root
+
+
+def _scan_reviewable_findings(
+    target: Path,
+    project_root: Path,
+    *,
+    environ: dict[str, str],
+    now: datetime,
+    trusted_cache_root: str | Path | None,
+    local_cache_root: str | Path | None,
+) -> list[dict[str, Any]]:
+    config_file = resolve_config_file_path()
+    project_config = load_config(project_root, config_file=config_file)
+    exclude_folders = parse_exclude_folders(
+        config_exclude_folders=project_config.get("exclude"),
+    )
+    raw = run_analyze(
+        str(target),
+        enable_danger=True,
+        enable_quality=True,
+        enable_secrets=True,
+        enable_ai_defects=True,
+        include_review_proofs=True,
+        include_review_context=True,
+        exclude_folders=list(exclude_folders),
+        config_file=config_file,
+    )
+    result = json.loads(raw)
+    if not isinstance(result, dict):
+        raise ValueError("Skylos returned an invalid scan result")
+    annotated = review_decisions.apply_trusted_review_decisions(
+        result,
+        project_root,
+        cache_root=trusted_cache_root,
+        local_cache_root=local_cache_root,
+        environ=environ,
+        now=now,
+        include_identities=True,
+    )
+
+    findings: list[dict[str, Any]] = []
+    for section, category, _default_rule_id in review_decisions.FINDING_SECTIONS:
+        for raw_finding in annotated.get(section, []) or []:
+            if not isinstance(raw_finding, dict):
+                continue
+            if not all(
+                raw_finding.get(key)
+                for key in (
+                    "fingerprint_version",
+                    "stable_fingerprint",
+                    "context_hash",
+                    "rule_revision",
+                )
+            ):
+                continue
+            finding = dict(raw_finding)
+            finding["_review_section"] = section
+            finding["_review_category"] = category
+            findings.append(finding)
+    return findings
+
+
+def _finding_location(finding: Mapping[str, Any]) -> str:
+    path = str(finding.get("file_path") or finding.get("file") or "unknown")
+    line = finding.get("line_number") or finding.get("line") or 1
+    return f"{path}:{line}"
+
+
+def _finding_message(finding: Mapping[str, Any]) -> str:
+    message = (
+        finding.get("message")
+        or finding.get("detail")
+        or finding.get("name")
+        or finding.get("symbol")
+        or "Finding"
+    )
+    return str(message).replace("\n", " ")[:180]
+
+
+def _finding_review_signal(finding: Mapping[str, Any]) -> str:
+    raw_confidence = finding.get("confidence")
+    if raw_confidence is None:
+        raw_confidence = finding.get("_confidence")
+    if isinstance(raw_confidence, bool):
+        confidence = ""
+    elif isinstance(raw_confidence, (int, float)):
+        confidence = f"{max(0, min(100, round(float(raw_confidence))))}%"
+    elif isinstance(raw_confidence, str):
+        confidence = raw_confidence.strip().upper()[:20]
+    else:
+        confidence = ""
+    needs_review = any(
+        finding.get(key) is True
+        for key in ("needs_review", "_needs_review", "_llm_uncertain")
+    ) or confidence in {"LOW", "MEDIUM", "UNCERTAIN"}
+    if needs_review:
+        return f"{confidence} · NEEDS REVIEW" if confidence else "NEEDS REVIEW"
+    return confidence or "—"
+
+
+def _render_findings(console: Console, findings: list[dict[str, Any]]) -> None:
+    console.print(
+        "[dim]A decision applies only while this finding's relevant code and "
+        "analyzer evidence still match. Material changes bring it back.[/dim]"
+    )
+    table = Table(title="Findings available for review", show_lines=False)
+    table.add_column("#", justify="right", style="cyan")
+    table.add_column("Severity")
+    table.add_column("Rule")
+    table.add_column("Location")
+    table.add_column("Signal")
+    table.add_column("Finding")
+    for index, finding in enumerate(findings, start=1):
+        table.add_row(
+            str(index),
+            _safe_display(finding.get("severity") or "—", 20),
+            _safe_display(finding.get("rule_id") or "UNKNOWN", 120),
+            _safe_display(_finding_location(finding), 300),
+            _safe_display(_finding_review_signal(finding), 40),
+            _safe_display(_finding_message(finding), 180),
+        )
+    console.print(table)
+
+
+def _prompt_index(
+    findings: list[dict[str, Any]], input_fn: Callable[[str], str]
+) -> int | None:
+    try:
+        raw = input_fn("Select a finding number, or q to cancel: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+    if raw.lower() in {"q", "quit", "cancel", ""}:
+        return None
+    try:
+        index = int(raw)
+    except ValueError:
+        return -1
+    return index - 1 if 1 <= index <= len(findings) else -1
+
+
+def _prompt_disposition(input_fn: Callable[[str], str]) -> str | None:
+    try:
+        raw = (
+            input_fn(
+                "Decision: [1] false positive  [2] accept risk temporarily  [q] cancel: "
+            )
+            .strip()
+            .lower()
+        )
+    except (EOFError, KeyboardInterrupt):
+        return None
+    return {
+        "1": _FALSE_POSITIVE,
+        _FALSE_POSITIVE: _FALSE_POSITIVE,
+        "2": _RISK_ACCEPTED,
+        _RISK_ACCEPTED: _RISK_ACCEPTED,
+    }.get(raw)
+
+
+def _prompt_reason(input_fn: Callable[[str], str]) -> str | None:
+    try:
+        reason = input_fn("Reason (required): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+    if not reason or len(reason) > _MAX_REASON_LENGTH or "\x00" in reason:
+        return None
+    return reason
+
+
+def _prompt_expiry_days(input_fn: Callable[[str], str]) -> int | None:
+    try:
+        raw = input_fn("Expires in days [30]: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+    if not raw:
+        return 30
+    try:
+        days = int(raw)
+    except ValueError:
+        return None
+    return days if 1 <= days <= _MAX_ACCEPTANCE_DAYS else None
+
+
+def _decision_from_finding(
+    finding: Mapping[str, Any],
+    *,
+    disposition: str,
+    reason: str,
+    now: datetime,
+    expiry_days: int | None,
+) -> dict[str, Any]:
+    if disposition not in _LOCAL_DISPOSITIONS:
+        raise ValueError("unsupported local review disposition")
+    decision = {
+        "decision_id": str(uuid.uuid4()),
+        "fingerprint_version": finding["fingerprint_version"],
+        "stable_fingerprint": finding["stable_fingerprint"],
+        "context_hash": finding["context_hash"],
+        "rule_revision": finding["rule_revision"],
+        "rule_id": finding["rule_id"],
+        "file_path": finding["file_path"],
+        "line_number": int(finding.get("line_number") or finding.get("line") or 1),
+        "language": finding["language"],
+        "symbol": finding["symbol"],
+        "section": finding["section"],
+        "category": finding["_review_category"],
+        "disposition": disposition,
+        "reason": reason,
+        "created_at": now.isoformat().replace("+00:00", "Z"),
+        "source": "local_cli",
+    }
+    if disposition == _RISK_ACCEPTED:
+        if expiry_days is None:
+            raise ValueError("risk acceptance requires an expiry")
+        decision["expires_at"] = (
+            (now + timedelta(days=expiry_days)).isoformat().replace("+00:00", "Z")
+        )
+    return decision
+
+
+def _choose_finding(
+    console: Console,
+    findings: list[dict[str, Any]],
+    input_fn: Callable[[str], str],
+) -> dict[str, Any] | None:
+    _render_findings(console, findings)
+    selected = _prompt_index(findings, input_fn)
+    if selected is None:
+        console.print("[dim]Review cancelled.[/dim]")
+        return None
+    if selected < 0:
+        raise ValueError("Invalid finding number.")
+    return findings[selected]
+
+
+def _prompt_decision_details(
+    input_fn: Callable[[str], str],
+) -> tuple[str, str, int | None]:
+    disposition = _prompt_disposition(input_fn)
+    if disposition is None:
+        raise ValueError("Choose false positive or temporary risk acceptance.")
+    reason = _prompt_reason(input_fn)
+    if reason is None:
+        raise ValueError(
+            f"Reason is required and must be at most {_MAX_REASON_LENGTH} characters."
+        )
+    expiry_days = None
+    if disposition == _RISK_ACCEPTED:
+        expiry_days = _prompt_expiry_days(input_fn)
+        if expiry_days is None:
+            raise ValueError(
+                f"Expiry must be between 1 and {_MAX_ACCEPTANCE_DAYS} days."
+            )
+    return disposition, reason, expiry_days
+
+
+def _select_review_decision(
+    console: Console,
+    findings: list[dict[str, Any]],
+    input_fn: Callable[[str], str],
+    now: datetime,
+) -> tuple[dict[str, Any], str] | None:
+    finding = _choose_finding(console, findings, input_fn)
+    if finding is None:
+        return None
+    disposition, reason, expiry_days = _prompt_decision_details(input_fn)
+    decision = _decision_from_finding(
+        finding,
+        disposition=disposition,
+        reason=reason,
+        now=now,
+        expiry_days=expiry_days,
+    )
+    return decision, disposition
+
+
+def _record_review_decision(
+    project_root: Path,
+    decision: dict[str, Any],
+    *,
+    disposition: str,
+    console: Console,
+    environ: dict[str, str],
+    now: datetime,
+    local_cache_root: str | Path | None,
+) -> int:
+    try:
+        saved = review_decisions.record_local_decision(
+            project_root,
+            decision,
+            environ=environ,
+            cache_root=local_cache_root,
+            now=now,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        console.print(
+            f"[red]Could not save review decision:[/red] {_safe_display(exc, 500)}"
+        )
+        return 2
+    if not saved:
+        console.print("[red]Could not save review decision securely.[/red]")
+        return 2
+
+    label = "false positive" if disposition == _FALSE_POSITIVE else "accepted risk"
+    decision_id = _safe_display(decision["decision_id"], 200)
+    console.print(f"[green]Recorded {label}.[/green]")
+    if disposition == _FALSE_POSITIVE:
+        console.print(
+            "[dim]Future local scans will exclude this exact finding while its "
+            "relevant code and evidence still match.[/dim]"
+        )
+    else:
+        console.print(
+            "[dim]Future local scans will exclude this exact finding until "
+            f"{_safe_display(decision.get('expires_at') or 'expiry', 80)}, unless "
+            "its relevant code or evidence changes first.[/dim]"
+        )
+    console.print(
+        f"[dim]Decision {decision_id}; restore with "
+        f"`skylos review restore {decision_id}`.[/dim]"
+    )
+    return 0
+
+
+def _run_add(
+    path: str,
+    *,
+    console: Console,
+    input_fn: Callable[[str], str],
+    environ: dict[str, str],
+    now: datetime,
+    trusted_cache_root: str | Path | None,
+    local_cache_root: str | Path | None,
+) -> int:
+    if _is_ci(environ):
+        console.print("[red]Local review decisions cannot be created in CI.[/red]")
+        return 2
+    try:
+        target, project_root = _resolve_target(path)
+        findings = _scan_reviewable_findings(
+            target,
+            project_root,
+            environ=environ,
+            now=now,
+            trusted_cache_root=trusted_cache_root,
+            local_cache_root=local_cache_root,
+        )
+    except Exception as exc:
+        console.print(f"[red]Review scan failed:[/red] {_safe_display(exc, 500)}")
+        return 2
+
+    if not findings:
+        console.print(
+            "[green]No findings with stable review identity were found.[/green]"
+        )
+        return 0
+    try:
+        selected = _select_review_decision(console, findings, input_fn, now)
+    except ValueError as exc:
+        console.print(f"[red]{_safe_display(exc, 500)}[/red]")
+        return 2
+    if selected is None:
+        return 0
+    decision, disposition = selected
+    return _record_review_decision(
+        project_root,
+        decision,
+        disposition=disposition,
+        console=console,
+        environ=environ,
+        now=now,
+        local_cache_root=local_cache_root,
+    )
+
+
+def _run_list(
+    path: str,
+    *,
+    console: Console,
+    environ: dict[str, str],
+    local_cache_root: str | Path | None,
+) -> int:
+    if _is_ci(environ):
+        console.print("[dim]Local review decisions are ignored in CI.[/dim]")
+        return 0
+    try:
+        _target, project_root = _resolve_target(path)
+        decisions = review_decisions.list_local_decisions(
+            project_root,
+            include_revoked=True,
+            environ=environ,
+            cache_root=local_cache_root,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        console.print(
+            f"[red]Could not load review decisions:[/red] {_safe_display(exc, 500)}"
+        )
+        return 2
+    if not decisions:
+        console.print("[dim]No local review decisions.[/dim]")
+        return 0
+
+    console.print(_local_decisions_table(decisions))
+    return 0
+
+
+def _local_decisions_table(decisions: list[dict[str, Any]]) -> Table:
+    table = Table(title="Local review decisions")
+    table.add_column("Decision ID")
+    table.add_column("Disposition")
+    table.add_column("Finding")
+    table.add_column("Expires")
+    table.add_column("Reason")
+    for decision in decisions:
+        if isinstance(decision, dict):
+            table.add_row(*_local_decision_row(decision))
+    return table
+
+
+def _local_decision_row(decision: dict[str, Any]) -> tuple[str, ...]:
+    state = (
+        "revoked"
+        if decision.get("revoked_at")
+        else str(decision.get("disposition") or "unknown")
+    )
+    location = (
+        f"{decision.get('rule_id') or 'UNKNOWN'}  "
+        f"{decision.get('file_path') or 'unknown'}:"
+        f"{decision.get('line_number') or 1}"
+    )
+    return (
+        _safe_display(decision.get("decision_id") or decision.get("id") or "", 200),
+        _safe_display(state, 40),
+        _safe_display(location, 400),
+        _safe_display(decision.get("expires_at") or "never", 80),
+        _safe_display(decision.get("reason") or "", 300),
+    )
+
+
+def _run_restore(
+    path: str,
+    decision_id: str,
+    *,
+    console: Console,
+    environ: dict[str, str],
+    local_cache_root: str | Path | None,
+    now: datetime,
+) -> int:
+    if _is_ci(environ):
+        console.print("[red]Local review decisions cannot be changed in CI.[/red]")
+        return 2
+    try:
+        _target, project_root = _resolve_target(path)
+        restored = review_decisions.revoke_local_decision(
+            project_root,
+            decision_id,
+            environ=environ,
+            cache_root=local_cache_root,
+            now=now,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        console.print(
+            f"[red]Could not restore finding:[/red] {_safe_display(exc, 500)}"
+        )
+        return 2
+    if not restored:
+        console.print(
+            f"[red]Active decision not found:[/red] {_safe_display(decision_id, 200)}"
+        )
+        return 2
+    console.print(
+        "[green]Restored finding by revoking "
+        f"{_safe_display(decision_id, 200)}.[/green]"
+    )
+    return 0
+
+
+def run_review_command(
+    argv: list[str],
+    *,
+    console_factory: Callable[[], Console] = Console,
+    input_fn: Callable[[str], str] = input,
+    environ: Mapping[str, str] | None = None,
+    now: datetime | None = None,
+    trusted_cache_root: str | Path | None = None,
+    local_cache_root: str | Path | None = None,
+) -> int:
+    console = console_factory()
+    env = _environment(environ)
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    else:
+        current = current.astimezone(timezone.utc)
+
+    if argv and argv[0] == "list":
+        args = _build_list_parser().parse_args(argv[1:])
+        return _run_list(
+            args.path,
+            console=console,
+            environ=env,
+            local_cache_root=local_cache_root,
+        )
+    if argv and argv[0] in {"restore", "revoke"}:
+        args = _build_restore_parser(argv[0]).parse_args(argv[1:])
+        return _run_restore(
+            args.path,
+            args.decision_id,
+            console=console,
+            environ=env,
+            local_cache_root=local_cache_root,
+            now=current,
+        )
+
+    args = _build_add_parser().parse_args(argv)
+    return _run_add(
+        args.path,
+        console=console,
+        input_fn=input_fn,
+        environ=env,
+        now=current,
+        trusted_cache_root=trusted_cache_root,
+        local_cache_root=local_cache_root,
+    )

--- a/skylos/commands/scan_cmd.py
+++ b/skylos/commands/scan_cmd.py
@@ -107,6 +107,12 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
     changed_files = pre_analysis.changed_files
     trace_file = pre_analysis.trace_file
 
+    from skylos.core.review_decisions import review_scan_requirements
+
+    review_context_needed, review_proofs_needed = review_scan_requirements(project_root)
+    include_review_context = bool(args.upload) or review_context_needed
+    include_review_proofs = bool(args.upload) or review_proofs_needed
+
     try:
         if len(args.path) > 1:
             scan_path = args.path
@@ -133,6 +139,8 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                 trace_file=trace_file,
                 config_file=config_file,
                 required_config_rules=args.select,
+                include_review_proofs=include_review_proofs,
+                include_review_context=include_review_context,
             )
 
         quiet_analysis_output = (
@@ -188,18 +196,6 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
             except Exception as e:
                 if args.verbose:
                     console.print(f"[warn]SCA scan error: {e}[/warn]")
-
-        if args.baseline:
-            from skylos.core.baseline import load_baseline, filter_new_findings
-
-            baseline = load_baseline(project_root)
-            if baseline is None:
-                console.print(
-                    "[warn]No baseline found. Run 'skylos baseline .' first.[/warn]"
-                )
-            else:
-                result = filter_new_findings(result, baseline)
-                result_json = json.dumps(result)
 
         if changed_files is not None:
             for category in [
@@ -417,6 +413,39 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                 if args.verbose:
                     console.print(f"[warn]Provenance annotation failed: {e}[/warn]")
 
+        from skylos.core.review_decisions import apply_trusted_review_decisions
+
+        result = apply_trusted_review_decisions(
+            result,
+            project_root,
+            include_identities=bool(args.upload),
+        )
+        reviewed_count = int(
+            (result.get("reviewed_findings_summary") or {}).get("suppressed_count", 0)
+            or 0
+        )
+        if reviewed_count and not machine_output:
+            console.print(
+                "[muted]Reviewed decisions:[/muted] "
+                f"{reviewed_count} finding{'s' if reviewed_count != 1 else ''} "
+                "excluded from local results (retained for audit and upload)."
+            )
+
+        if args.baseline:
+            from skylos.core.baseline import load_baseline, filter_new_findings
+
+            baseline = load_baseline(project_root)
+            if baseline is None:
+                console.print(
+                    "[warn]No baseline found. Run 'skylos baseline .' first.[/warn]"
+                )
+            else:
+                result = filter_new_findings(result, baseline)
+
+        json_result = dict(result)
+        if _skip_provenance and json_result.get("provenance") is None:
+            json_result.pop("provenance", None)
+        result_json = json.dumps(json_result)
         output_result = result
         json_output_result = json.loads(result_json)
         _cli_severity = getattr(args, "severity", None)
@@ -436,6 +465,27 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                 file_filter=_cli_file_filter,
             )
         output_result_json = json.dumps(json_output_result)
+
+        def upload_formatted_result() -> None:
+            if not args.upload:
+                return
+            _attach_upload_project_context(result, project_root)
+            upload_resp = upload_report(
+                result,
+                is_forced=args.force,
+                strict=args.strict,
+                quiet=True,
+                analyzer_owned=True,
+            )
+            if not upload_resp.get("success"):
+                raise SystemExit(1)
+            cloud_gate_passed = upload_resp.get("quality_gate_passed")
+            if cloud_gate_passed is None:
+                cloud_gate_passed = (upload_resp.get("quality_gate") or {}).get(
+                    "passed", True
+                )
+            if cloud_gate_passed is False and not args.force:
+                raise SystemExit(1)
 
         if args.sarif:
             all_findings = []
@@ -515,6 +565,13 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                 "DEAD_CODE",
                 "SKYLOS-DEADCODE-UNUSED_PARAMETER",
             )
+            for reviewed in output_result.get("reviewed_findings", []) or []:
+                if isinstance(reviewed, dict):
+                    _add(
+                        [reviewed],
+                        str(reviewed.get("category") or "QUALITY").upper(),
+                        None,
+                    )
 
             exporter = _get_sarif_exporter_class()(
                 all_findings,
@@ -539,24 +596,7 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
             if incomplete_exit_code == 2:
                 raise SystemExit(incomplete_exit_code)
 
-            if args.upload:
-                _attach_upload_project_context(result, project_root)
-                upload_resp = upload_report(
-                    result,
-                    is_forced=args.force,
-                    strict=args.strict,
-                    quiet=True,
-                    analyzer_owned=True,
-                )
-                if not upload_resp.get("success"):
-                    raise SystemExit(1)
-
-                passed = upload_resp.get("quality_gate_passed")
-                if passed is None:
-                    passed = (upload_resp.get("quality_gate") or {}).get("passed", True)
-
-                if passed is False and not args.force:
-                    raise SystemExit(1)
+            upload_formatted_result()
 
             if args.gate:
                 exit_code = _formatted_output_gate_exit_code(
@@ -588,6 +628,8 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
             elif concise_output:
                 print(concise_output, end="")
 
+            upload_formatted_result()
+
             exit_code = _concise_scan_exit_code(
                 result,
                 config,
@@ -604,6 +646,8 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
                 _write_scan_output(args.output, llm_report)
             else:
                 print(llm_report)
+
+            upload_formatted_result()
 
             if args.gate:
                 exit_code = _formatted_output_gate_exit_code(
@@ -622,6 +666,7 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
 
         if args.github:
             _emit_github_annotations(output_result)
+            upload_formatted_result()
             if args.gate:
                 exit_code = _formatted_output_gate_exit_code(
                     result,
@@ -672,6 +717,14 @@ def run_scan_command(argv: Sequence[str], *, cli_module: ModuleType) -> None:
             if not upload_resp.get("success"):
                 _render_upload_failure(console, upload_resp)
                 if getattr(args, "_explicit_upload_requested", False):
+                    raise SystemExit(1)
+            else:
+                cloud_gate_passed = upload_resp.get("quality_gate_passed")
+                if cloud_gate_passed is None:
+                    cloud_gate_passed = (upload_resp.get("quality_gate") or {}).get(
+                        "passed", True
+                    )
+                if cloud_gate_passed is False and not args.force:
                     raise SystemExit(1)
 
         exit_code = run_gate_interaction(

--- a/skylos/commands/suite_cmd.py
+++ b/skylos/commands/suite_cmd.py
@@ -19,6 +19,16 @@ _VALID_STATIC_UPLOAD_CATEGORIES = (
     "dependency",
 )
 
+_REVIEW_CATEGORY_TO_STATIC_UPLOAD_CATEGORY = {
+    "SECURITY": "danger",
+    "RELIABILITY": "reliability",
+    "AI_DEFECT": "ai_defects",
+    "QUALITY": "quality",
+    "SECRET": "secrets",
+    "DEAD_CODE": "dead_code",
+    "DEPENDENCY": "dependency",
+}
+
 
 def _parse_csv_selection(raw: str | None, valid_values: tuple[str, ...]) -> list[str]:
     if not raw:
@@ -48,7 +58,7 @@ def _build_static_upload_result(
 ) -> dict:
     category_set = set(static_categories)
     payload = {
-        "analysis_summary": static_result.get("analysis_summary") or {},
+        "analysis_summary": dict(static_result.get("analysis_summary") or {}),
     }
     if "provenance" in static_result:
         payload["provenance"] = static_result.get("provenance")
@@ -83,6 +93,22 @@ def _build_static_upload_result(
             "unused_files",
         ):
             payload[key] = list(static_result.get(key) or [])
+
+    reviewed = [
+        dict(finding)
+        for finding in static_result.get("reviewed_findings", []) or []
+        if isinstance(finding, dict)
+        and _REVIEW_CATEGORY_TO_STATIC_UPLOAD_CATEGORY.get(
+            str(finding.get("category") or "").strip().upper()
+        )
+        in category_set
+    ]
+    if "reviewed_findings" in static_result:
+        review_summary = dict(static_result.get("reviewed_findings_summary") or {})
+        review_summary["suppressed_count"] = len(reviewed)
+        payload["reviewed_findings"] = reviewed
+        payload["reviewed_findings_summary"] = review_summary
+        payload["analysis_summary"]["reviewed_findings"] = dict(review_summary)
 
     return payload
 
@@ -214,6 +240,7 @@ def _run_suite_report(
     progress_factory,
     run_analyze_func,
     get_git_root_func,
+    include_review_identities: bool,
 ):
     try:
         report = run_suite(
@@ -227,6 +254,7 @@ def _run_suite_report(
             no_provenance=args.no_provenance,
             diff_base=args.diff_base,
             get_git_root_func=get_git_root_func,
+            include_review_identities=include_review_identities,
         )
     except (FileNotFoundError, ValueError, ImportError) as exc:
         console.print(f"[bold red]Suite error: {exc}[/bold red]")
@@ -325,6 +353,7 @@ def _upload_static_suite_family(
         static_upload_result,
         quiet=args.output_json,
         scan_bundle_id=scan_bundle_id,
+        analyzer_owned=True,
     )
     if not static_upload.get("success"):
         if not args.output_json:
@@ -489,6 +518,7 @@ def run_suite_command(
         progress_factory=progress_factory,
         run_analyze_func=run_analyze_func,
         get_git_root_func=get_git_root_func,
+        include_review_identities=bool(args.upload and "static" in selected_families),
     )
     if suite_error:
         return suite_error

--- a/skylos/core/file_discovery.py
+++ b/skylos/core/file_discovery.py
@@ -6,6 +6,11 @@ from fnmatch import fnmatchcase
 from collections.abc import Iterable, Sequence
 from pathlib import Path
 
+from skylos.core.git_safety import (
+    read_only_git_command,
+    read_only_git_environment,
+)
+
 
 def _normalize_path_text(value: str) -> str:
     return value.replace("\\", "/").rstrip("/")
@@ -40,7 +45,9 @@ def _absolute_exclude_candidate(exclude_folder: str, root_path: Path) -> str | N
     return _normalize_path_text(str(rel))
 
 
-def _root_prefixed_exclude_candidate(exclude_normalized: str, root_path: Path) -> str | None:
+def _root_prefixed_exclude_candidate(
+    exclude_normalized: str, root_path: Path
+) -> str | None:
     if "/" not in exclude_normalized:
         return None
 
@@ -180,15 +187,19 @@ def list_git_visible_files(path: str | Path) -> list[Path] | None:
     if target.is_file():
         target = target.parent
 
-    cmd = [
-        "git",
-        "-C",
-        str(root),
-        "ls-files",
-        "-co",
-        "--exclude-standard",
-        "--full-name",
-    ]
+    cmd = read_only_git_command(
+        [
+            "-C",
+            str(root),
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--full-name",
+        ],
+        literal_pathspecs=True,
+    )
 
     if target != root:
         try:
@@ -201,20 +212,21 @@ def list_git_visible_files(path: str | Path) -> list[Path] | None:
         result = subprocess.run(
             cmd,
             capture_output=True,
-            text=True,
             check=False,
+            env=read_only_git_environment(),
+            timeout=10,
         )
-    except (OSError, ValueError):
+    except (OSError, subprocess.SubprocessError, ValueError):
         return None
 
     if result.returncode != 0:
         return None
 
     files = []
-    for line in result.stdout.splitlines():
-        rel_path = line.strip()
-        if not rel_path:
+    for raw_path in result.stdout.split(b"\0"):
+        if not raw_path:
             continue
+        rel_path = os.fsdecode(raw_path)
         files.append(root / rel_path)
 
     files.sort()

--- a/skylos/core/git_context.py
+++ b/skylos/core/git_context.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
 from skylos.core.file_discovery import find_git_root
+from skylos.core.git_safety import (
+    read_only_git_command,
+    read_only_git_environment,
+)
 
 
 _REPOSITORY_ENV = (
@@ -16,6 +21,18 @@ _REPOSITORY_ENV = (
     "GIT_PREFIX",
     "GIT_INTERNAL_SUPER_PREFIX",
 )
+_FILTER_CONFIG_KEY_RE = re.compile(
+    r"^filter\.(?P<driver>.+)\.(?:clean|smudge|process|required)$",
+    re.IGNORECASE,
+)
+_DIFF_CONFIG_KEY_RE = re.compile(
+    r"^diff\.(?P<driver>.+)\.(?:command|textconv|cachetextconv|trustExitCode)$",
+    re.IGNORECASE,
+)
+_SAFE_FILTER_DRIVER_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_MAX_FILTER_DRIVERS = 128
+_MAX_FILTER_DRIVER_LENGTH = 128
+_MAX_FILTER_CONFIG_OUTPUT = 128_000
 
 
 def _absolute_env_path(value: str, cwd: Path) -> Path:
@@ -27,14 +44,15 @@ def _git_paths(root: Path, env: dict[str, str]) -> tuple[Path, Path] | None:
     """Ask Git how this invocation resolves its repository and index."""
     try:
         result = subprocess.run(
-            [
-                "git",
-                "rev-parse",
-                "--path-format=absolute",
-                "--absolute-git-dir",
-                "--git-path",
-                "index",
-            ],
+            read_only_git_command(
+                [
+                    "rev-parse",
+                    "--path-format=absolute",
+                    "--absolute-git-dir",
+                    "--git-path",
+                    "index",
+                ]
+            ),
             capture_output=True,
             text=True,
             timeout=10,
@@ -49,12 +67,94 @@ def _git_paths(root: Path, env: dict[str, str]) -> tuple[Path, Path] | None:
     return tuple(_absolute_env_path(line, root) for line in lines)
 
 
+def _filter_config_overrides(
+    root: Path,
+    env: dict[str, str],
+) -> tuple[str, ...] | None:
+    """Neutralize clean/process filters selected by repository attributes."""
+
+    try:
+        result = subprocess.run(
+            read_only_git_command(
+                [
+                    "config",
+                    "--includes",
+                    "--null",
+                    "--name-only",
+                    "--get-regexp",
+                    (
+                        r"^(filter\..*\.(clean|smudge|process|required)"
+                        r"|diff\..*\.(command|textconv|cachetextconv|trustExitCode))$"
+                    ),
+                ]
+            ),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=str(root),
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode == 1:
+        return ()
+    if result.returncode != 0:
+        return None
+    if len(result.stdout.encode("utf-8")) > _MAX_FILTER_CONFIG_OUTPUT:
+        return None
+
+    filter_drivers: set[str] = set()
+    diff_drivers: set[str] = set()
+    for key in result.stdout.split("\0"):
+        if not key:
+            continue
+        match = _FILTER_CONFIG_KEY_RE.fullmatch(key)
+        drivers = filter_drivers
+        if match is None:
+            match = _DIFF_CONFIG_KEY_RE.fullmatch(key)
+            drivers = diff_drivers
+        if match is None:
+            return None
+        driver = match.group("driver")
+        if (
+            not driver
+            or len(driver) > _MAX_FILTER_DRIVER_LENGTH
+            or _SAFE_FILTER_DRIVER_RE.fullmatch(driver) is None
+        ):
+            return None
+        drivers.add(driver)
+        if len(filter_drivers) + len(diff_drivers) > _MAX_FILTER_DRIVERS:
+            return None
+
+    overrides = []
+    for driver in sorted(filter_drivers):
+        overrides.extend(
+            (
+                f"filter.{driver}.clean=",
+                f"filter.{driver}.smudge=",
+                f"filter.{driver}.process=",
+                f"filter.{driver}.required=false",
+            )
+        )
+    for driver in sorted(diff_drivers):
+        overrides.extend(
+            (
+                f"diff.{driver}.command=",
+                f"diff.{driver}.textconv=",
+                f"diff.{driver}.cachetextconv=false",
+                f"diff.{driver}.trustExitCode=false",
+            )
+        )
+    return tuple(overrides)
+
+
 @dataclass(frozen=True)
 class GitContext:
     """Git reads anchored to the requested worktree, including inside hooks."""
 
     root: Path
     env: dict[str, str]
+    filter_config_overrides: tuple[str, ...] | None
 
     @classmethod
     def from_path(cls, path: str | Path) -> GitContext:
@@ -76,9 +176,7 @@ class GitContext:
                     inherited["GIT_DIR"], original_cwd
                 )
 
-        env = dict(inherited)
-        for key in (*_REPOSITORY_ENV, "GIT_INDEX_FILE"):
-            env.pop(key, None)
+        env = read_only_git_environment(inherited)
         if root is not None:
             env["GIT_WORK_TREE"] = str(root)
         if explicit_git_dir is not None:
@@ -90,17 +188,44 @@ class GitContext:
 
         root = root or start
         if inherited.get("GIT_INDEX_FILE"):
-            original_paths = _git_paths(original_cwd, inherited)
+            original_env = read_only_git_environment(inherited)
+            for key in (*_REPOSITORY_ENV, "GIT_INDEX_FILE"):
+                if inherited.get(key):
+                    original_env[key] = inherited[key]
+            original_paths = _git_paths(original_cwd, original_env)
             target_paths = _git_paths(root, env)
             if original_paths and target_paths and original_paths[0] == target_paths[0]:
                 # Relative index paths follow Git's setup semantics, which
                 # differ between repository discovery and an explicit GIT_DIR.
                 env["GIT_INDEX_FILE"] = str(original_paths[1])
-        return cls(root=root, env=env)
+        return cls(
+            root=root,
+            env=env,
+            filter_config_overrides=_filter_config_overrides(root, env),
+        )
 
     def run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        safe_args = list(args)
+        config_overrides: tuple[str, ...] = ()
+        if safe_args and safe_args[0] in {"blame", "diff"}:
+            if self.filter_config_overrides is None:
+                return subprocess.CompletedProcess(
+                    args=list(args),
+                    returncode=2,
+                    stdout="",
+                    stderr="Could not safely inspect repository Git filters",
+                )
+            config_overrides = self.filter_config_overrides
+        if safe_args and safe_args[0] == "diff":
+            if "--no-ext-diff" not in safe_args:
+                safe_args.insert(1, "--no-ext-diff")
+            if "--no-textconv" not in safe_args:
+                safe_args.insert(1, "--no-textconv")
         return subprocess.run(
-            ["git", *args],
+            read_only_git_command(
+                safe_args,
+                config_overrides=config_overrides,
+            ),
             capture_output=True,
             text=True,
             timeout=10,

--- a/skylos/core/git_safety.py
+++ b/skylos/core/git_safety.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+
+
+_READ_ONLY_CONFIG_OVERRIDES = (
+    "core.fsmonitor=false",
+    f"core.hooksPath={os.devnull}",
+    "core.untrackedCache=false",
+    "diff.external=",
+    "diff.trustExitCode=false",
+)
+
+
+def read_only_git_environment(
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Return an environment that cannot inject Git configuration or helpers."""
+
+    source = os.environ if environ is None else environ
+    environment = {
+        key: value for key, value in source.items() if not key.startswith("GIT_")
+    }
+    environment.update(
+        {
+            "GIT_ATTR_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_NO_LAZY_FETCH": "1",
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    return environment
+
+
+def read_only_git_command(
+    args: Sequence[str],
+    *,
+    config_overrides: Sequence[str] = (),
+    literal_pathspecs: bool = False,
+) -> list[str]:
+    """Build a Git command with repository-configured execution disabled."""
+
+    command = ["git", "--no-pager", "--no-replace-objects"]
+    if literal_pathspecs:
+        command.append("--literal-pathspecs")
+    for override in (*_READ_ONLY_CONFIG_OVERRIDES, *config_overrides):
+        command.extend(("-c", override))
+    command.extend(args)
+    return command

--- a/skylos/core/result_cache.py
+++ b/skylos/core/result_cache.py
@@ -4,7 +4,6 @@ import hashlib
 import json
 import os
 import platform
-import shutil
 import stat
 import sys
 import tempfile
@@ -14,7 +13,11 @@ from pathlib import Path
 from typing import Any
 
 import skylos
-from skylos.core.safe_cache_io import load_project_json_cache, save_project_json_cache
+from skylos.core.safe_cache_io import (
+    load_project_json_cache,
+    remove_project_tree_no_symlink,
+    save_project_json_cache,
+)
 
 SCHEMA_VERSION = 1
 CACHE_KIND_TRACE = "trace"
@@ -212,19 +215,7 @@ def save_trace_cache(
 
 def clear_run_cache(project_root: str | Path) -> bool:
     root = _normalize_root(project_root)
-    path = root / RUN_CACHE_DIR
-    try:
-        path.resolve(strict=False).relative_to(root.resolve(strict=True))
-    except (OSError, ValueError):
-        return False
-    if path.is_symlink():
-        return False
-    if not path.exists():
-        return False
-    shutil.rmtree(
-        path
-    )  # skylos: ignore[SKY-D215] guarded project-local cache directory
-    return True
+    return remove_project_tree_no_symlink(root, RUN_CACHE_DIR)
 
 
 def run_cache_stats(project_root: str | Path) -> dict[str, Any]:

--- a/skylos/core/result_cache.py
+++ b/skylos/core/result_cache.py
@@ -6,7 +6,6 @@ import os
 import platform
 import shutil
 import stat
-import subprocess
 import sys
 import tempfile
 import time
@@ -222,7 +221,9 @@ def clear_run_cache(project_root: str | Path) -> bool:
         return False
     if not path.exists():
         return False
-    shutil.rmtree(path)  # skylos: ignore[SKY-D215] guarded project-local cache directory
+    shutil.rmtree(
+        path
+    )  # skylos: ignore[SKY-D215] guarded project-local cache directory
     return True
 
 
@@ -432,27 +433,9 @@ def _fingerprinted_files(project_root: Path) -> list[dict[str, Any]]:
 
 
 def _git_visible_files(project_root: Path) -> list[Path] | None:
-    try:
-        result = subprocess.run(
-            ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
-            cwd=project_root,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    except (OSError, ValueError):
-        return None
+    from skylos.core.file_discovery import list_git_visible_files
 
-    if result.returncode != 0:
-        return None
-
-    files = []
-    for line in result.stdout.splitlines():
-        rel = line.strip()
-        if not rel:
-            continue
-        files.append(project_root / rel)
-    return files
+    return list_git_visible_files(project_root)
 
 
 def _walk_visible_files(project_root: Path) -> list[Path]:

--- a/skylos/core/review_context.py
+++ b/skylos/core/review_context.py
@@ -1,0 +1,1215 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import math
+import os
+import posixpath
+import re
+from pathlib import Path
+from typing import Any
+
+from skylos.core.safe_cache_io import read_project_text_no_symlink
+
+
+REVIEW_CONTEXT_SCHEMA = "skylos.analysis-review-context-v2"
+LLM_REVIEW_CONTEXT_SCHEMA = "skylos.llm-review-context-v1"
+
+_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_DISABLED_VALUES = frozenset({"0", "false", "no", "off"})
+_CATEGORIES = frozenset(
+    {
+        "AI_DEFECT",
+        "CUSTOM",
+        "DEAD_CODE",
+        "DEPENDENCY",
+        "QUALITY",
+        "RELIABILITY",
+        "SECRET",
+        "SECURITY",
+    }
+)
+_ENABLED_CATEGORIES = frozenset(
+    {"ai_defects", "dependencies", "quality", "secrets", "security"}
+)
+_LLM_REVIEW_CATEGORIES = frozenset({"AI_DEFECT", "QUALITY", "RELIABILITY", "SECURITY"})
+_LLM_REVIEW_MODES = frozenset({"agent_hybrid_llm", "agent_llm_only"})
+_CONFIG_PROJECTIONS: dict[str, tuple[str, ...]] = {
+    "dead_code": (
+        "dead_code",
+        "exclude",
+        "ignore",
+        "lower_confidence",
+        "masking",
+        "non_library_dirs",
+        "overrides",
+        "whitelist",
+        "whitelist_documented",
+        "whitelist_temporary",
+    ),
+    "security": (
+        "exclude",
+        "ignore",
+        "masking",
+        "security_contracts",
+        "vibe",
+    ),
+    "ai_defect": (
+        "api_signature_modules",
+        "exclude",
+        "ignore",
+        "masking",
+        "security_contracts",
+        "vibe",
+    ),
+    "quality": (
+        "architecture",
+        "check_circular",
+        "complexity",
+        "duplicate_strings",
+        "exclude",
+        "god_file_max_definitions",
+        "god_file_max_lines",
+        "god_file_max_top_level_definitions",
+        "ignore",
+        "masking",
+        "max_args",
+        "max_circular_deps",
+        "max_lines",
+        "nesting",
+        "nudges",
+        "vibe",
+    ),
+    # Custom rule bodies carry their own content-derived rule revision.  The
+    # effective custom-rules bundle is bound separately in analyzer options.
+    "custom": ("exclude", "ignore", "masking"),
+    # Secret and dependency analyzers do not currently read project config.
+    "secret": (),
+    "dependency": (),
+}
+_MAX_CONTEXT_BYTES = 128_000
+_MAX_CONFIG_BYTES = 2_000_000
+_MAX_PATHS = 20_000
+_MAX_RULES = 2_000
+_MAX_PATH_LENGTH = 2_000
+_MAX_LLM_SOURCE_BYTES = 4_000_000
+_MAX_LLM_SOURCE_TOTAL_BYTES = 32_000_000
+
+
+class _InvalidContext(ValueError):
+    pass
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def _hash(value: Any, *, maximum_bytes: int = _MAX_CONTEXT_BYTES) -> str:
+    encoded = _canonical_json(value).encode("utf-8")
+    if len(encoded) > maximum_bytes:
+        raise _InvalidContext("review context exceeds its size limit")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _bounded_json(value: Any, *, depth: int = 0, budget: list[int]) -> Any:
+    if depth > 12:
+        raise _InvalidContext("review context is nested too deeply")
+    budget[0] -= 1
+    if budget[0] < 0:
+        raise _InvalidContext("review context has too many values")
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise _InvalidContext("review context contains a non-finite number")
+        return value
+    if isinstance(value, str):
+        if len(value) > 100_000:
+            raise _InvalidContext("review context contains an oversized string")
+        return value
+    if isinstance(value, (list, tuple)):
+        if len(value) > 20_000:
+            raise _InvalidContext("review context contains an oversized list")
+        return [_bounded_json(item, depth=depth + 1, budget=budget) for item in value]
+    if isinstance(value, dict):
+        if len(value) > 5_000:
+            raise _InvalidContext("review context contains an oversized mapping")
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or len(key) > 1_000:
+                raise _InvalidContext("review context contains an invalid key")
+            normalized[key] = _bounded_json(
+                item,
+                depth=depth + 1,
+                budget=budget,
+            )
+        return normalized
+    raise _InvalidContext("review context contains an unsupported value")
+
+
+def _config_hash(config: Any) -> str:
+    normalized = _bounded_json(config, budget=[100_000])
+    return _hash(normalized, maximum_bytes=_MAX_CONFIG_BYTES)
+
+
+def _category_config_hashes(config: Any) -> dict[str, str]:
+    if not isinstance(config, dict):
+        raise _InvalidContext("effective analyzer config is not a mapping")
+    return {
+        category: _config_hash(review_config_projection(config, category))
+        for category in _CONFIG_PROJECTIONS
+    }
+
+
+def review_config_hash_for_category(config: Any, category: str) -> str | None:
+    """Hash the effective config projection used by one finding category."""
+    normalized_category = str(category).strip().upper()
+    config_category = {
+        "AI_DEFECT": "ai_defect",
+        "CUSTOM": "custom",
+        "DEAD_CODE": "dead_code",
+        "DEPENDENCY": "dependency",
+        "QUALITY": "quality",
+        "RELIABILITY": "security",
+        "SECRET": "secret",
+        "SECURITY": "security",
+    }.get(normalized_category)
+    if config_category is None:
+        return None
+    try:
+        return _config_hash(review_config_projection(config, config_category))
+    except (MemoryError, RecursionError, TypeError, ValueError):
+        return None
+
+
+def review_config_projection(config: Any, category: str) -> dict[str, Any]:
+    """Return only effective config keys read by one analyzer category."""
+    if not isinstance(config, dict):
+        raise _InvalidContext("effective analyzer config is not a mapping")
+    keys = _CONFIG_PROJECTIONS.get(str(category).strip().lower())
+    if keys is None:
+        raise _InvalidContext("unknown analyzer config category")
+    projected = {key: config[key] for key in keys if key in config}
+    normalized = _bounded_json(projected, budget=[100_000])
+    if not isinstance(normalized, dict):
+        raise _InvalidContext("effective analyzer config projection is invalid")
+    return normalized
+
+
+def _resolved_root(project_root: str | Path) -> Path:
+    return Path(project_root).expanduser().resolve(strict=False)
+
+
+def _relative_target(value: Any, root: Path) -> str:
+    if not isinstance(value, (str, os.PathLike)):
+        raise _InvalidContext("scan selection contains a non-path value")
+    raw = os.fspath(value)
+    if not raw or "\x00" in raw or len(raw) > _MAX_PATH_LENGTH:
+        raise _InvalidContext("scan selection contains an invalid path")
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute():
+        candidate = Path.cwd() / candidate
+    try:
+        relative = candidate.resolve(strict=False).relative_to(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise _InvalidContext("scan selection escapes the project root") from exc
+    normalized = relative.as_posix()
+    return normalized if normalized else "."
+
+
+def _relative_changed_file(value: Any, root: Path) -> str:
+    if not isinstance(value, (str, os.PathLike)):
+        raise _InvalidContext("changed-file selection contains a non-path value")
+    raw = os.fspath(value)
+    if not raw or "\x00" in raw or len(raw) > _MAX_PATH_LENGTH:
+        raise _InvalidContext("changed-file selection contains an invalid path")
+    candidate = Path(raw).expanduser()
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    try:
+        relative = candidate.resolve(strict=False).relative_to(root)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise _InvalidContext(
+            "changed-file selection escapes the project root"
+        ) from exc
+    normalized = relative.as_posix()
+    if not normalized or normalized == ".":
+        raise _InvalidContext("changed-file selection names the project root")
+    return normalized
+
+
+def _path_selection(values: Any, root: Path, *, changed: bool) -> list[str] | None:
+    if values is None:
+        return None
+    if isinstance(values, (str, os.PathLike)):
+        candidates = [values]
+    else:
+        try:
+            candidates = list(values)
+        except (MemoryError, TypeError) as exc:
+            raise _InvalidContext("scan selection is not iterable") from exc
+    if len(candidates) > _MAX_PATHS:
+        raise _InvalidContext("scan selection contains too many paths")
+    normalizer = _relative_changed_file if changed else _relative_target
+    return sorted({normalizer(value, root) for value in candidates})
+
+
+def _exclude_selection(values: Any, root: Path) -> list[str]:
+    if values is None:
+        return []
+    if isinstance(values, (str, os.PathLike)):
+        candidates = [values]
+    else:
+        try:
+            candidates = list(values)
+        except (MemoryError, TypeError) as exc:
+            raise _InvalidContext("exclude selection is not iterable") from exc
+    if len(candidates) > _MAX_PATHS:
+        raise _InvalidContext("exclude selection contains too many paths")
+
+    normalized: set[str] = set()
+    for value in candidates:
+        if not isinstance(value, (str, os.PathLike)):
+            raise _InvalidContext("exclude selection contains a non-path value")
+        raw = os.fspath(value).strip()
+        if not raw or "\x00" in raw or len(raw) > _MAX_PATH_LENGTH:
+            raise _InvalidContext("exclude selection contains an invalid path")
+        if Path(raw).is_absolute():
+            normalized.add(_relative_target(raw, root))
+            continue
+        portable = posixpath.normpath(raw.replace("\\", "/"))
+        if portable == ".." or portable.startswith("../") or portable.startswith("/"):
+            raise _InvalidContext("exclude selection escapes the project root")
+        normalized.add(portable.removeprefix("./"))
+    return sorted(normalized)
+
+
+def _rule_selection(required_rules: Any) -> list[str]:
+    if required_rules is None:
+        return []
+    values = (
+        [required_rules] if isinstance(required_rules, str) else list(required_rules)
+    )
+    if len(values) > _MAX_RULES:
+        raise _InvalidContext("required-rule selection is too large")
+    normalized = set()
+    for value in values:
+        if not isinstance(value, str):
+            raise _InvalidContext("required-rule selection contains a non-string")
+        rule_id = value.strip().upper()
+        if not rule_id or len(rule_id) > 120:
+            raise _InvalidContext("required-rule selection contains an invalid rule")
+        normalized.add(rule_id)
+    return sorted(normalized)
+
+
+def _optional_text(value: Any, *, maximum: int) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        value = os.fspath(value) if isinstance(value, os.PathLike) else str(value)
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if "\x00" in normalized or len(normalized) > maximum:
+        raise _InvalidContext("review option contains invalid text")
+    return normalized
+
+
+def _custom_rules_hash(custom_rules_data: Any, environ: dict[str, str]) -> str | None:
+    raw_environment = environ.get("SKYLOS_CUSTOM_RULES")
+    if raw_environment:
+        if len(raw_environment) > _MAX_CONFIG_BYTES:
+            raise _InvalidContext("custom rules exceed their size limit")
+        try:
+            custom_rules_data = json.loads(raw_environment)
+        except (MemoryError, RecursionError, TypeError, ValueError):
+            raise _InvalidContext("custom rules are not valid JSON")
+    if custom_rules_data in (None, [], {}):
+        return None
+    return _config_hash(custom_rules_data)
+
+
+def _isolated_custom_hash(builder) -> tuple[str | None, bool]:
+    """Keep incomplete custom extensions from poisoning built-in findings."""
+    try:
+        return builder(), True
+    except (
+        MemoryError,
+        OSError,
+        RecursionError,
+        TypeError,
+        ValueError,
+    ):
+        return None, False
+
+
+def _visitor_hash(extra_visitors: Any) -> str | None:
+    if extra_visitors is None:
+        return None
+    try:
+        visitors = list(extra_visitors)
+    except (MemoryError, TypeError) as exc:
+        raise _InvalidContext("custom visitors are not iterable") from exc
+    if not visitors:
+        return None
+    if len(visitors) > 1_000:
+        raise _InvalidContext("too many custom visitors")
+    records = []
+    for visitor in visitors:
+        module = getattr(visitor, "__module__", None)
+        qualified_name = getattr(visitor, "__qualname__", None)
+        if not isinstance(module, str) or not isinstance(qualified_name, str):
+            raise _InvalidContext("custom visitor has no stable name")
+        try:
+            source = inspect.getsource(visitor).replace("\r\n", "\n")
+        except (OSError, TypeError) as exc:
+            raise _InvalidContext("custom visitor source is unavailable") from exc
+        records.append(
+            {
+                "name": f"{module}.{qualified_name}",
+                "source_hash": "sha256:"
+                + hashlib.sha256(source.encode("utf-8")).hexdigest(),
+            }
+        )
+    return _hash(sorted(records, key=lambda item: item["name"]))
+
+
+def build_analysis_review_context(
+    project_root: str | Path,
+    scan_targets: Any,
+    *,
+    config: Any,
+    threshold: int,
+    exclude_folders: Any,
+    requested_changed_files: Any,
+    effective_changed_files: Any,
+    enable_secrets: bool,
+    enable_danger: bool,
+    enable_quality: bool,
+    enable_ai_defects: bool,
+    enable_sca: bool,
+    enable_dependency_hallucinations: bool,
+    grep_verify: bool,
+    trace_file: Any,
+    required_config_rules: Any,
+    dependency_bump_diff_base: Any,
+    custom_rules_data: Any,
+    extra_visitors: Any,
+    analysis_scope: Any,
+    environ: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build the checkout-independent analyzer inputs used by review identity."""
+    try:
+        if isinstance(threshold, bool) or not isinstance(threshold, int):
+            raise _InvalidContext("confidence threshold is not an integer")
+        if not 0 <= threshold <= 100:
+            raise _InvalidContext("confidence threshold is outside 0-100")
+        root = _resolved_root(project_root)
+        targets = (
+            scan_targets if isinstance(scan_targets, (list, tuple)) else [scan_targets]
+        )
+        normalized_targets = _path_selection(targets, root, changed=False)
+        if not normalized_targets:
+            raise _InvalidContext("scan target selection is empty")
+
+        scope_kind = "unknown"
+        complete_repository = False
+        if isinstance(analysis_scope, dict):
+            raw_kind = analysis_scope.get("kind")
+            if isinstance(raw_kind, str) and 0 < len(raw_kind) <= 120:
+                scope_kind = raw_kind
+            complete_repository = analysis_scope.get("complete_repository") is True
+
+        enabled_categories = sorted(
+            category
+            for category, enabled in (
+                ("ai_defects", enable_ai_defects),
+                ("dependencies", enable_sca),
+                ("quality", enable_quality),
+                ("secrets", enable_secrets),
+                ("security", enable_danger),
+            )
+            if enabled
+        )
+        environment = dict(os.environ if environ is None else environ)
+        custom_rules_hash, custom_rules_complete = _isolated_custom_hash(
+            lambda: _custom_rules_hash(custom_rules_data, environment)
+        )
+        custom_visitors_hash, custom_visitors_complete = _isolated_custom_hash(
+            lambda: _visitor_hash(extra_visitors)
+        )
+        payload = {
+            "config_hashes": _category_config_hashes(config),
+            "scope": {
+                "kind": scope_kind,
+                "targets": normalized_targets,
+                "complete_repository": complete_repository,
+                "excluded_folders": _exclude_selection(exclude_folders, root),
+                "requested_changed_files": _path_selection(
+                    requested_changed_files,
+                    root,
+                    changed=True,
+                ),
+                "effective_changed_files": _path_selection(
+                    effective_changed_files,
+                    root,
+                    changed=True,
+                ),
+            },
+            "options": {
+                "confidence_threshold": threshold,
+                "enabled_categories": enabled_categories,
+                "grep_verify": bool(grep_verify),
+                "dead_code_liveness": str(
+                    environment.get("SKYLOS_DEAD_CODE_LIVENESS", "1")
+                ).lower()
+                not in _DISABLED_VALUES,
+                "trace_mode": (
+                    "disabled"
+                    if trace_file is False
+                    else "default"
+                    if trace_file is None
+                    else "explicit"
+                ),
+                "dependency_hallucinations": bool(enable_dependency_hallucinations),
+                "required_config_rules": _rule_selection(required_config_rules),
+                "dependency_bump_diff_base": _optional_text(
+                    dependency_bump_diff_base,
+                    maximum=500,
+                ),
+                "custom_rules_hash": custom_rules_hash,
+                "custom_rules_complete": custom_rules_complete,
+                "custom_visitors_hash": custom_visitors_hash,
+                "custom_visitors_complete": custom_visitors_complete,
+            },
+        }
+        return {
+            "schema": REVIEW_CONTEXT_SCHEMA,
+            "context_hash": _hash(payload),
+            **payload,
+        }
+    except (
+        MemoryError,
+        OSError,
+        RecursionError,
+        TypeError,
+        ValueError,
+    ):
+        # A present but incomplete context prevents identity creation.  It is
+        # safer to ask for review again than to reuse a decision across inputs
+        # the analyzer could not bind canonically.
+        return {"schema": REVIEW_CONTEXT_SCHEMA, "complete": False}
+
+
+def _selection_summary(values: Any, root: Path, *, allow_none: bool) -> Any:
+    if values is None:
+        if allow_none:
+            return None
+        values = []
+    normalized = _path_selection(values, root, changed=True)
+    if normalized is None:
+        normalized = []
+    return {
+        "count": len(normalized),
+        "paths_hash": _hash(normalized, maximum_bytes=_MAX_CONFIG_BYTES),
+    }
+
+
+def _repo_context_hash(value: Any, root: Path) -> str:
+    if value is None:
+        value = {}
+    if not isinstance(value, dict) or len(value) > _MAX_PATHS:
+        raise _InvalidContext("LLM repository context is not a bounded mapping")
+    normalized = []
+    for path, context in value.items():
+        relative = _relative_changed_file(path, root)
+        if not isinstance(context, str) or len(context) > 200_000:
+            raise _InvalidContext("LLM repository context contains invalid text")
+        normalized.append({"file": relative, "context": context})
+    normalized.sort(key=lambda item: item["file"])
+    return _hash(normalized, maximum_bytes=_MAX_CONFIG_BYTES)
+
+
+def _source_selection_hash(values: Any, root: Path) -> str:
+    normalized = _path_selection(values, root, changed=True) or []
+    digest = hashlib.sha256(b"skylos-llm-source-selection-v1\0")
+    total_bytes = 0
+    for relative_path in normalized:
+        source = read_project_text_no_symlink(
+            root,
+            relative_path,
+            max_bytes=_MAX_LLM_SOURCE_BYTES,
+            encoding="utf-8",
+        )
+        if source is None:
+            raise _InvalidContext("LLM source selection could not be read safely")
+        path_bytes = relative_path.encode("utf-8")
+        source_bytes = source.encode("utf-8")
+        total_bytes += len(source_bytes)
+        if total_bytes > _MAX_LLM_SOURCE_TOTAL_BYTES:
+            raise _InvalidContext("LLM source selection exceeds its size limit")
+        digest.update(len(path_bytes).to_bytes(4, "big"))
+        digest.update(path_bytes)
+        digest.update(len(source_bytes).to_bytes(8, "big"))
+        digest.update(source_bytes)
+    return "sha256:" + digest.hexdigest()
+
+
+def _llm_definitions_hash(value: Any, root: Path) -> str:
+    """Hash the static definition projection that can enter LLM prompts."""
+    if value is None:
+        value = {}
+    if not isinstance(value, dict) or len(value) > _MAX_PATHS:
+        raise _InvalidContext("LLM definitions are not a bounded mapping")
+
+    normalized = []
+    for key, raw_info in value.items():
+        if not isinstance(key, str) or not _valid_llm_text(key, 1_000):
+            raise _InvalidContext("LLM definitions contain an invalid name")
+        if not isinstance(raw_info, dict):
+            raise _InvalidContext("LLM definitions contain invalid metadata")
+
+        name = _optional_text(raw_info.get("name", key), maximum=1_000)
+        definition_type = _optional_text(raw_info.get("type", "unknown"), maximum=120)
+        if name is None or definition_type is None:
+            raise _InvalidContext("LLM definitions contain incomplete metadata")
+
+        raw_file = raw_info.get("file")
+        definition_file = None
+        if raw_file not in (None, ""):
+            definition_file = _relative_changed_file(raw_file, root)
+
+        entry = {
+            "key": key,
+            "name": name,
+            "type": definition_type,
+            "file": definition_file,
+        }
+        for source_key in ("code", "source"):
+            source = raw_info.get(source_key)
+            if source is None:
+                continue
+            if not isinstance(source, str) or len(source) > _MAX_LLM_SOURCE_BYTES:
+                raise _InvalidContext("LLM definitions contain invalid source text")
+            entry[source_key] = source
+        # Preserve insertion order: ContextBuilder walks this mapping in order
+        # and caps dependency/project-index material included in prompts.
+        normalized.append(entry)
+
+    return _hash(normalized, maximum_bytes=_MAX_CONFIG_BYTES)
+
+
+def build_llm_review_context(
+    project_root: str | Path,
+    scan_targets: Any,
+    *,
+    mode: str,
+    config: Any,
+    exclude_folders: Any,
+    requested_changed_files: Any,
+    effective_files: Any,
+    repo_context_map: Any,
+    force_full_file_paths: Any,
+    definitions: Any,
+    scan_kind: str,
+    complete_target: bool,
+    model: Any,
+    provider: Any,
+    base_url: Any,
+    min_confidence: Any,
+    prompt_revision: Any,
+    enable_security: bool,
+    enable_quality: bool,
+    temperature: float,
+    max_tokens: int,
+    strict_validation: bool,
+    stream: bool,
+    smart_filter: bool,
+    full_file_review: bool,
+    parallel: bool,
+    max_workers: int,
+    max_chunk_tokens: int,
+    batch_functions: bool,
+    batch_size: int,
+    complexity_threshold: int,
+    agent_route: str,
+) -> dict[str, Any]:
+    """Bind an agent LLM pass to the inputs that shape its findings."""
+    try:
+        root = _resolved_root(project_root)
+        targets = (
+            scan_targets if isinstance(scan_targets, (list, tuple)) else [scan_targets]
+        )
+        normalized_targets = _path_selection(targets, root, changed=False)
+        if not normalized_targets:
+            raise _InvalidContext("LLM scan target selection is empty")
+        if mode not in _LLM_REVIEW_MODES:
+            raise _InvalidContext("LLM scan mode is invalid")
+        if scan_kind not in {"file", "directory"}:
+            raise _InvalidContext("LLM scan kind is invalid")
+        if not isinstance(complete_target, bool):
+            raise _InvalidContext("LLM scan completeness is invalid")
+
+        model_name = _optional_text(model, maximum=300)
+        provider_name = _optional_text(provider, maximum=120)
+        if model_name is None or provider_name is None:
+            raise _InvalidContext("LLM runtime identity is incomplete")
+        if min_confidence not in {"low", "medium", "high"}:
+            raise _InvalidContext("LLM confidence selection is invalid")
+        if not isinstance(prompt_revision, str) or not _HASH_RE.fullmatch(
+            prompt_revision
+        ):
+            raise _InvalidContext("LLM prompt revision is invalid")
+        if agent_route not in {"full", "static_first", "static_only"}:
+            raise _InvalidContext("LLM agent route is invalid")
+        if (
+            isinstance(temperature, bool)
+            or not isinstance(temperature, (int, float))
+            or not math.isfinite(temperature)
+            or not 0 <= temperature <= 10
+        ):
+            raise _InvalidContext("LLM temperature is invalid")
+        for name, value, minimum in (
+            ("max_tokens", max_tokens, 1),
+            ("max_workers", max_workers, 1),
+            ("max_chunk_tokens", max_chunk_tokens, 1),
+            ("batch_size", batch_size, 1),
+            ("complexity_threshold", complexity_threshold, 0),
+        ):
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or not minimum <= value <= 1_000_000
+            ):
+                raise _InvalidContext(f"LLM {name} is invalid")
+
+        raw_base_url = _optional_text(base_url, maximum=2_000)
+        payload = {
+            "mode": mode,
+            "scope": {
+                "kind": scan_kind,
+                "targets": normalized_targets,
+                "complete_target": complete_target,
+                "excluded_folders": _exclude_selection(exclude_folders, root),
+                "requested_changed_files": _selection_summary(
+                    requested_changed_files,
+                    root,
+                    allow_none=True,
+                ),
+                "effective_files": _selection_summary(
+                    effective_files,
+                    root,
+                    allow_none=False,
+                ),
+                "force_full_file_paths": _selection_summary(
+                    force_full_file_paths,
+                    root,
+                    allow_none=False,
+                ),
+            },
+            "analyzer": {
+                "config_hash": _config_hash(config),
+                "model": model_name,
+                "provider": provider_name,
+                "endpoint_hash": _hash(raw_base_url) if raw_base_url else None,
+                "min_confidence": min_confidence,
+                "prompt_revision": prompt_revision,
+                "enable_security": bool(enable_security),
+                "enable_quality": bool(enable_quality),
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+                "strict_validation": bool(strict_validation),
+                "stream": bool(stream),
+                "smart_filter": bool(smart_filter),
+                "full_file_review": bool(full_file_review),
+                "parallel": bool(parallel),
+                "max_workers": max_workers,
+                "max_chunk_tokens": max_chunk_tokens,
+                "batch_functions": bool(batch_functions),
+                "batch_size": batch_size,
+                "complexity_threshold": complexity_threshold,
+                "agent_route": agent_route,
+                "repo_context_hash": _repo_context_hash(repo_context_map, root),
+                "definitions_hash": _llm_definitions_hash(definitions, root),
+                "effective_source_hash": _source_selection_hash(
+                    effective_files,
+                    root,
+                ),
+            },
+        }
+        return {
+            "schema": LLM_REVIEW_CONTEXT_SCHEMA,
+            "context_hash": _hash(payload),
+            **payload,
+        }
+    except (
+        MemoryError,
+        OSError,
+        RecursionError,
+        TypeError,
+        ValueError,
+    ):
+        return {"schema": LLM_REVIEW_CONTEXT_SCHEMA, "complete": False}
+
+
+def _valid_relative_paths(value: Any, *, allow_none: bool) -> bool:
+    if value is None:
+        return allow_none
+    if not isinstance(value, list) or len(value) > _MAX_PATHS:
+        return False
+    if value != sorted(set(value)):
+        return False
+    for path in value:
+        if not isinstance(path, str) or not path or len(path) > _MAX_PATH_LENGTH:
+            return False
+        if (
+            any(ord(char) < 32 or ord(char) == 127 for char in path)
+            or "\\" in path
+            or path.startswith("/")
+        ):
+            return False
+        if path == ".." or path.startswith("../"):
+            return False
+        if path != "." and posixpath.normpath(path) != path:
+            return False
+    return True
+
+
+def _validated_payload(context: Any) -> dict[str, Any] | None:
+    if not isinstance(context, dict):
+        return None
+    if set(context) != {
+        "schema",
+        "context_hash",
+        "config_hashes",
+        "scope",
+        "options",
+    }:
+        return None
+    if context.get("schema") != REVIEW_CONTEXT_SCHEMA:
+        return None
+    context_hash = context.get("context_hash")
+    config_hashes = context.get("config_hashes")
+    if not isinstance(context_hash, str) or not _HASH_RE.fullmatch(context_hash):
+        return None
+    if (
+        not isinstance(config_hashes, dict)
+        or set(config_hashes) != set(_CONFIG_PROJECTIONS)
+        or any(
+            not isinstance(value, str) or not _HASH_RE.fullmatch(value)
+            for value in config_hashes.values()
+        )
+    ):
+        return None
+    scope = context.get("scope")
+    if not isinstance(scope, dict) or set(scope) != {
+        "kind",
+        "targets",
+        "complete_repository",
+        "excluded_folders",
+        "requested_changed_files",
+        "effective_changed_files",
+    }:
+        return None
+    if not isinstance(scope.get("kind"), str) or not 0 < len(scope["kind"]) <= 120:
+        return None
+    if not isinstance(scope.get("complete_repository"), bool):
+        return None
+    if not _valid_relative_paths(scope.get("targets"), allow_none=False):
+        return None
+    if not scope["targets"]:
+        return None
+    if not _valid_relative_paths(scope.get("excluded_folders"), allow_none=False):
+        return None
+    if not _valid_relative_paths(scope.get("requested_changed_files"), allow_none=True):
+        return None
+    if not _valid_relative_paths(scope.get("effective_changed_files"), allow_none=True):
+        return None
+
+    options = context.get("options")
+    if not isinstance(options, dict) or set(options) != {
+        "confidence_threshold",
+        "enabled_categories",
+        "grep_verify",
+        "dead_code_liveness",
+        "trace_mode",
+        "dependency_hallucinations",
+        "required_config_rules",
+        "dependency_bump_diff_base",
+        "custom_rules_hash",
+        "custom_rules_complete",
+        "custom_visitors_hash",
+        "custom_visitors_complete",
+    }:
+        return None
+    threshold = options.get("confidence_threshold")
+    if isinstance(threshold, bool) or not isinstance(threshold, int):
+        return None
+    if not 0 <= threshold <= 100:
+        return None
+    enabled = options.get("enabled_categories")
+    if (
+        not isinstance(enabled, list)
+        or enabled != sorted(set(enabled))
+        or any(item not in _ENABLED_CATEGORIES for item in enabled)
+    ):
+        return None
+    for key in ("grep_verify", "dead_code_liveness", "dependency_hallucinations"):
+        if not isinstance(options.get(key), bool):
+            return None
+    for key in ("custom_rules_complete", "custom_visitors_complete"):
+        if not isinstance(options.get(key), bool):
+            return None
+    if options.get("trace_mode") not in {"default", "disabled", "explicit"}:
+        return None
+    rules = options.get("required_config_rules")
+    if (
+        not isinstance(rules, list)
+        or len(rules) > _MAX_RULES
+        or rules != sorted(set(rules))
+        or any(
+            not isinstance(rule, str) or not rule or len(rule) > 120 for rule in rules
+        )
+    ):
+        return None
+    diff_base = options.get("dependency_bump_diff_base")
+    if diff_base is not None and (
+        not isinstance(diff_base, str) or not diff_base or len(diff_base) > 500
+    ):
+        return None
+    for key in ("custom_rules_hash", "custom_visitors_hash"):
+        value = options.get(key)
+        if value is not None and (
+            not isinstance(value, str) or not _HASH_RE.fullmatch(value)
+        ):
+            return None
+
+    payload = {
+        "config_hashes": config_hashes,
+        "scope": scope,
+        "options": options,
+    }
+    try:
+        if _hash(payload) != context_hash:
+            return None
+    except (MemoryError, RecursionError, TypeError, ValueError):
+        return None
+    return payload
+
+
+def _valid_selection_summary(value: Any, *, allow_none: bool) -> bool:
+    if value is None:
+        return allow_none
+    if not isinstance(value, dict) or set(value) != {"count", "paths_hash"}:
+        return False
+    count = value.get("count")
+    paths_hash = value.get("paths_hash")
+    return (
+        isinstance(count, int)
+        and not isinstance(count, bool)
+        and 0 <= count <= _MAX_PATHS
+        and isinstance(paths_hash, str)
+        and bool(_HASH_RE.fullmatch(paths_hash))
+    )
+
+
+def _valid_llm_text(value: Any, maximum: int) -> bool:
+    return (
+        isinstance(value, str)
+        and value == value.strip()
+        and 0 < len(value) <= maximum
+        and not any(ord(char) < 32 or ord(char) == 127 for char in value)
+    )
+
+
+def _validated_llm_payload(context: Any) -> dict[str, Any] | None:
+    if not isinstance(context, dict) or set(context) != {
+        "schema",
+        "context_hash",
+        "mode",
+        "scope",
+        "analyzer",
+    }:
+        return None
+    if (
+        context.get("schema") != LLM_REVIEW_CONTEXT_SCHEMA
+        or context.get("mode") not in _LLM_REVIEW_MODES
+    ):
+        return None
+    context_hash = context.get("context_hash")
+    if not isinstance(context_hash, str) or not _HASH_RE.fullmatch(context_hash):
+        return None
+
+    scope = context.get("scope")
+    if not isinstance(scope, dict) or set(scope) != {
+        "kind",
+        "targets",
+        "complete_target",
+        "excluded_folders",
+        "requested_changed_files",
+        "effective_files",
+        "force_full_file_paths",
+    }:
+        return None
+    if scope.get("kind") not in {"file", "directory"}:
+        return None
+    if not isinstance(scope.get("complete_target"), bool):
+        return None
+    if not _valid_relative_paths(scope.get("targets"), allow_none=False):
+        return None
+    if not scope["targets"]:
+        return None
+    if not _valid_relative_paths(scope.get("excluded_folders"), allow_none=False):
+        return None
+    if not _valid_selection_summary(
+        scope.get("requested_changed_files"), allow_none=True
+    ):
+        return None
+    if not _valid_selection_summary(scope.get("effective_files"), allow_none=False):
+        return None
+    if not _valid_selection_summary(
+        scope.get("force_full_file_paths"), allow_none=False
+    ):
+        return None
+
+    analyzer = context.get("analyzer")
+    if not isinstance(analyzer, dict) or set(analyzer) != {
+        "config_hash",
+        "model",
+        "provider",
+        "endpoint_hash",
+        "min_confidence",
+        "prompt_revision",
+        "enable_security",
+        "enable_quality",
+        "temperature",
+        "max_tokens",
+        "strict_validation",
+        "stream",
+        "smart_filter",
+        "full_file_review",
+        "parallel",
+        "max_workers",
+        "max_chunk_tokens",
+        "batch_functions",
+        "batch_size",
+        "complexity_threshold",
+        "agent_route",
+        "repo_context_hash",
+        "definitions_hash",
+        "effective_source_hash",
+    }:
+        return None
+    for key in (
+        "config_hash",
+        "prompt_revision",
+        "repo_context_hash",
+        "definitions_hash",
+        "effective_source_hash",
+    ):
+        value = analyzer.get(key)
+        if not isinstance(value, str) or not _HASH_RE.fullmatch(value):
+            return None
+    endpoint_hash = analyzer.get("endpoint_hash")
+    if endpoint_hash is not None and (
+        not isinstance(endpoint_hash, str) or not _HASH_RE.fullmatch(endpoint_hash)
+    ):
+        return None
+    if not _valid_llm_text(analyzer.get("model"), 300):
+        return None
+    if not _valid_llm_text(analyzer.get("provider"), 120):
+        return None
+    if analyzer.get("min_confidence") not in {"low", "medium", "high"}:
+        return None
+    if analyzer.get("agent_route") not in {"full", "static_first", "static_only"}:
+        return None
+    for key in (
+        "enable_security",
+        "enable_quality",
+        "strict_validation",
+        "stream",
+        "smart_filter",
+        "full_file_review",
+        "parallel",
+        "batch_functions",
+    ):
+        if not isinstance(analyzer.get(key), bool):
+            return None
+    temperature = analyzer.get("temperature")
+    if (
+        isinstance(temperature, bool)
+        or not isinstance(temperature, (int, float))
+        or not math.isfinite(temperature)
+        or not 0 <= temperature <= 10
+    ):
+        return None
+    for key, minimum in (
+        ("max_tokens", 1),
+        ("max_workers", 1),
+        ("max_chunk_tokens", 1),
+        ("batch_size", 1),
+        ("complexity_threshold", 0),
+    ):
+        value = analyzer.get(key)
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or not minimum <= value <= 1_000_000
+        ):
+            return None
+
+    payload = {
+        "mode": context["mode"],
+        "scope": scope,
+        "analyzer": analyzer,
+    }
+    try:
+        if _hash(payload) != context_hash:
+            return None
+    except (MemoryError, RecursionError, TypeError, ValueError):
+        return None
+    return payload
+
+
+def review_context_hash_for_category(
+    context: Any,
+    category: str,
+    *,
+    effective_config_hash: str | None = None,
+) -> str | None:
+    """Validate a context and return only inputs material to ``category``."""
+    normalized_category = str(category).strip().upper()
+    if isinstance(context, dict) and context.get("schema") == LLM_REVIEW_CONTEXT_SCHEMA:
+        payload = _validated_llm_payload(context)
+        if (
+            payload is None
+            or normalized_category not in _LLM_REVIEW_CATEGORIES
+            or effective_config_hash is not None
+        ):
+            return None
+        try:
+            return _hash(
+                {
+                    "schema": LLM_REVIEW_CONTEXT_SCHEMA,
+                    "category": normalized_category,
+                    **payload,
+                }
+            )
+        except (MemoryError, RecursionError, TypeError, ValueError):
+            return None
+
+    payload = _validated_payload(context)
+    if payload is None or normalized_category not in _CATEGORIES:
+        return None
+
+    options = payload["options"]
+    full_scope = payload["scope"]
+    selected_scope = {
+        "kind": full_scope["kind"],
+        "targets": full_scope["targets"],
+        "complete_repository": full_scope["complete_repository"],
+        "excluded_folders": full_scope["excluded_folders"],
+    }
+    if normalized_category != "DEPENDENCY":
+        selected_scope["requested_changed_files"] = full_scope[
+            "requested_changed_files"
+        ]
+    if normalized_category in {
+        "AI_DEFECT",
+        "QUALITY",
+        "RELIABILITY",
+        "SECURITY",
+    }:
+        # These categories have repository/diff passes after the static worker
+        # and can therefore consume Skylos's auto-detected Git selection.
+        selected_scope["effective_changed_files"] = full_scope[
+            "effective_changed_files"
+        ]
+
+    common = {
+        "schema": REVIEW_CONTEXT_SCHEMA,
+        "category": normalized_category,
+        "scope": selected_scope,
+    }
+    if normalized_category == "DEAD_CODE":
+        config_category = "dead_code"
+        selected_options = {
+            "confidence_threshold": options["confidence_threshold"],
+            "grep_verify": options["grep_verify"],
+            "dead_code_liveness": options["dead_code_liveness"],
+            "trace_mode": options["trace_mode"],
+        }
+    elif normalized_category in {"SECURITY", "RELIABILITY"}:
+        if not options["custom_visitors_complete"]:
+            return None
+        config_category = "security"
+        selected_options = {
+            "enabled": "security" in options["enabled_categories"],
+            "required_config_rules": options["required_config_rules"],
+            "custom_visitors_hash": options["custom_visitors_hash"],
+        }
+    elif normalized_category == "AI_DEFECT":
+        if not options["custom_visitors_complete"]:
+            return None
+        config_category = "ai_defect"
+        selected_options = {
+            "enabled": "ai_defects" in options["enabled_categories"],
+            "security_enabled": "security" in options["enabled_categories"],
+            "dependency_hallucinations": options["dependency_hallucinations"],
+            "dependency_bump_diff_base": options["dependency_bump_diff_base"],
+            "custom_visitors_hash": options["custom_visitors_hash"],
+        }
+    elif normalized_category == "QUALITY":
+        config_category = "quality"
+        selected_options = {
+            "enabled": "quality" in options["enabled_categories"],
+        }
+    elif normalized_category == "CUSTOM":
+        if not options["custom_rules_complete"]:
+            return None
+        config_category = "custom"
+        selected_options = {
+            "custom_rules_hash": options["custom_rules_hash"],
+        }
+    elif normalized_category == "SECRET":
+        config_category = "secret"
+        selected_options = {
+            "enabled": "secrets" in options["enabled_categories"],
+        }
+    else:
+        config_category = "dependency"
+        selected_options = {
+            "enabled": "dependencies" in options["enabled_categories"],
+        }
+    config_hash = payload["config_hashes"][config_category]
+    if effective_config_hash is not None:
+        if not isinstance(effective_config_hash, str) or not _HASH_RE.fullmatch(
+            effective_config_hash
+        ):
+            return None
+        config_hash = _hash(
+            {
+                "root_config_hash": config_hash,
+                "effective_file_config_hash": effective_config_hash,
+            }
+        )
+    common["config_hash"] = config_hash
+    common["options"] = selected_options
+    try:
+        return _hash(common)
+    except (MemoryError, RecursionError, TypeError, ValueError):
+        return None
+
+
+def review_context_is_valid(context: Any) -> bool:
+    if isinstance(context, dict) and context.get("schema") == LLM_REVIEW_CONTEXT_SCHEMA:
+        return _validated_llm_payload(context) is not None
+    return _validated_payload(context) is not None

--- a/skylos/core/review_decisions.py
+++ b/skylos/core/review_decisions.py
@@ -1,0 +1,3886 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import os
+import re
+import stat
+import subprocess
+from collections import Counter, defaultdict
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from skylos import __version__ as skylos_version
+from skylos.core.git_safety import (
+    read_only_git_command,
+    read_only_git_environment,
+)
+from skylos.core.review_context import (
+    review_context_hash_for_category,
+    review_context_is_valid,
+)
+from skylos.core.safe_cache_io import read_project_text_no_symlink
+from skylos.core.safe_cache_io import (
+    load_project_json_cache,
+    project_cache_lock,
+    read_text_no_symlink,
+    save_project_json_cache,
+    write_text_no_symlink,
+)
+
+
+REVIEW_SCHEMA = "skylos.reviewed-findings"
+REVIEW_SCHEMA_VERSION = 2
+FINGERPRINT_VERSION = "skylos-finding-v2"
+DEFAULT_RULE_REVISION = f"skylos:{skylos_version}"
+
+MAX_BUNDLE_BYTES = 1_000_000
+MAX_DECISIONS = 10_000
+MAX_STRING_LENGTH = 4_000
+MAX_SOURCE_BYTES = 2_000_000
+MAX_DEPENDENCY_FILES = 128
+MAX_DEPENDENCY_SOURCE_BYTES = 16_000_000
+MAX_PYTHON_INDEX_FILES = 20_000
+MAX_ENVIRONMENT_FILES = 512
+MAX_REPOSITORY_SOURCE_BYTES = 128_000_000
+DEFAULT_CLOUD_ORIGIN = "https://skylos.dev"
+TRUSTED_CLOUD_CACHE_TTL = timedelta(hours=24)
+
+SUPPRESSING_DISPOSITIONS = frozenset({"false_positive", "risk_accepted"})
+KNOWN_DISPOSITIONS = SUPPRESSING_DISPOSITIONS | {"fixed"}
+
+FINDING_SECTIONS: tuple[tuple[str, str, str], ...] = (
+    ("danger", "SECURITY", "SKY-D000"),
+    ("reliability", "RELIABILITY", "SKY-R000"),
+    ("ai_defects", "AI_DEFECT", "SKY-AI000"),
+    ("quality", "QUALITY", "SKY-Q000"),
+    ("secrets", "SECRET", "SKY-S000"),
+    ("custom_rules", "CUSTOM", "CUSTOM"),
+    ("unused_functions", "DEAD_CODE", "SKY-U001"),
+    ("unused_imports", "DEAD_CODE", "SKY-U002"),
+    ("unused_variables", "DEAD_CODE", "SKY-U003"),
+    ("unused_classes", "DEAD_CODE", "SKY-U004"),
+    ("unused_parameters", "DEAD_CODE", "SKY-U006"),
+    ("unused_files", "DEAD_CODE", "SKY-E002"),
+    ("unused_fixtures", "DEAD_CODE", "SKY-U000"),
+    ("unused_exports", "DEAD_CODE", "SKY-U000"),
+    ("forgotten", "DEAD_CODE", "SKY-U001"),
+    ("circular_dependencies", "QUALITY", "SKY-CIRC"),
+    ("dependency_vulnerabilities", "DEPENDENCY", "SKY-SCA-000"),
+)
+_DEAD_CODE_SECTIONS = frozenset(
+    section
+    for section, category, _rule_id in FINDING_SECTIONS
+    if category == "DEAD_CODE"
+)
+_DEAD_CODE_RULE_IDS = frozenset(
+    rule_id
+    for _section, category, rule_id in FINDING_SECTIONS
+    if category == "DEAD_CODE"
+)
+
+_SUMMARY_COUNT_KEYS = {
+    "danger": "danger_count",
+    "reliability": "reliability_count",
+    "ai_defects": "ai_defects_count",
+    "quality": "quality_count",
+    "secrets": "secrets_count",
+    "custom_rules": "custom_rules_count",
+    "unused_functions": "unused_functions_count",
+    "unused_imports": "unused_imports_count",
+    "unused_variables": "unused_variables_count",
+    "unused_classes": "unused_classes_count",
+    "unused_parameters": "unused_parameters_count",
+    "unused_files": "unused_files_count",
+    "unused_fixtures": "unused_fixtures_count",
+    "unused_exports": "unused_exports_count",
+    "circular_dependencies": "circular_dependencies_count",
+    "dependency_vulnerabilities": "sca_count",
+}
+
+_HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_RULE_REVISION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:+-]{0,119}$")
+_RFC3339_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$"
+)
+_RESERVED_REVIEW_KEYS = frozenset(
+    {
+        "fingerprint_version",
+        "stable_fingerprint",
+        "context_hash",
+        "rule_revision",
+        "review_decision",
+        "_skylos_trusted_review",
+    }
+)
+_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+_IDENTIFIER_TOKEN_RE = re.compile(r"[A-Za-z_$][A-Za-z0-9_$]{0,499}")
+_LANGUAGES = {
+    ".py": "python",
+    ".pyi": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".mts": "typescript",
+    ".cts": "typescript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".java": "java",
+    ".go": "go",
+    ".php": "php",
+    ".rs": "rust",
+    ".dart": "dart",
+    ".cs": "csharp",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".sh": "shell",
+    ".bash": "shell",
+    ".zsh": "shell",
+    ".ksh": "shell",
+    ".bats": "shell",
+}
+
+_TS_JS_SOURCE_SUFFIXES = frozenset(
+    {".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"}
+)
+_JS_ENVIRONMENT_FILES = frozenset(
+    {
+        "package.json",
+        "package-lock.json",
+        "npm-shrinkwrap.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+        "bun.lock",
+        "bun.lockb",
+        "deno.json",
+        "deno.jsonc",
+        "deno.lock",
+    }
+)
+_POLYGLOT_ENVIRONMENT_FILES = frozenset(
+    {
+        ".gitmodules",
+        ".tool-versions",
+        "Dockerfile",
+        "go.mod",
+        "go.sum",
+        "go.work",
+        "go.work.sum",
+        "Cargo.toml",
+        "Cargo.lock",
+        "rust-toolchain",
+        "rust-toolchain.toml",
+        "pom.xml",
+        "build.gradle",
+        "build.gradle.kts",
+        "settings.gradle",
+        "settings.gradle.kts",
+        "gradle.properties",
+        "composer.json",
+        "composer.lock",
+        "pubspec.yaml",
+        "pubspec.lock",
+        "global.json",
+        "Directory.Packages.props",
+        "packages.lock.json",
+        "NuGet.Config",
+    }
+)
+
+_CI_RUN_KEYS = (
+    ("github", "GITHUB_RUN_ID"),
+    ("gitlab", "CI_PIPELINE_ID"),
+    ("azure", "BUILD_BUILDID"),
+    ("circle", "CIRCLE_WORKFLOW_ID"),
+    ("jenkins", "BUILD_TAG"),
+)
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        # Repository paths can contain undecodable bytes represented by
+        # surrogate escapes.  Escaping non-ASCII text keeps canonicalization
+        # deterministic without trying to encode those surrogates as UTF-8.
+        ensure_ascii=True,
+    )
+
+
+def sha256_value(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _normalize_repository_identity(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw or "\x00" in raw:
+        return None
+    scp_match = re.fullmatch(r"[^/@\s]+@([^:\s]+):(.+)", raw)
+    if scp_match:
+        host, repo_path = scp_match.groups()
+    else:
+        from urllib.parse import unquote, urlparse
+
+        parsed = urlparse(raw if "://" in raw else f"https://{raw}")
+        if parsed.scheme.lower() not in {"http", "https", "ssh", "git"}:
+            return None
+        if not parsed.hostname or parsed.username and parsed.scheme != "ssh":
+            return None
+        try:
+            port = parsed.port
+        except ValueError:
+            return None
+        default_port = {"http": 80, "https": 443, "ssh": 22, "git": 9418}.get(
+            parsed.scheme.lower()
+        )
+        host = parsed.hostname
+        if port and port != default_port:
+            host = f"{host}:{port}"
+        repo_path = unquote(parsed.path)
+    host = host.strip().lower()
+    repo_path = repo_path.replace("\\", "/").strip("/")
+    if repo_path.lower().endswith(".git"):
+        repo_path = repo_path[:-4]
+    parts = repo_path.split("/") if repo_path else []
+    if not host or not parts or any(part in {"", ".", ".."} for part in parts):
+        return None
+    if host == "github.com":
+        repo_path = repo_path.lower()
+    return f"{host}/{repo_path}"
+
+
+def _identity_project_root(project_root: str | Path) -> Path | None:
+    try:
+        requested = Path(project_root).expanduser().resolve(strict=True)
+        if requested.is_file():
+            requested = requested.parent
+        from skylos.core.file_discovery import find_git_root
+
+        git_root = find_git_root(requested)
+        if git_root is None:
+            return None
+        requested.relative_to(git_root)
+        return git_root
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _review_scope_candidates(
+    project_root: str | Path, *, git_root: Path | None = None
+) -> list[Path]:
+    git_root = git_root or _identity_project_root(project_root)
+    if git_root is None:
+        return []
+    try:
+        current = Path(project_root).expanduser().resolve(strict=True)
+        if current.is_file():
+            current = current.parent
+    except OSError:
+        return []
+    candidates: list[Path] = []
+    while True:
+        candidates.append(current)
+        if current == git_root:
+            return candidates
+        if current.parent == current:
+            return []
+        current = current.parent
+
+
+def _git_remote_identity(git_root: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            read_only_git_command(["-C", str(git_root), "remote", "get-url", "origin"]),
+            capture_output=True,
+            check=False,
+            env=read_only_git_environment(),
+            timeout=5,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    remote = completed.stdout.strip()
+    return _normalize_repository_identity(remote)
+
+
+def _scope_for_project(
+    project_root: str | Path,
+    git_root: Path,
+    repository_identity: str,
+) -> dict[str, str] | None:
+    try:
+        requested = Path(project_root).expanduser().resolve(strict=True)
+        if requested.is_file():
+            requested = requested.parent
+        subpath = requested.relative_to(git_root).as_posix()
+    except (OSError, ValueError):
+        return None
+    return {
+        "repository_identity": repository_identity,
+        "repo_subpath": "" if subpath == "." else subpath,
+    }
+
+
+def _linked_project_id(identity_root: Path, scan_root: str | Path) -> str | None:
+    raw = read_project_text_no_symlink(
+        identity_root,
+        Path(".skylos") / "link.json",
+        max_bytes=200_000,
+        encoding="utf-8",
+    )
+    if raw is None:
+        return None
+    try:
+        link = json.loads(raw)
+        requested = Path(scan_root).expanduser().resolve(strict=True)
+        if requested.is_file():
+            requested = requested.parent
+        requested_subpath = requested.relative_to(identity_root).as_posix()
+    except (json.JSONDecodeError, OSError, RecursionError, ValueError):
+        return None
+    if requested_subpath == ".":
+        requested_subpath = ""
+    if not isinstance(link, dict):
+        return None
+    projects = link.get("projects")
+    matches: list[tuple[int, str]] = []
+    if isinstance(projects, dict):
+        for raw_subpath, entry in projects.items():
+            if not isinstance(raw_subpath, str) or not isinstance(entry, dict):
+                continue
+            subpath = (
+                normalize_repo_path(raw_subpath, identity_root) if raw_subpath else ""
+            )
+            if subpath is None:
+                continue
+            if (
+                requested_subpath == subpath
+                or (subpath and requested_subpath.startswith(f"{subpath}/"))
+                or not subpath
+            ):
+                project_id = _bounded_string(
+                    entry.get("project_id") or entry.get("projectId"), maximum=200
+                )
+                if project_id:
+                    matches.append((len(subpath), project_id))
+    if matches:
+        return max(matches, key=lambda item: item[0])[1]
+    return _bounded_string(link.get("project_id") or link.get("projectId"), maximum=200)
+
+
+def repository_scope(project_root: str | Path) -> dict[str, str] | None:
+    git_root = _identity_project_root(project_root)
+    if git_root is None:
+        return None
+    identity = _git_remote_identity(git_root)
+    if identity is None:
+        return None
+    return _scope_for_project(project_root, git_root, identity)
+
+
+def current_ci_run_identity(environ: dict[str, str] | None = None) -> str | None:
+    env = environ if environ is not None else os.environ
+    for provider, key in _CI_RUN_KEYS:
+        value = str(env.get(key) or "").strip()
+        if value:
+            identity = f"{provider}:{value[:300]}"
+            if provider == "github":
+                attempt = str(env.get("GITHUB_RUN_ATTEMPT") or "").strip()
+                job = str(env.get("GITHUB_JOB") or "").strip()
+                if attempt:
+                    identity += f":attempt:{attempt[:40]}"
+                if job:
+                    identity += f":job:{job[:120]}"
+            return identity
+    return None
+
+
+def is_ci_environment(environ: dict[str, str] | None = None) -> bool:
+    env = environ if environ is not None else os.environ
+    marker = str(env.get("CI") or "").strip().lower()
+    return marker in {"1", "true", "yes"} or current_ci_run_identity(env) is not None
+
+
+def _cloud_service_origin(
+    value: str | None = None, environ: dict[str, str] | None = None
+) -> str | None:
+    from urllib.parse import urlparse
+
+    env = environ if environ is not None else os.environ
+    raw = (
+        str(value or env.get("SKYLOS_API_URL") or DEFAULT_CLOUD_ORIGIN)
+        .strip()
+        .rstrip("/")
+    )
+    parsed = urlparse(raw)
+    if (
+        parsed.scheme.lower() not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    host = parsed.hostname.lower()
+    default_port = 443 if parsed.scheme.lower() == "https" else 80
+    authority = host if port in (None, default_port) else f"{host}:{port}"
+    path = parsed.path.rstrip("/")
+    return f"{parsed.scheme.lower()}://{authority}{path}"
+
+
+def _cache_root(value: str | Path | None = None) -> Path:
+    if value is not None:
+        return Path(value).expanduser()
+    return Path.home() / ".skylos" / "reviewed-findings"
+
+
+def _trusted_cache_path(
+    project_root: str | Path, *, cache_root: str | Path | None = None
+) -> Path | None:
+    scope = repository_scope(project_root)
+    if scope is None:
+        return None
+    return _trusted_cache_path_for_scope(scope, cache_root=cache_root)
+
+
+def _trusted_cache_path_for_scope(
+    scope: dict[str, str], *, cache_root: str | Path | None = None
+) -> Path:
+    digest = hashlib.sha256(canonical_json(scope).encode("utf-8")).hexdigest()
+    return _cache_root(cache_root) / f"{digest}.json"
+
+
+def _local_cache_root(value: str | Path | None = None) -> Path:
+    if value is not None:
+        return Path(value).expanduser()
+    return Path.home() / ".skylos" / "local-review-decisions"
+
+
+def _local_repository_scope(project_root: str | Path) -> dict[str, str] | None:
+    git_root = _identity_project_root(project_root)
+    if git_root is None:
+        return None
+    remote_scope = repository_scope(git_root)
+    if remote_scope is not None:
+        return remote_scope
+    return {
+        "repository_identity": "local:"
+        + hashlib.sha256(str(git_root).encode("utf-8")).hexdigest(),
+        "repo_subpath": "",
+    }
+
+
+def _local_cache_path(
+    project_root: str | Path, *, cache_root: str | Path | None = None
+) -> tuple[Path, Path, dict[str, str]] | None:
+    scope = _local_repository_scope(project_root)
+    if scope is None:
+        return None
+    return _local_cache_path_for_scope(scope, cache_root=cache_root)
+
+
+def _local_cache_path_for_scope(
+    scope: dict[str, str], *, cache_root: str | Path | None = None
+) -> tuple[Path, Path, dict[str, str]]:
+    root = _local_cache_root(cache_root)
+    digest = hashlib.sha256(canonical_json(scope).encode("utf-8")).hexdigest()
+    return root, root / f"{digest}.json", scope
+
+
+def _ensure_private_cache_root(path: Path) -> bool:
+    try:
+        path = Path(os.path.abspath(path))
+        missing: list[Path] = []
+        current = path
+        while not current.exists():
+            missing.append(current)
+            if current.parent == current:
+                return False
+            current = current.parent
+        if current.is_symlink() or not current.is_dir():
+            return False
+        for directory in reversed(missing):
+            directory.mkdir(mode=0o700)
+        if path.is_symlink() or not path.is_dir():
+            return False
+        os.chmod(path, 0o700)
+        return True
+    except OSError:
+        return False
+
+
+def write_trusted_bundle(
+    project_root: str | Path,
+    bundle: dict[str, Any],
+    *,
+    cache_root: str | Path | None = None,
+    fetched_at: datetime | None = None,
+    environ: dict[str, str] | None = None,
+    service_origin: str | None = None,
+) -> Path | None:
+    if not isinstance(bundle, dict):
+        return None
+    if bundle.get("schema") not in (None, REVIEW_SCHEMA):
+        return None
+    if bundle.get("version") not in (None, 1, REVIEW_SCHEMA_VERSION):
+        return None
+    scope = repository_scope(project_root)
+    if scope is None:
+        return None
+    path = _trusted_cache_path_for_scope(scope, cache_root=cache_root)
+    if not _ensure_private_cache_root(path.parent):
+        return None
+    current = _now_utc(fetched_at)
+    payload = deepcopy(bundle)
+    origin = _cloud_service_origin(service_origin, environ)
+    project_id = _bounded_string(payload.get("project_id"), maximum=200)
+    if origin is None:
+        return None
+    if _bundle_decision_records(payload) and project_id is None:
+        return None
+    payload["_local_trust"] = {
+        **scope,
+        "project_id": project_id,
+        "service_origin": origin,
+        "fetched_at": current.isoformat().replace("+00:00", "Z"),
+        "ci_run": current_ci_run_identity(environ),
+    }
+    try:
+        serialized = json.dumps(payload, sort_keys=True, indent=2) + "\n"
+    except (MemoryError, RecursionError, TypeError, ValueError):
+        return None
+    if len(serialized.encode("utf-8")) > MAX_BUNDLE_BYTES:
+        return None
+    if not write_text_no_symlink(path, serialized):
+        return None
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    return path
+
+
+def invalidate_trusted_bundle(
+    project_root: str | Path, *, cache_root: str | Path | None = None
+) -> bool:
+    scope = repository_scope(project_root)
+    if scope is None:
+        return False
+    path = _trusted_cache_path_for_scope(scope, cache_root=cache_root)
+    try:
+        file_stat = path.lstat()
+        if stat.S_ISLNK(file_stat.st_mode) or not stat.S_ISREG(file_stat.st_mode):
+            return False
+        path.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
+
+
+def load_trusted_bundle(
+    project_root: str | Path,
+    *,
+    cache_root: str | Path | None = None,
+    environ: dict[str, str] | None = None,
+    service_origin: str | None = None,
+    expected_project_id: str | None = None,
+    now: datetime | None = None,
+    _scope: dict[str, str] | None = None,
+) -> dict[str, Any] | None:
+    env = environ if environ is not None else os.environ
+    # Cloud cache files are locally writable and therefore cannot authorize a
+    # CI suppression. CI uploads raw findings and lets the authenticated Cloud
+    # response make the gate decision.
+    if is_ci_environment(env):
+        return None
+    scope = _scope or repository_scope(project_root)
+    if scope is None:
+        return None
+    path = _trusted_cache_path_for_scope(scope, cache_root=cache_root)
+    raw = read_text_no_symlink(path, max_bytes=MAX_BUNDLE_BYTES, encoding="utf-8")
+    if raw is None:
+        return None
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, MemoryError, RecursionError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    trust = payload.get("_local_trust")
+    if not isinstance(trust, dict):
+        return None
+    if trust.get("repository_identity") != scope["repository_identity"]:
+        return None
+    if trust.get("repo_subpath") != scope["repo_subpath"]:
+        return None
+    expected_origin = _cloud_service_origin(service_origin, environ)
+    if expected_origin is None or trust.get("service_origin") != expected_origin:
+        return None
+    project_id = _bounded_string(payload.get("project_id"), maximum=200)
+    if trust.get("project_id") != project_id:
+        return None
+    if expected_project_id is not None and project_id != expected_project_id:
+        return None
+    if _bundle_decision_records(payload) and project_id is None:
+        return None
+    fetched_at = _parse_timestamp(trust.get("fetched_at"))
+    current = _now_utc(now)
+    if (
+        fetched_at is None
+        or fetched_at > current
+        or current - fetched_at >= TRUSTED_CLOUD_CACHE_TTL
+    ):
+        return None
+    payload.pop("_local_trust", None)
+    return payload
+
+
+def _load_local_bundle(
+    project_root: str | Path,
+    *,
+    cache_root: str | Path | None = None,
+    environ: dict[str, str] | None = None,
+    _scope: dict[str, str] | None = None,
+    _identity_root: Path | None = None,
+) -> dict[str, Any] | None:
+    if is_ci_environment(environ):
+        return None
+    resolved = (
+        _local_cache_path_for_scope(_scope, cache_root=cache_root)
+        if _scope is not None
+        else _local_cache_path(project_root, cache_root=cache_root)
+    )
+    if resolved is None:
+        return None
+    root, path, scope = resolved
+    try:
+        payload = load_project_json_cache(root, path, max_bytes=MAX_BUNDLE_BYTES)
+    except (MemoryError, RecursionError):
+        return None
+    if not payload:
+        return None
+    if (
+        payload.get("schema") != REVIEW_SCHEMA
+        or payload.get("version") != REVIEW_SCHEMA_VERSION
+    ):
+        return None
+    if payload.get("source") != "local_cli":
+        return None
+    if payload.get("repository_scope") != scope:
+        return None
+    decisions = payload.get("decisions")
+    if not isinstance(decisions, list) or len(decisions) > MAX_DECISIONS:
+        return None
+    identity_root = _identity_root or _identity_project_root(project_root)
+    if identity_root is None or any(
+        not _valid_stored_local_record(record, identity_root) for record in decisions
+    ):
+        return None
+    return payload
+
+
+def list_local_decisions(
+    project_root: str | Path,
+    *,
+    include_revoked: bool = False,
+    environ: dict[str, str] | None = None,
+    cache_root: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    if is_ci_environment(environ):
+        return []
+    resolved = _local_cache_path(project_root, cache_root=cache_root)
+    if resolved is None:
+        raise ValueError("local review decisions require a Git repository")
+    identity_root = _identity_project_root(project_root)
+    if identity_root is None:
+        raise ValueError("local review decisions require a Git repository")
+    _root, path, _scope = resolved
+    payload = _load_local_bundle(
+        project_root,
+        cache_root=cache_root,
+        environ=environ,
+    )
+    if payload is None:
+        try:
+            if path.exists() or path.is_symlink():
+                raise ValueError("local review decision store is invalid or unsafe")
+        except OSError as exc:
+            raise OSError("could not inspect local review decision store") from exc
+        return []
+    records = payload["decisions"]
+    if include_revoked:
+        return [deepcopy(record) for record in records if isinstance(record, dict)]
+    return [
+        {
+            key: deepcopy(value)
+            for key, value in record.items()
+            if not key.startswith("_")
+        }
+        for record in active_decisions(payload, identity_root)
+    ]
+
+
+def _validated_local_decision(
+    decision: Any,
+    project_root: str | Path,
+    *,
+    now: datetime,
+) -> dict[str, Any]:
+    if not isinstance(decision, dict):
+        raise ValueError("review decision must be an object")
+    try:
+        decision_size = len(canonical_json(decision).encode("utf-8"))
+    except (MemoryError, RecursionError, TypeError, ValueError) as exc:
+        raise ValueError("review decision is not valid JSON") from exc
+    if decision_size > 20_000:
+        raise ValueError("review decision is too large")
+
+    decision_id = _decision_id(decision.get("decision_id"))
+    reason = _bounded_string(decision.get("reason"), maximum=2_000)
+    disposition = decision.get("disposition")
+    created_at = _parse_timestamp(decision.get("created_at"))
+    file_path = normalize_repo_path(decision.get("file_path"), project_root)
+    line_number = _strict_positive_line(
+        decision.get("line_number") or decision.get("line")
+    )
+    if decision_id is None:
+        raise ValueError("review decision requires a decision_id")
+    if reason is None:
+        raise ValueError("review decision requires a reason")
+    if disposition not in SUPPRESSING_DISPOSITIONS:
+        raise ValueError("unsupported local review disposition")
+    if created_at is None:
+        raise ValueError("review decision requires a timezone-aware created_at")
+    if file_path is None or line_number is None:
+        raise ValueError("review decision has an invalid repository location")
+    if _v2_key(decision) is None:
+        raise ValueError("review decision requires a complete v2 finding identity")
+    if _active_disposition(decision, now) is None:
+        raise ValueError("review decision is expired or missing a required expiry")
+
+    normalized: dict[str, Any] = {
+        "decision_id": decision_id,
+        "fingerprint_version": decision["fingerprint_version"],
+        "stable_fingerprint": decision["stable_fingerprint"],
+        "context_hash": decision["context_hash"],
+        "rule_revision": str(decision["rule_revision"]).strip(),
+        "rule_id": str(decision["rule_id"]).strip(),
+        "file_path": file_path,
+        "line_number": line_number,
+        "disposition": disposition,
+        "reason": reason,
+        "created_at": created_at.isoformat().replace("+00:00", "Z"),
+        "source": "local_cli",
+    }
+    expires_raw = decision.get("expires_at")
+    if expires_raw not in (None, ""):
+        expires_at = _parse_timestamp(expires_raw)
+        if expires_at is None:
+            raise ValueError("review decision has an invalid expiry")
+        normalized["expires_at"] = expires_at.isoformat().replace("+00:00", "Z")
+    for key, maximum in (
+        ("language", 40),
+        ("symbol", 500),
+        ("section", 80),
+        ("category", 80),
+    ):
+        value = _bounded_string(decision.get(key), maximum=maximum)
+        if value is not None:
+            normalized[key] = value
+    return normalized
+
+
+def _new_local_bundle(scope: dict[str, str]) -> dict[str, Any]:
+    return {
+        "schema": REVIEW_SCHEMA,
+        "version": REVIEW_SCHEMA_VERSION,
+        "source": "local_cli",
+        "repository_scope": scope,
+        "decisions": [],
+    }
+
+
+def record_local_decision(
+    project_root: str | Path,
+    decision: dict[str, Any],
+    *,
+    environ: dict[str, str] | None = None,
+    cache_root: str | Path | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    if is_ci_environment(environ):
+        raise RuntimeError("local review decisions cannot be created in CI")
+    current = _now_utc(now)
+    identity_root = _identity_project_root(project_root)
+    if identity_root is None:
+        raise ValueError("local review decisions require a Git repository")
+    normalized = _validated_local_decision(decision, identity_root, now=current)
+    resolved = _local_cache_path(project_root, cache_root=cache_root)
+    if resolved is None:
+        raise ValueError("local review decisions require a Git repository")
+    root, path, scope = resolved
+    if not _ensure_private_cache_root(root):
+        raise OSError("could not create a private local review store")
+
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with project_cache_lock(root, lock_path) as acquired:
+        if not acquired:
+            raise OSError("local review decision store is busy or unsafe")
+        payload = _load_local_bundle(
+            project_root,
+            cache_root=cache_root,
+            environ=environ,
+        )
+        if payload is None:
+            try:
+                if path.exists() or path.is_symlink():
+                    raise ValueError("local review decision store is invalid or unsafe")
+            except OSError as exc:
+                raise OSError("could not inspect local review decision store") from exc
+            payload = _new_local_bundle(scope)
+        records = payload["decisions"]
+        if any(
+            isinstance(record, dict)
+            and (record.get("decision_id") or record.get("id"))
+            == normalized["decision_id"]
+            for record in records
+        ):
+            raise ValueError("review decision_id already exists")
+        if len(records) >= MAX_DECISIONS:
+            raise ValueError("local review decision store is full")
+
+        new_key = _v2_key(normalized)
+        revoked_at = current.isoformat().replace("+00:00", "Z")
+        for record in records:
+            if (
+                isinstance(record, dict)
+                and record.get("revoked_at") in (None, "")
+                and _v2_key(record) == new_key
+            ):
+                record["revoked_at"] = revoked_at
+                record["revoked_reason"] = "superseded by a newer local decision"
+        records.append(normalized)
+        if not save_project_json_cache(root, path, payload):
+            raise OSError("could not save local review decision securely")
+    return deepcopy(normalized)
+
+
+def revoke_local_decision(
+    project_root: str | Path,
+    decision_id: str,
+    *,
+    environ: dict[str, str] | None = None,
+    cache_root: str | Path | None = None,
+    now: datetime | None = None,
+) -> bool:
+    if is_ci_environment(environ):
+        raise RuntimeError("local review decisions cannot be changed in CI")
+    normalized_id = _bounded_string(decision_id, maximum=200)
+    if normalized_id is None:
+        raise ValueError("decision_id is required")
+    resolved = _local_cache_path(project_root, cache_root=cache_root)
+    if resolved is None:
+        raise ValueError("local review decisions require a Git repository")
+    root, path, _scope = resolved
+    if not _ensure_private_cache_root(root):
+        raise OSError("could not access the private local review store")
+
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with project_cache_lock(root, lock_path) as acquired:
+        if not acquired:
+            raise OSError("local review decision store is busy or unsafe")
+        payload = _load_local_bundle(
+            project_root,
+            cache_root=cache_root,
+            environ=environ,
+        )
+        if payload is None:
+            try:
+                if path.exists() or path.is_symlink():
+                    raise ValueError("local review decision store is invalid or unsafe")
+            except OSError as exc:
+                raise OSError("could not inspect local review decision store") from exc
+            return False
+        target = None
+        for record in payload["decisions"]:
+            if (
+                isinstance(record, dict)
+                and record.get("decision_id") == normalized_id
+                and record.get("revoked_at") in (None, "")
+            ):
+                target = record
+        if target is None:
+            return False
+        target["revoked_at"] = _now_utc(now).isoformat().replace("+00:00", "Z")
+        target["revoked_reason"] = "restored from local CLI"
+        if not save_project_json_cache(root, path, payload):
+            raise OSError("could not update local review decision securely")
+    return True
+
+
+def normalize_repo_path(
+    value: Any,
+    project_root: str | Path,
+    *,
+    allow_absolute: bool = False,
+) -> str | None:
+    if not isinstance(value, (str, Path)):
+        return None
+    original = str(value)
+    if any(ord(char) < 32 or ord(char) == 127 for char in original):
+        return None
+    raw = original.strip().replace("\\", "/")
+    if not raw or raw.startswith("//") or _DRIVE_RE.match(raw):
+        return None
+
+    root = Path(project_root).expanduser()
+    try:
+        root = root.resolve(strict=True)
+    except OSError:
+        return None
+
+    candidate = Path(raw).expanduser()
+    if candidate.is_absolute():
+        if not allow_absolute:
+            return None
+        try:
+            relative = Path(os.path.abspath(candidate)).relative_to(root)
+        except (OSError, ValueError):
+            return None
+    else:
+        posix = PurePosixPath(raw)
+        if not posix.parts or any(part in {"", ".", ".."} for part in posix.parts):
+            return None
+        relative = Path(*posix.parts)
+
+    normalized = relative.as_posix()
+    if (
+        not normalized
+        or len(normalized) > 500
+        or normalized == "."
+        or normalized.startswith("../")
+    ):
+        return None
+
+    try:
+        resolved = (root / relative).resolve(strict=False)
+        resolved.relative_to(root)
+    except (OSError, ValueError):
+        return None
+    return normalized
+
+
+def _positive_line(value: Any) -> int | None:
+    try:
+        line = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    return line if line > 0 else None
+
+
+def _strict_positive_line(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if 0 < value <= 9_007_199_254_740_991 else None
+
+
+def _bounded_string(value: Any, *, maximum: int = MAX_STRING_LENGTH) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized or len(normalized) > maximum or "\x00" in normalized:
+        return None
+    return normalized
+
+
+def _decision_id(value: Any) -> str | None:
+    if not isinstance(value, str) or not value or len(value) > 200:
+        return None
+    if value != value.strip() or any(
+        ord(char) < 32 or ord(char) == 127 for char in value
+    ):
+        return None
+    return value
+
+
+def _valid_stored_local_record(record: Any, project_root: str | Path) -> bool:
+    if not isinstance(record, dict) or record.get("source") != "local_cli":
+        return False
+    allowed_keys = {
+        "decision_id",
+        "fingerprint_version",
+        "stable_fingerprint",
+        "context_hash",
+        "rule_revision",
+        "rule_id",
+        "file_path",
+        "line_number",
+        "disposition",
+        "reason",
+        "created_at",
+        "source",
+        "expires_at",
+        "language",
+        "symbol",
+        "section",
+        "category",
+        "revoked_at",
+        "revoked_reason",
+        "status",
+    }
+    if not set(record).issubset(allowed_keys):
+        return False
+    if _v2_key(record) is None:
+        return False
+    if _decision_id(record.get("decision_id")) is None:
+        return False
+    if _strict_positive_line(record.get("line_number")) is None:
+        return False
+    if normalize_repo_path(record.get("file_path"), project_root) is None:
+        return False
+    if record.get("disposition") not in SUPPRESSING_DISPOSITIONS or "type" in record:
+        return False
+    if _bounded_string(record.get("reason"), maximum=2_000) is None:
+        return False
+    if _parse_timestamp(record.get("created_at")) is None:
+        return False
+    if (
+        record.get("expires_at") is not None
+        and _parse_timestamp(record.get("expires_at")) is None
+    ):
+        return False
+    if (
+        record.get("disposition") == "risk_accepted"
+        and record.get("expires_at") is None
+    ):
+        return False
+    if (
+        record.get("revoked_at") is not None
+        and _parse_timestamp(record.get("revoked_at")) is None
+    ):
+        return False
+    status = record.get("status")
+    return status is None or status == "active"
+
+
+def _valid_rule_id(value: Any) -> str | None:
+    if not isinstance(value, str) or not value or len(value) > 120:
+        return None
+    if value != value.strip() or any(
+        ord(char) < 32 or ord(char) == 127 for char in value
+    ):
+        return None
+    return value
+
+
+def _rule_id(finding: dict[str, Any], fallback: str) -> str | None:
+    value = (
+        finding.get("rule_id")
+        or finding.get("rule")
+        or finding.get("code")
+        or finding.get("id")
+        or fallback
+    )
+    return _valid_rule_id(value)
+
+
+def _symbol(finding: dict[str, Any]) -> str:
+    value = (
+        finding.get("qualified_name")
+        or finding.get("qualname")
+        or finding.get("symbol")
+        or finding.get("function")
+        or finding.get("name")
+        or "<file>"
+    )
+    return str(value).strip()[:500] or "<file>"
+
+
+def _language(finding: dict[str, Any], file_path: str) -> str:
+    explicit = finding.get("language")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip().lower()[:40]
+    return _LANGUAGES.get(Path(file_path).suffix.lower(), "unknown")
+
+
+def _strip_untrusted_review_fields(result: dict[str, Any]) -> dict[str, Any]:
+    sanitized = dict(result)
+    sanitized.pop("reviewed_findings", None)
+    sanitized.pop("reviewed_findings_summary", None)
+    for section, _category, _default_rule_id in FINDING_SECTIONS:
+        findings = result.get(section)
+        if not isinstance(findings, list):
+            continue
+        cleaned_items: list[Any] = []
+        changed = False
+        for item in findings:
+            if not isinstance(item, dict):
+                cleaned_items.append(item)
+                continue
+            metadata = item.get("metadata")
+            has_reserved_metadata = isinstance(metadata, dict) and any(
+                key in metadata for key in _RESERVED_REVIEW_KEYS
+            )
+            if (
+                not any(key in item for key in _RESERVED_REVIEW_KEYS)
+                and not has_reserved_metadata
+            ):
+                cleaned_items.append(item)
+                continue
+            cleaned = {
+                key: value
+                for key, value in item.items()
+                if key not in _RESERVED_REVIEW_KEYS
+            }
+            if isinstance(metadata, dict):
+                cleaned_metadata = {
+                    key: value
+                    for key, value in metadata.items()
+                    if key not in _RESERVED_REVIEW_KEYS
+                }
+                if cleaned_metadata:
+                    cleaned["metadata"] = cleaned_metadata
+                else:
+                    cleaned.pop("metadata", None)
+            cleaned_items.append(cleaned)
+            changed = True
+        if changed:
+            sanitized[section] = cleaned_items
+    return sanitized
+
+
+def _normalize_source_line(value: str) -> str:
+    # Whitespace can change program semantics (Python indentation and string
+    # literals in every supported language), so it is part of the identity.
+    return value
+
+
+def _bounded_evidence(value: Any, *, depth: int = 0) -> Any:
+    if depth > 6:
+        return None
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return value[:2_000]
+    if isinstance(value, list):
+        return [_bounded_evidence(item, depth=depth + 1) for item in value[:64]]
+    if isinstance(value, dict):
+        bounded: dict[str, Any] = {}
+        for key in sorted(value, key=lambda item: str(item))[:64]:
+            safe_key = str(key)[:120]
+            bounded[safe_key] = _bounded_evidence(value[key], depth=depth + 1)
+        return bounded
+    return str(value)[:500]
+
+
+def _bounded_result_copy(
+    value: Any,
+    *,
+    depth: int = 0,
+    ancestors: frozenset[int] = frozenset(),
+) -> Any:
+    """Copy analyzer output without trusting its nesting depth or acyclicity."""
+    if depth > 32:
+        return None
+    if value is None or isinstance(value, (bool, int, float, str, bytes)):
+        return value
+    value_id = id(value)
+    if value_id in ancestors:
+        return None
+    nested_ancestors = ancestors | {value_id}
+    if isinstance(value, dict):
+        return {
+            key: _bounded_result_copy(
+                item,
+                depth=depth + 1,
+                ancestors=nested_ancestors,
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _bounded_result_copy(
+                item,
+                depth=depth + 1,
+                ancestors=nested_ancestors,
+            )
+            for item in value
+        ]
+    if isinstance(value, tuple):
+        return tuple(
+            _bounded_result_copy(
+                item,
+                depth=depth + 1,
+                ancestors=nested_ancestors,
+            )
+            for item in value
+        )
+    try:
+        return deepcopy(value)
+    except (MemoryError, RecursionError, TypeError, ValueError):
+        return str(value)[:500]
+
+
+def _security_evidence(finding: dict[str, Any]) -> Any:
+    metadata = finding.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    # These are analyzer proof inputs, not presentation fields.  A decision
+    # made for an unverified candidate must not silently carry over after a
+    # verifier, data-flow path, or related location changes.
+    evidence = {
+        "security_evidence": (
+            finding.get("security_evidence")
+            or finding.get("_security_evidence")
+            or finding.get("security_details")
+            or metadata.get("security_evidence")
+        ),
+        "evidence_contract": finding.get("evidence_contract")
+        or metadata.get("evidence_contract"),
+        "verification": finding.get("verification") or metadata.get("verification"),
+        "related_locations": finding.get("related_locations")
+        or metadata.get("related_locations"),
+        "verdict": finding.get("verdict")
+        or finding.get("_review_verdict")
+        or finding.get("_llm_verdict")
+        or metadata.get("review_verdict"),
+        "proof": finding.get("proof")
+        or finding.get("_review_safety_proof")
+        or metadata.get("review_safety_proof"),
+        "proof_kind": finding.get("proof_kind")
+        or finding.get("_review_proof_kind")
+        or metadata.get("review_proof_kind"),
+        "proof_lines": finding.get("proof_lines")
+        or finding.get("_review_proof_lines")
+        or metadata.get("review_proof_lines"),
+    }
+    bounded = _bounded_evidence(evidence)
+    if isinstance(bounded, dict):
+        return {
+            key: value for key, value in bounded.items() if value not in (None, [], {})
+        }
+    return bounded
+
+
+def _finding_assurance_context(finding: dict[str, Any]) -> dict[str, Any]:
+    """Return state that changes how strongly Skylos stands behind a finding."""
+    metadata = finding.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+    raw_source = _bounded_string(
+        finding.get("_source") or metadata.get("source"), maximum=120
+    )
+    normalized_source = None
+    if raw_source:
+        lowered_source = raw_source.lower()
+        if lowered_source in {"analyzer", "skylos", "static"}:
+            # The native analyzer normally emits no source label. Agent views
+            # add ``static`` while flattening the same finding, so treating it
+            # as evidence would make one analyzer finding acquire two
+            # incompatible review identities.
+            normalized_source = None
+        else:
+            normalized_source = "llm" if "llm" in lowered_source else lowered_source
+    confidence = finding.get("confidence", finding.get("_confidence"))
+    if isinstance(confidence, str):
+        confidence = confidence.strip().lower()[:120]
+    return {
+        "severity": str(finding.get("severity") or "UNKNOWN").strip().upper(),
+        "confidence": _bounded_evidence(confidence),
+        "source": normalized_source,
+        "model": _bounded_string(
+            finding.get("model") or metadata.get("model"), maximum=300
+        ),
+        "provider": _bounded_string(
+            finding.get("provider") or metadata.get("provider"), maximum=120
+        ),
+        "prompt_revision": _bounded_string(
+            finding.get("prompt_revision") or metadata.get("prompt_revision"),
+            maximum=200,
+        ),
+        "evidence_contract": _bounded_evidence(
+            finding.get("evidence_contract") or metadata.get("evidence_contract")
+        ),
+        "verification": _bounded_evidence(
+            finding.get("verification") or metadata.get("verification")
+        ),
+        "verdict": _bounded_string(
+            finding.get("verdict")
+            or finding.get("_review_verdict")
+            or finding.get("_llm_verdict")
+            or metadata.get("review_verdict"),
+            maximum=120,
+        ),
+    }
+
+
+def _tree_sitter_language(language: str, suffix: str):
+    from tree_sitter import Language
+
+    if language in {"typescript", "javascript"}:
+        import tree_sitter_typescript as grammar
+
+        factory = (
+            grammar.language_tsx
+            if suffix in {".tsx", ".jsx"}
+            else grammar.language_typescript
+        )
+    elif language == "java":
+        import tree_sitter_java as grammar
+
+        factory = grammar.language
+    elif language == "go":
+        import tree_sitter_go as grammar
+
+        factory = grammar.language
+    elif language == "php":
+        import tree_sitter_php as grammar
+
+        factory = grammar.language_php
+    elif language == "rust":
+        import tree_sitter_rust as grammar
+
+        factory = grammar.language
+    elif language == "dart":
+        import tree_sitter_dart_orchard as grammar
+
+        factory = grammar.language
+    else:
+        return None
+    return Language(factory())
+
+
+def _semantic_source_hash(source: str, language: str, suffix: str) -> str:
+    if language == "python":
+        try:
+            tree = ast.parse(source, type_comments=True)
+            return sha256_value(
+                {
+                    "parser": "python-ast-v1",
+                    "tree": ast.dump(tree, include_attributes=False),
+                }
+            )
+        except Exception:
+            return sha256_value({"parser": "raw-v1", "source": source})
+
+    try:
+        from tree_sitter import Parser
+
+        grammar = _tree_sitter_language(language, suffix)
+        if grammar is None:
+            raise ValueError("unsupported semantic parser")
+        source_bytes = source.encode("utf-8")
+        root = Parser(grammar).parse(source_bytes).root_node
+        digest = hashlib.sha256(f"tree-sitter-{language}-v1\0".encode("ascii"))
+        stack: list[tuple[Any, bool]] = [(root, False)]
+        while stack:
+            node, closing = stack.pop()
+            if closing:
+                digest.update(b")")
+                continue
+            node_type = node.type.encode("utf-8")
+            digest.update(b"(")
+            digest.update(len(node_type).to_bytes(4, "big"))
+            digest.update(node_type)
+            children = [child for child in node.children if not child.is_extra]
+            if children:
+                stack.append((node, True))
+                stack.extend((child, False) for child in reversed(children))
+                continue
+            token_text = source_bytes[node.start_byte : node.end_byte]
+            digest.update(len(token_text).to_bytes(8, "big"))
+            digest.update(token_text)
+            digest.update(b")")
+        return "sha256:" + digest.hexdigest()
+    except Exception:
+        return sha256_value({"parser": "raw-v1", "source": source})
+
+
+def _python_import_candidates(
+    project_root: Path,
+    importer_path: str,
+    node: ast.Import | ast.ImportFrom,
+    module_index: dict[str, tuple[str, ...]],
+) -> list[str] | None:
+    importer_parent = Path(importer_path).parent
+    modules: list[tuple[Path | None, tuple[str, ...]]] = []
+    if isinstance(node, ast.Import):
+        modules.extend((None, tuple(alias.name.split("."))) for alias in node.names)
+    else:
+        module_parts = tuple((node.module or "").split(".")) if node.module else ()
+        if node.level:
+            base = importer_parent
+            for _ in range(max(0, node.level - 1)):
+                base = base.parent
+            modules.append((base, module_parts))
+        elif module_parts:
+            modules.append((None, module_parts))
+        for alias in node.names:
+            if alias.name != "*":
+                modules.append(
+                    (
+                        modules[-1][0] if modules else None,
+                        module_parts + tuple(alias.name.split(".")),
+                    )
+                )
+
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for relative_base, parts in modules:
+        if not parts:
+            continue
+        if relative_base is None:
+            indexed_paths = module_index.get(".".join(parts), ())
+            direct_stem = Path(*parts)
+            resolved_paths = tuple(
+                dict.fromkeys(
+                    (
+                        *indexed_paths,
+                        direct_stem.with_suffix(".py").as_posix(),
+                        (direct_stem / "__init__.py").as_posix(),
+                    )
+                )
+            )
+        else:
+            stem = relative_base.joinpath(*parts)
+            resolved_paths = tuple(
+                candidate.as_posix()
+                for candidate in (stem.with_suffix(".py"), stem / "__init__.py")
+            )
+        for candidate in resolved_paths:
+            normalized = normalize_repo_path(candidate, project_root)
+            if normalized is None:
+                try:
+                    if (project_root / candidate).exists() or (
+                        project_root / candidate
+                    ).is_symlink():
+                        return None
+                except OSError:
+                    return None
+                continue
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            try:
+                candidate_stat = (project_root / normalized).lstat()
+            except FileNotFoundError:
+                continue
+            except OSError:
+                candidates.append(normalized)
+                continue
+            if stat.S_ISREG(candidate_stat.st_mode) or stat.S_ISLNK(
+                candidate_stat.st_mode
+            ):
+                candidates.append(normalized)
+    return candidates
+
+
+def _python_module_index(project_root: Path) -> dict[str, tuple[str, ...]] | None:
+    from collections import defaultdict as _defaultdict
+
+    modules: dict[str, set[str]] = _defaultdict(set)
+    file_count = 0
+    walk_failed = False
+
+    def onerror(_error: OSError) -> None:
+        nonlocal walk_failed
+        walk_failed = True
+
+    excluded = {".git", ".hg", ".svn", ".venv", "node_modules", "__pycache__"}
+    for current, directories, files in os.walk(
+        project_root,
+        topdown=True,
+        followlinks=False,
+        onerror=onerror,
+    ):
+        safe_directories: list[str] = []
+        for name in directories:
+            directory = Path(current) / name
+            try:
+                if directory.is_symlink():
+                    walk_failed = True
+                    continue
+            except OSError:
+                walk_failed = True
+                continue
+            if name in excluded:
+                continue
+            safe_directories.append(name)
+        directories[:] = safe_directories
+        for name in files:
+            if not name.endswith((".py", ".pyi")):
+                continue
+            file_count += 1
+            if file_count > MAX_PYTHON_INDEX_FILES:
+                return None
+            absolute = Path(current) / name
+            try:
+                relative = absolute.relative_to(project_root)
+                file_stat = absolute.lstat()
+            except (OSError, ValueError):
+                walk_failed = True
+                continue
+            if not stat.S_ISREG(file_stat.st_mode):
+                walk_failed = True
+                continue
+            parts = list(relative.with_suffix("").parts)
+            if parts and parts[-1] == "__init__":
+                parts.pop()
+            if not parts:
+                continue
+            relative_path = relative.as_posix()
+            for start in range(len(parts)):
+                modules[".".join(parts[start:])].add(relative_path)
+    if walk_failed:
+        return None
+
+    package_directories = _python_package_directories(project_root)
+    if package_directories is None:
+        return None
+    for package_name, directory in package_directories.items():
+        base = project_root / directory
+        try:
+            base_stat = base.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError:
+            return None
+        if not stat.S_ISDIR(base_stat.st_mode):
+            return None
+        for absolute in base.rglob("*"):
+            if not absolute.name.endswith((".py", ".pyi")):
+                continue
+            try:
+                file_stat = absolute.lstat()
+                relative_to_base = absolute.relative_to(base).with_suffix("")
+                relative_to_root = absolute.relative_to(project_root).as_posix()
+            except (OSError, ValueError):
+                return None
+            if not stat.S_ISREG(file_stat.st_mode):
+                return None
+            parts = list(relative_to_base.parts)
+            if parts and parts[-1] == "__init__":
+                parts.pop()
+            mapped_parts = [*package_name.split("."), *parts]
+            if mapped_parts:
+                modules[".".join(mapped_parts)].add(relative_to_root)
+    return {key: tuple(sorted(paths)) for key, paths in modules.items()}
+
+
+def _python_package_directories(project_root: Path) -> dict[str, Path] | None:
+    """Read static package-name-to-directory mappings without executing setup code."""
+    mappings: dict[str, Path] = {}
+
+    def add_mapping(raw_package: Any, raw_directory: Any) -> bool:
+        if not isinstance(raw_package, str) or not isinstance(raw_directory, str):
+            return False
+        package = raw_package.strip()
+        directory_text = raw_directory.strip().replace("\\", "/")
+        if not package:
+            # Default source roots are already represented by suffix indexing.
+            return True
+        if not re.fullmatch(r"[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*", package):
+            return False
+        directory = PurePosixPath(directory_text)
+        if (
+            not directory_text
+            or directory.is_absolute()
+            or any(part in {"", ".", ".."} for part in directory.parts)
+        ):
+            return False
+        mappings[package] = Path(*directory.parts)
+        return True
+
+    pyproject = read_project_text_no_symlink(
+        project_root,
+        "pyproject.toml",
+        max_bytes=MAX_SOURCE_BYTES,
+        encoding="utf-8",
+    )
+    if pyproject is not None:
+        try:
+            import tomllib
+
+            parsed = tomllib.loads(pyproject)
+            package_dir = (
+                parsed.get("tool", {}).get("setuptools", {}).get("package-dir", {})
+            )
+        except (MemoryError, RecursionError, TypeError, ValueError):
+            return None
+        if not isinstance(package_dir, dict):
+            return None
+        if any(not add_mapping(key, value) for key, value in package_dir.items()):
+            return None
+
+    setup_cfg = read_project_text_no_symlink(
+        project_root,
+        "setup.cfg",
+        max_bytes=MAX_SOURCE_BYTES,
+        encoding="utf-8",
+    )
+    if setup_cfg is not None:
+        try:
+            import configparser
+
+            parser = configparser.ConfigParser(interpolation=None)
+            parser.read_string(setup_cfg)
+            raw = parser.get("options", "package_dir", fallback="")
+            for line in raw.splitlines():
+                if not line.strip():
+                    continue
+                if "=" not in line:
+                    return None
+                package, directory = line.split("=", 1)
+                if not add_mapping(package, directory):
+                    return None
+        except (configparser.Error, MemoryError, RecursionError, ValueError):
+            return None
+
+    setup_py = read_project_text_no_symlink(
+        project_root,
+        "setup.py",
+        max_bytes=MAX_SOURCE_BYTES,
+        encoding="utf-8",
+    )
+    if setup_py is not None and re.search(r"\bpackage_dir\s*=", setup_py):
+        # setup.py is executable Python; guessing its computed mapping would
+        # let a reviewed security finding outlive a dependency change.
+        return None
+    return mappings
+
+
+def _python_parent_initializers(
+    project_root: Path,
+    file_path: str,
+) -> list[str] | None:
+    parents: list[str] = []
+    current = Path(file_path).parent
+    while current != Path(".") and current.parts:
+        candidate = current / "__init__.py"
+        absolute = project_root / candidate
+        try:
+            candidate_stat = absolute.lstat()
+        except FileNotFoundError:
+            current = current.parent
+            continue
+        except OSError:
+            return None
+        if not stat.S_ISREG(candidate_stat.st_mode):
+            return None
+        parents.append(candidate.as_posix())
+        current = current.parent
+    return parents
+
+
+def _environment_dependency_hash(
+    project_root: Path,
+    language: str,
+    *,
+    dependency_cache: dict[str, Any] | None,
+) -> str | None:
+    """Hash dependency-resolution inputs that can change a security proof."""
+    cache_key = f"environment:{language}"
+    if dependency_cache is not None and cache_key in dependency_cache:
+        return dependency_cache[cache_key]
+
+    try:
+        from skylos.verification.comparison import is_environment_file
+    except ImportError:
+        return None
+
+    records: list[dict[str, str]] = []
+    environment: dict[str, str] = {}
+    for name in ("SKYLOS_ADDOPTS", "SKYLOS_CUSTOM_RULES"):
+        if name not in os.environ:
+            continue
+        raw_value = str(os.environ.get(name) or "")
+        if len(raw_value.encode("utf-8")) > MAX_DEPENDENCY_SOURCE_BYTES:
+            if dependency_cache is not None:
+                dependency_cache[cache_key] = None
+            return None
+        environment[name] = (
+            "sha256:" + hashlib.sha256(raw_value.encode("utf-8")).hexdigest()
+        )
+
+    explicit_config = str(os.environ.get("SKYLOS_CONFIG_FILE") or "").strip()
+    if explicit_config:
+        candidate = Path(explicit_config).expanduser()
+        if not candidate.is_absolute():
+            candidate = Path.cwd() / candidate
+        try:
+            resolved_config = candidate.resolve(strict=True)
+        except OSError:
+            if dependency_cache is not None:
+                dependency_cache[cache_key] = None
+            return None
+        config_text = read_text_no_symlink(
+            resolved_config,
+            max_bytes=MAX_SOURCE_BYTES,
+            encoding="utf-8",
+            errors="surrogateescape",
+        )
+        if config_text is None:
+            if dependency_cache is not None:
+                dependency_cache[cache_key] = None
+            return None
+        config_bytes = config_text.encode("utf-8", "surrogateescape")
+        environment["SKYLOS_CONFIG_FILE"] = sha256_value(
+            {
+                "content": "sha256:" + hashlib.sha256(config_bytes).hexdigest(),
+            }
+        )
+    total_bytes = 0
+    matched_files = 0
+    walk_failed = False
+
+    def onerror(_error: OSError) -> None:
+        nonlocal walk_failed
+        walk_failed = True
+
+    excluded = {
+        ".git",
+        ".hg",
+        ".svn",
+        ".venv",
+        "node_modules",
+        "__pycache__",
+    }
+    for current, directories, files in os.walk(
+        project_root,
+        topdown=True,
+        followlinks=False,
+        onerror=onerror,
+    ):
+        directories[:] = [name for name in directories if name not in excluded]
+        for name in files:
+            try:
+                relative = (Path(current) / name).relative_to(project_root)
+            except ValueError:
+                walk_failed = True
+                continue
+            relative_path = relative.as_posix()
+            relevant = is_environment_file(relative_path) or relative_path in {
+                ".skylos/config.yaml",
+                ".skylos/config.yml",
+            }
+            if language in {"javascript", "typescript", "all"}:
+                relevant = (
+                    relevant
+                    or name in _JS_ENVIRONMENT_FILES
+                    or (
+                        name.startswith(("tsconfig", "jsconfig"))
+                        and name.endswith(".json")
+                    )
+                )
+            if language == "all":
+                relevant = (
+                    relevant
+                    or name in _POLYGLOT_ENVIRONMENT_FILES
+                    or Path(name).suffix.lower()
+                    in {".csproj", ".fsproj", ".vbproj", ".sln", ".props", ".targets"}
+                )
+            if not relevant:
+                continue
+            matched_files += 1
+            if matched_files > MAX_ENVIRONMENT_FILES:
+                walk_failed = True
+                break
+            try:
+                file_stat = (project_root / relative).lstat()
+            except OSError:
+                walk_failed = True
+                continue
+            if not stat.S_ISREG(file_stat.st_mode):
+                walk_failed = True
+                continue
+            remaining = MAX_DEPENDENCY_SOURCE_BYTES - total_bytes
+            if remaining <= 0:
+                walk_failed = True
+                break
+            content = read_project_text_no_symlink(
+                project_root,
+                relative_path,
+                max_bytes=remaining,
+                encoding="utf-8",
+                errors="surrogateescape",
+            )
+            if content is None:
+                walk_failed = True
+                continue
+            raw = content.encode("utf-8", "surrogateescape")
+            total_bytes += len(raw)
+            records.append(
+                {
+                    "file_path": relative_path,
+                    "content_hash": "sha256:" + hashlib.sha256(raw).hexdigest(),
+                }
+            )
+        if walk_failed:
+            break
+
+    if walk_failed:
+        if dependency_cache is not None:
+            dependency_cache[cache_key] = None
+        return None
+    digest = sha256_value(
+        {
+            "scope": f"{language}-environment-v1",
+            "environment": environment,
+            "files": sorted(records, key=lambda item: item["file_path"]),
+        }
+    )
+    if dependency_cache is not None:
+        dependency_cache[cache_key] = digest
+    return digest
+
+
+def _repository_semantic_hash(
+    project_root: str | Path,
+    *,
+    source_cache: dict[str, str | None] | None,
+    semantic_cache: dict[str, str] | None,
+    dependency_cache: dict[str, Any] | None,
+) -> str | None:
+    """Bind a high-risk review to inputs the analyzer can actually consume.
+
+    Repository checkouts routinely contain large images, archives, generated
+    output, and worktree metadata.  Those files cannot change a Skylos proof,
+    so reading them made review identities both slow and needlessly fragile.
+    The inventory below follows Skylos' source/config/dependency inputs.  The
+    finding's proven dependency closure uses syntax hashes; reverse runtime
+    setup uses a fast conservative content hash.
+    """
+    if dependency_cache is None:
+        dependency_cache = {}
+    records_cache_key = "repository-input-records-v3"
+    try:
+        root = Path(project_root).resolve(strict=True)
+    except OSError:
+        return None
+
+    try:
+        from skylos.core.result_cache import _is_relevant_rel
+        from skylos.rules.secrets import ALLOWED_FILE_SUFFIXES
+    except ImportError:
+        return None
+
+    cached_records = (
+        dependency_cache.get(records_cache_key)
+        if dependency_cache is not None
+        else None
+    )
+    if isinstance(cached_records, list):
+        environment_hash = _environment_dependency_hash(
+            root,
+            "all",
+            dependency_cache=dependency_cache,
+        )
+        if environment_hash is None:
+            return None
+        overrides = {
+            item["file_path"]: semantic_cache[item["file_path"]]
+            for item in cached_records
+            if semantic_cache is not None and item.get("file_path") in semantic_cache
+        }
+        digest_cache_key = "repository-input-envelope-v3:" + sha256_value(overrides)
+        if dependency_cache is not None and digest_cache_key in dependency_cache:
+            return dependency_cache[digest_cache_key]
+        effective_records = [
+            {
+                "file_path": item["file_path"],
+                "semantic_hash": overrides.get(
+                    item["file_path"], item["semantic_hash"]
+                ),
+            }
+            for item in cached_records
+        ]
+        digest = sha256_value(
+            {
+                "scope": "repository-input-envelope-v3",
+                "environment_hash": environment_hash,
+                "files": effective_records,
+            }
+        )
+        if dependency_cache is not None:
+            dependency_cache[digest_cache_key] = digest
+        return digest
+
+    records: list[dict[str, str]] = []
+    total_bytes = 0
+    file_count = 0
+    failed = False
+
+    def onerror(_error: OSError) -> None:
+        nonlocal failed
+        failed = True
+
+    excluded = {
+        ".git",
+        ".hg",
+        ".svn",
+        ".venv",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".tox",
+        "node_modules",
+        "__pycache__",
+        "dist",
+        "build",
+        "target",
+    }
+
+    def is_input(relative: Path) -> bool:
+        relative_text = relative.as_posix()
+        name = relative.name.lower()
+        suffix = relative.suffix.lower()
+        return bool(
+            _is_relevant_rel(relative)
+            or suffix in ALLOWED_FILE_SUFFIXES
+            or name == ".env"
+            or name.startswith(".env.")
+            or relative_text in {".skylos/config.yaml", ".skylos/config.yml"}
+        )
+
+    candidates: list[Path] | None = None
+    try:
+        completed = subprocess.run(
+            read_only_git_command(
+                [
+                    "-C",
+                    str(root),
+                    "ls-files",
+                    "-z",
+                    "--cached",
+                    "--others",
+                    "--exclude-standard",
+                    "--",
+                    ".",
+                ],
+                literal_pathspecs=True,
+            ),
+            capture_output=True,
+            check=False,
+            env=read_only_git_environment(),
+            timeout=10,
+        )
+        if completed.returncode == 0:
+            candidates = [
+                root / os.fsdecode(raw) for raw in completed.stdout.split(b"\0") if raw
+            ]
+    except (OSError, subprocess.SubprocessError, ValueError):
+        candidates = None
+
+    if candidates is None:
+        candidates = []
+        for current, directories, files in os.walk(
+            root,
+            topdown=True,
+            followlinks=False,
+            onerror=onerror,
+        ):
+            safe_directories: list[str] = []
+            for name in directories:
+                directory = Path(current) / name
+                try:
+                    if directory.is_symlink():
+                        failed = True
+                        continue
+                except OSError:
+                    failed = True
+                    continue
+                relative_dir = directory.relative_to(root)
+                if name in excluded or (
+                    len(relative_dir.parts) >= 2
+                    and relative_dir.parts[:2] == (".skylos", "cache")
+                ):
+                    continue
+                safe_directories.append(name)
+            directories[:] = safe_directories
+            candidates.extend(Path(current) / name for name in files)
+
+    seen_paths: set[str] = set()
+    for absolute in sorted(candidates, key=lambda item: os.fsencode(str(item))):
+        try:
+            relative_path = absolute.relative_to(root)
+        except ValueError:
+            failed = True
+            break
+        if not is_input(relative_path):
+            continue
+        relative = relative_path.as_posix()
+        if relative in seen_paths:
+            continue
+        seen_paths.add(relative)
+        file_count += 1
+        if file_count > MAX_PYTHON_INDEX_FILES:
+            failed = True
+            break
+        try:
+            file_stat = absolute.lstat()
+        except FileNotFoundError:
+            # A tracked deletion changes the analyzer input just as a content
+            # edit does.  Retain a marker instead of abandoning every review.
+            records.append({"file_path": relative, "semantic_hash": "missing"})
+            continue
+        except OSError:
+            failed = True
+            break
+        if not stat.S_ISREG(file_stat.st_mode):
+            failed = True
+            break
+        suffix = relative_path.suffix.lower()
+        language = _LANGUAGES.get(suffix)
+        if (
+            language is not None
+            and source_cache is not None
+            and relative in source_cache
+        ):
+            source = source_cache[relative]
+        else:
+            source = read_project_text_no_symlink(
+                root,
+                relative,
+                max_bytes=MAX_SOURCE_BYTES,
+                encoding="utf-8",
+                errors=None if language is not None else "surrogateescape",
+            )
+            if language is not None and source_cache is not None:
+                source_cache[relative] = source
+        if source is None:
+            failed = True
+            break
+        encoded_source = source.encode(
+            "utf-8", "strict" if language is not None else "surrogateescape"
+        )
+        total_bytes += len(encoded_source)
+        if total_bytes > MAX_REPOSITORY_SOURCE_BYTES:
+            failed = True
+            break
+        raw_hash = "sha256:" + hashlib.sha256(encoded_source).hexdigest()
+        records.append({"file_path": relative, "semantic_hash": raw_hash})
+
+    environment_hash = None
+    if not failed:
+        environment_hash = _environment_dependency_hash(
+            root,
+            "all",
+            dependency_cache=dependency_cache,
+        )
+        failed = environment_hash is None
+    if failed:
+        return None
+
+    records = sorted(records, key=lambda item: item["file_path"])
+    if dependency_cache is not None:
+        dependency_cache[records_cache_key] = records
+    # Re-enter through the cached-record branch so semantic overrides are
+    # applied consistently on the first and subsequent findings.
+    return _repository_semantic_hash(
+        root,
+        source_cache=source_cache,
+        semantic_cache=semantic_cache,
+        dependency_cache=dependency_cache,
+    )
+
+
+def _dead_code_proof_digest(finding: dict[str, Any]) -> str | None:
+    proof = finding.get("dead_code_review_proof")
+    if not isinstance(proof, dict):
+        return None
+    if proof.get("schema") != "skylos.dead-code-review-proof-v1":
+        return None
+    if proof.get("complete") is not True:
+        return None
+    digest = proof.get("digest")
+    return digest if isinstance(digest, str) and _HASH_RE.fullmatch(digest) else None
+
+
+def _dead_code_leaf(symbol: str) -> str | None:
+    leaf = re.split(r"[.:/#]", symbol)[-1]
+    return leaf if _IDENTIFIER_TOKEN_RE.fullmatch(leaf) else None
+
+
+def _prepare_dead_code_symbol_support(
+    project_root: str | Path,
+    symbols: set[str],
+    *,
+    source_cache: dict[str, str | None] | None,
+    semantic_cache: dict[str, str] | None,
+    dependency_cache: dict[str, Any],
+) -> bool:
+    """Index files mentioning requested symbols in one repository pass."""
+    requested = {
+        leaf for symbol in symbols if (leaf := _dead_code_leaf(symbol)) is not None
+    }
+    cache_key = "dead-code-symbol-support-v2"
+    cached = dependency_cache.get(cache_key)
+    if isinstance(cached, dict) and requested.issubset(cached.get("symbols", set())):
+        return cached.get("support") is not None
+    if cache_key in dependency_cache:
+        # A partially-built or failed index must never be treated as proof.
+        dependency_cache[cache_key] = None
+        return False
+    if not requested:
+        dependency_cache[cache_key] = None
+        return False
+    if (
+        _repository_semantic_hash(
+            project_root,
+            source_cache=source_cache,
+            semantic_cache=semantic_cache,
+            dependency_cache=dependency_cache,
+        )
+        is None
+    ):
+        dependency_cache[cache_key] = None
+        return False
+    records = dependency_cache.get("repository-input-records-v3")
+    if not isinstance(records, list):
+        dependency_cache[cache_key] = None
+        return False
+
+    support: dict[str, list[dict[str, str]]] = {symbol: [] for symbol in requested}
+    records_by_path: dict[str, dict[str, str]] = {}
+    for record in records:
+        relative = record.get("file_path") if isinstance(record, dict) else None
+        if not isinstance(relative, str):
+            dependency_cache[cache_key] = None
+            return False
+        records_by_path[relative] = record
+        suffix = Path(relative).suffix.lower()
+        language = _LANGUAGES.get(suffix)
+        source = source_cache.get(relative) if source_cache is not None else None
+        if source is None:
+            source = read_project_text_no_symlink(
+                project_root,
+                relative,
+                max_bytes=MAX_SOURCE_BYTES,
+                encoding="utf-8",
+                errors=None if language is not None else "surrogateescape",
+            )
+            if source_cache is not None and language is not None:
+                source_cache[relative] = source
+        if source is None:
+            dependency_cache[cache_key] = None
+            return False
+        matches = {
+            match.group(0)
+            for match in _IDENTIFIER_TOKEN_RE.finditer(source)
+            if match.group(0) in requested
+        }
+        if not matches:
+            continue
+        if language is None:
+            semantic_hash = str(record.get("semantic_hash") or "")
+            if not _HASH_RE.fullmatch(semantic_hash):
+                dependency_cache[cache_key] = None
+                return False
+        elif semantic_cache is not None and relative in semantic_cache:
+            semantic_hash = semantic_cache[relative]
+        else:
+            semantic_hash = _semantic_source_hash(source, language, suffix)
+            if semantic_cache is not None:
+                semantic_cache[relative] = semantic_hash
+        support_record = {"file_path": relative, "semantic_hash": semantic_hash}
+        for match in matches:
+            support[match].append(support_record)
+
+    environment_hash = _environment_dependency_hash(
+        Path(project_root),
+        "all",
+        dependency_cache=dependency_cache,
+    )
+    if environment_hash is None:
+        dependency_cache[cache_key] = None
+        return False
+    dependency_cache[cache_key] = {
+        "symbols": requested,
+        "support": support,
+        "records_by_path": records_by_path,
+        "environment_hash": environment_hash,
+    }
+    return True
+
+
+def _dead_code_symbol_context_hash(
+    project_root: str | Path,
+    file_path: str,
+    symbol: str,
+    *,
+    source_cache: dict[str, str | None] | None,
+    semantic_cache: dict[str, str] | None,
+    dependency_cache: dict[str, Any] | None,
+) -> str | None:
+    """Hash source files that can carry external evidence for one symbol."""
+    if dependency_cache is None:
+        dependency_cache = {}
+    leaf = _dead_code_leaf(symbol)
+    if leaf is None or not _prepare_dead_code_symbol_support(
+        project_root,
+        {leaf},
+        source_cache=source_cache,
+        semantic_cache=semantic_cache,
+        dependency_cache=dependency_cache,
+    ):
+        return None
+    index = dependency_cache.get("dead-code-symbol-support-v2")
+    if not isinstance(index, dict):
+        return None
+    indexed_support = index.get("support")
+    records_by_path = index.get("records_by_path")
+    environment_hash = index.get("environment_hash")
+    if (
+        not isinstance(indexed_support, dict)
+        or not isinstance(records_by_path, dict)
+        or not isinstance(environment_hash, str)
+        or not _HASH_RE.fullmatch(environment_hash)
+    ):
+        return None
+    support = list(indexed_support.get(leaf, ()))
+    if not any(item.get("file_path") == file_path for item in support):
+        primary_record = records_by_path.get(file_path)
+        if not isinstance(primary_record, dict):
+            return None
+        suffix = Path(file_path).suffix.lower()
+        language = _LANGUAGES.get(suffix)
+        source = source_cache.get(file_path) if source_cache is not None else None
+        if source is None:
+            source = read_project_text_no_symlink(
+                project_root,
+                file_path,
+                max_bytes=MAX_SOURCE_BYTES,
+                encoding="utf-8",
+                errors=None if language is not None else "surrogateescape",
+            )
+        if source is None:
+            return None
+        if language is None:
+            semantic_hash = str(primary_record.get("semantic_hash") or "")
+        else:
+            semantic_hash = _semantic_source_hash(source, language, suffix)
+        if not _HASH_RE.fullmatch(semantic_hash):
+            return None
+        support.append({"file_path": file_path, "semantic_hash": semantic_hash})
+
+    if any(
+        not isinstance(item, dict)
+        or not isinstance(item.get("file_path"), str)
+        or not isinstance(item.get("semantic_hash"), str)
+        or not _HASH_RE.fullmatch(item["semantic_hash"])
+        for item in support
+    ):
+        return None
+    return sha256_value(
+        {
+            "scope": "dead-code-symbol-context-v2",
+            "symbol": leaf,
+            "environment_hash": environment_hash,
+            "files": sorted(support, key=lambda item: item["file_path"]),
+        }
+    )
+
+
+def _python_dynamic_imports(tree: ast.AST) -> list[str] | None:
+    """Return literal dynamic imports, or abstain when loader behavior escapes."""
+    module_aliases: dict[str, str] = {"__builtins__": "builtins"}
+    function_aliases = {"__import__"}
+    unsafe_module_aliases: set[str] = set()
+    unsafe_symbol_aliases: set[str] = set()
+    sys_aliases: set[str] = set()
+    site_aliases: set[str] = set()
+    unsafe_modules = {
+        "importlib.machinery",
+        "importlib.util",
+        "runpy",
+        "pkgutil",
+        "zipimport",
+    }
+    unsafe_symbols = {
+        "SourceFileLoader",
+        "SourcelessFileLoader",
+        "ExtensionFileLoader",
+        "spec_from_file_location",
+        "module_from_spec",
+        "run_module",
+        "run_path",
+        "resolve_name",
+        "zipimporter",
+    }
+    parents: dict[int, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[id(child)] = parent
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "importlib" or alias.name.startswith("importlib."):
+                    module_aliases[alias.asname or alias.name] = "importlib"
+                elif alias.name == "builtins":
+                    module_aliases[alias.asname or alias.name] = "builtins"
+                if alias.name == "sys":
+                    sys_aliases.add(alias.asname or alias.name)
+                if alias.name == "site":
+                    site_aliases.add(alias.asname or alias.name)
+                if alias.name in unsafe_modules and alias.asname:
+                    unsafe_module_aliases.add(alias.asname)
+                elif alias.name in {"runpy", "pkgutil", "zipimport"}:
+                    unsafe_module_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "importlib":
+                for alias in node.names:
+                    if alias.name == "import_module":
+                        function_aliases.add(alias.asname or alias.name)
+                    elif alias.name in {"machinery", "util"}:
+                        unsafe_module_aliases.add(alias.asname or alias.name)
+            elif node.module == "builtins":
+                for alias in node.names:
+                    if alias.name == "__import__":
+                        function_aliases.add(alias.asname or alias.name)
+            if node.module in unsafe_modules:
+                for alias in node.names:
+                    if alias.name in unsafe_symbols or alias.name == "*":
+                        unsafe_symbol_aliases.add(alias.asname or alias.name)
+            if node.module == "site":
+                for alias in node.names:
+                    if alias.name == "addsitedir":
+                        unsafe_symbol_aliases.add(alias.asname or alias.name)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            if node.id in unsafe_module_aliases or node.id in unsafe_symbol_aliases:
+                return None
+            if node.id in sys_aliases:
+                parent = parents.get(id(node))
+                if (
+                    isinstance(parent, ast.Attribute)
+                    and parent.value is node
+                    and parent.attr == "path"
+                ):
+                    return None
+            if node.id in site_aliases:
+                parent = parents.get(id(node))
+                if (
+                    isinstance(parent, ast.Attribute)
+                    and parent.value is node
+                    and parent.attr == "addsitedir"
+                ):
+                    return None
+        if isinstance(node, ast.Constant) and node.value == "PYTHONPATH":
+            return None
+
+    def is_loader(expression: ast.AST) -> bool:
+        if isinstance(expression, ast.Name):
+            return expression.id in function_aliases
+        return (
+            isinstance(expression, ast.Attribute)
+            and isinstance(expression.value, ast.Name)
+            and (
+                (
+                    module_aliases.get(expression.value.id) == "importlib"
+                    and expression.attr == "import_module"
+                )
+                or (
+                    module_aliases.get(expression.value.id) == "builtins"
+                    and expression.attr == "__import__"
+                )
+            )
+        )
+
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            value: ast.AST | None = None
+            targets: list[ast.AST] = []
+            if isinstance(node, ast.Assign):
+                value = node.value
+                targets = list(node.targets)
+            elif isinstance(node, ast.NamedExpr):
+                value = node.value
+                targets = [node.target]
+            if value is None or not is_loader(value):
+                continue
+            for target in targets:
+                if not isinstance(target, ast.Name):
+                    return None
+                if target.id not in function_aliases:
+                    function_aliases.add(target.id)
+                    changed = True
+
+    dynamic_modules: list[str] = []
+    for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+        dotted_call = ""
+        if isinstance(call.func, ast.Name):
+            dotted_call = call.func.id
+        elif isinstance(call.func, ast.Attribute):
+            parts: list[str] = []
+            current: ast.AST = call.func
+            while isinstance(current, ast.Attribute):
+                parts.append(current.attr)
+                current = current.value
+            if isinstance(current, ast.Name):
+                parts.append(current.id)
+                dotted_call = ".".join(reversed(parts))
+        if dotted_call in {"eval", "exec", "compile"} or dotted_call.endswith(
+            (
+                ".run_module",
+                ".run_path",
+                ".resolve_name",
+                ".spec_from_file_location",
+                ".module_from_spec",
+                ".SourceFileLoader",
+            )
+        ):
+            return None
+        if not is_loader(call.func):
+            continue
+        if (
+            not call.args
+            or not isinstance(call.args[0], ast.Constant)
+            or not isinstance(call.args[0].value, str)
+        ):
+            return None
+        dynamic_name = call.args[0].value.strip()
+        if not dynamic_name or dynamic_name.startswith("."):
+            return None
+        dynamic_modules.append(dynamic_name)
+
+    # Reflection or passing a loader as a value can load a module that the
+    # closure above cannot prove. In that case the review must not be reused.
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id in function_aliases:
+            parent = parents.get(id(node))
+            if isinstance(parent, ast.Call) and parent.func is node:
+                continue
+            if isinstance(parent, (ast.Assign, ast.NamedExpr)) and parent.value is node:
+                continue
+            if isinstance(parent, (ast.Import, ast.ImportFrom, ast.alias)):
+                continue
+            # ast.Name nodes are not emitted for import aliases, so every other
+            # load is an escape. Store-context assignment targets are harmless.
+            if isinstance(node.ctx, ast.Store):
+                continue
+            return None
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and is_loader(node)
+        ):
+            parent = parents.get(id(node))
+            if isinstance(parent, ast.Call) and parent.func is node:
+                continue
+            if isinstance(parent, (ast.Assign, ast.NamedExpr)) and parent.value is node:
+                continue
+            return None
+        if isinstance(node, ast.Name) and node.id in module_aliases:
+            parent = parents.get(id(node))
+            if (
+                isinstance(parent, ast.Attribute)
+                and parent.value is node
+                and is_loader(parent)
+            ):
+                continue
+            if isinstance(node.ctx, ast.Store):
+                continue
+            # getattr(), __dict__, passing the module around, and other
+            # reflection can recover a loader without an analyzable edge.
+            return None
+    return dynamic_modules
+
+
+def _python_dependency_hash(
+    project_root: str | Path,
+    file_path: str,
+    source: str,
+    *,
+    source_cache: dict[str, str | None] | None,
+    semantic_cache: dict[str, str] | None,
+    dependency_cache: dict[str, Any] | None,
+) -> str | None:
+    cache_key = f"python-dependencies:{file_path}"
+    if dependency_cache is not None and cache_key in dependency_cache:
+        return dependency_cache[cache_key]
+    try:
+        root = Path(project_root).resolve(strict=True)
+    except OSError:
+        return None
+    index_cache_key = "python-module-index"
+    module_index = (
+        dependency_cache.get(index_cache_key) if dependency_cache is not None else None
+    )
+    if not isinstance(module_index, dict):
+        module_index = _python_module_index(root)
+        if module_index is None:
+            if dependency_cache is not None:
+                dependency_cache[cache_key] = None
+            return None
+        if dependency_cache is not None:
+            dependency_cache[index_cache_key] = module_index
+    pending: list[tuple[str, str]] = [(file_path, source)]
+    visited = {file_path}
+    dependencies: list[dict[str, str]] = []
+    total_bytes = 0
+
+    while pending:
+        importer_path, importer_source = pending.pop()
+        try:
+            tree = ast.parse(importer_source, type_comments=True)
+        except (MemoryError, RecursionError, SyntaxError, ValueError):
+            if dependency_cache is not None:
+                dependency_cache[cache_key] = None
+            return None
+        dynamic_modules = _python_dynamic_imports(tree)
+        if dynamic_modules is None:
+            if dependency_cache is not None:
+                dependency_cache[cache_key] = None
+            return None
+        candidates_from_dynamic: list[str] = []
+        for dynamic_module in dynamic_modules:
+            candidates_from_dynamic.extend(module_index.get(dynamic_module, ()))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Import, ast.ImportFrom)):
+                continue
+            candidates = _python_import_candidates(
+                root,
+                importer_path,
+                node,
+                module_index,
+            )
+            if candidates is None:
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+            if isinstance(node, ast.ImportFrom) and node.level and not candidates:
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+            candidates_from_dynamic.extend(candidates)
+        parent_initializers = _python_parent_initializers(root, importer_path)
+        if parent_initializers is None:
+            if dependency_cache is not None:
+                dependency_cache[cache_key] = None
+            return None
+        candidates_from_dynamic.extend(parent_initializers)
+        for dependency_path in candidates_from_dynamic:
+            if dependency_path in visited:
+                continue
+            visited.add(dependency_path)
+            if len(visited) > MAX_DEPENDENCY_FILES:
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+            if source_cache is not None and dependency_path in source_cache:
+                dependency_source = source_cache[dependency_path]
+            else:
+                dependency_source = read_project_text_no_symlink(
+                    root,
+                    dependency_path,
+                    max_bytes=MAX_SOURCE_BYTES,
+                    encoding="utf-8",
+                )
+                if source_cache is not None:
+                    source_cache[dependency_path] = dependency_source
+            if dependency_source is None:
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+            total_bytes += len(dependency_source.encode("utf-8"))
+            if total_bytes > MAX_DEPENDENCY_SOURCE_BYTES:
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+            if semantic_cache is not None and dependency_path in semantic_cache:
+                semantic_hash = semantic_cache[dependency_path]
+            else:
+                semantic_hash = _semantic_source_hash(
+                    dependency_source, "python", ".py"
+                )
+                if semantic_cache is not None:
+                    semantic_cache[dependency_path] = semantic_hash
+            dependencies.append(
+                {"file_path": dependency_path, "semantic_hash": semantic_hash}
+            )
+            pending.append((dependency_path, dependency_source))
+
+    environment_hash = _environment_dependency_hash(
+        root,
+        "python",
+        dependency_cache=dependency_cache,
+    )
+    if environment_hash is None:
+        if dependency_cache is not None:
+            dependency_cache[cache_key] = None
+        return None
+    digest = sha256_value(
+        {
+            "scope": "python-local-import-closure-v2",
+            "environment_hash": environment_hash,
+            "files": sorted(dependencies, key=lambda item: item["file_path"]),
+        }
+    )
+    if dependency_cache is not None:
+        dependency_cache[cache_key] = digest
+    return digest
+
+
+def _typescript_dependency_hash(
+    project_root: str | Path,
+    file_path: str,
+    source: str,
+    *,
+    source_cache: dict[str, str | None] | None,
+    semantic_cache: dict[str, str] | None,
+    dependency_cache: dict[str, Any] | None,
+) -> str | None:
+    cache_key = f"typescript-dependencies:{file_path}"
+    if dependency_cache is not None and cache_key in dependency_cache:
+        return dependency_cache[cache_key]
+    try:
+        root = Path(project_root).resolve(strict=True)
+        from skylos.visitors.languages.typescript.analysis import resolve_ts_module
+        from skylos.visitors.languages.typescript.core import TypeScriptCore
+        from skylos.visitors.languages.typescript.resolve import MonorepoResolver
+    except (ImportError, OSError):
+        return None
+
+    resolver = MonorepoResolver(str(root))
+    source_suffixes = {
+        ".ts",
+        ".tsx",
+        ".js",
+        ".jsx",
+        ".mts",
+        ".cts",
+        ".mjs",
+        ".cjs",
+    }
+    pending: list[tuple[str, str]] = [(file_path, source)]
+    visited = {file_path}
+    dependencies: list[dict[str, str]] = []
+    total_bytes = 0
+    while pending:
+        importer_path, importer_source = pending.pop()
+        try:
+            core = TypeScriptCore(
+                str(root / importer_path), importer_source.encode("utf-8")
+            )
+            if core.root_node is None or core.root_node.has_error:
+                raise ValueError("incomplete TypeScript parse")
+            core.scan()
+        except (MemoryError, RecursionError, UnicodeError, ValueError):
+            if dependency_cache is not None:
+                dependency_cache[cache_key] = None
+            return None
+        for node in core._iter_nodes(core.root_node):
+            if node.type == "identifier" and core._get_text(node) == "require":
+                parent = node.parent
+                direct_call = (
+                    parent is not None
+                    and parent.type == "call_expression"
+                    and parent.child_by_field_name("function") == node
+                )
+                resolve_member = (
+                    parent is not None
+                    and parent.type == "member_expression"
+                    and parent.child_by_field_name("object") == node
+                    and core._get_text(parent) == "require.resolve"
+                )
+                if not direct_call and not resolve_member:
+                    if dependency_cache is not None:
+                        dependency_cache[cache_key] = None
+                    return None
+            if node.type == "member_expression":
+                member_text = core._get_text(node)
+                if member_text.endswith(
+                    (".require", ".require.resolve")
+                ) and not member_text.startswith("require."):
+                    if dependency_cache is not None:
+                        dependency_cache[cache_key] = None
+                    return None
+            if node.type != "call_expression":
+                continue
+            function_node = node.child_by_field_name("function")
+            arguments_node = node.child_by_field_name("arguments")
+            if function_node is None or arguments_node is None:
+                continue
+            function_text = core._get_text(function_node)
+            if function_text not in {
+                "import",
+                "require",
+                "require.resolve",
+                "import.meta.glob",
+                "import.meta.globEager",
+            }:
+                continue
+            arguments = arguments_node.named_children
+            literal_types = (
+                {"string", "array"}
+                if function_text.startswith("import.meta.glob")
+                else {"string"}
+            )
+            if not arguments or arguments[0].type not in literal_types:
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+            if arguments[0].type == "array" and any(
+                child.type != "string" for child in arguments[0].named_children
+            ):
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+        for raw_import in core.raw_imports:
+            source_path = raw_import.get("source")
+            if not isinstance(source_path, str) or not source_path:
+                continue
+            resolved = resolve_ts_module(
+                source_path,
+                str(root / importer_path),
+                resolver,
+            )
+            if resolved is None:
+                if source_path.startswith((".", "#")):
+                    if dependency_cache is not None:
+                        dependency_cache[cache_key] = None
+                    return None
+                continue
+            dependency_path = normalize_repo_path(
+                resolved,
+                root,
+                allow_absolute=True,
+            )
+            if dependency_path is None:
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+            if dependency_path in visited:
+                continue
+            visited.add(dependency_path)
+            if len(visited) > MAX_DEPENDENCY_FILES:
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+            if source_cache is not None and dependency_path in source_cache:
+                dependency_source = source_cache[dependency_path]
+            else:
+                dependency_source = read_project_text_no_symlink(
+                    root,
+                    dependency_path,
+                    max_bytes=MAX_SOURCE_BYTES,
+                    encoding="utf-8",
+                )
+                if source_cache is not None:
+                    source_cache[dependency_path] = dependency_source
+            if dependency_source is None:
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+            total_bytes += len(dependency_source.encode("utf-8"))
+            if total_bytes > MAX_DEPENDENCY_SOURCE_BYTES:
+                if dependency_cache is not None:
+                    dependency_cache[cache_key] = None
+                return None
+            dependency_suffix = Path(dependency_path).suffix.lower()
+            dependency_language = _LANGUAGES.get(dependency_suffix)
+            if semantic_cache is not None and dependency_path in semantic_cache:
+                semantic_hash = semantic_cache[dependency_path]
+            elif dependency_language is None:
+                semantic_hash = sha256_value(
+                    {"parser": "raw-dependency-v1", "source": dependency_source}
+                )
+            else:
+                semantic_hash = _semantic_source_hash(
+                    dependency_source,
+                    dependency_language,
+                    dependency_suffix,
+                )
+                if semantic_cache is not None:
+                    semantic_cache[dependency_path] = semantic_hash
+            dependencies.append(
+                {"file_path": dependency_path, "semantic_hash": semantic_hash}
+            )
+            if dependency_suffix in source_suffixes:
+                pending.append((dependency_path, dependency_source))
+
+    environment_hash = _environment_dependency_hash(
+        root,
+        "typescript",
+        dependency_cache=dependency_cache,
+    )
+    if environment_hash is None:
+        if dependency_cache is not None:
+            dependency_cache[cache_key] = None
+        return None
+    digest = sha256_value(
+        {
+            "scope": "typescript-local-import-closure-v2",
+            "environment_hash": environment_hash,
+            "files": sorted(dependencies, key=lambda item: item["file_path"]),
+        }
+    )
+    if dependency_cache is not None:
+        dependency_cache[cache_key] = digest
+    return digest
+
+
+def finding_identity(
+    finding: dict[str, Any],
+    *,
+    section: str,
+    category: str,
+    default_rule_id: str,
+    project_root: str | Path,
+    source_cache: dict[str, str | None] | None = None,
+    semantic_cache: dict[str, str] | None = None,
+    dependency_cache: dict[str, Any] | None = None,
+) -> dict[str, str] | None:
+    if finding.get("_review_identity_incomplete") is True:
+        return None
+    llm_analysis_context_hash = finding.get("_llm_analysis_context_hash")
+    if llm_analysis_context_hash is not None and (
+        not isinstance(llm_analysis_context_hash, str)
+        or not _HASH_RE.fullmatch(llm_analysis_context_hash)
+    ):
+        return None
+    if dependency_cache is not None and dependency_cache.get(
+        "analysis-review-context-invalid"
+    ):
+        return None
+    raw_path = finding.get("file_path") or finding.get("file")
+    file_path = normalize_repo_path(raw_path, project_root, allow_absolute=True)
+    line = _strict_positive_line(finding.get("line_number") or finding.get("line"))
+    if file_path is None or line is None:
+        return None
+
+    if source_cache is not None and file_path in source_cache:
+        source = source_cache[file_path]
+    else:
+        source = read_project_text_no_symlink(
+            project_root,
+            file_path,
+            max_bytes=MAX_SOURCE_BYTES,
+            encoding="utf-8",
+        )
+        if source_cache is not None:
+            source_cache[file_path] = source
+    if source is None:
+        return None
+    lines = source.splitlines()
+    empty_file_finding = section == "unused_files" and line == 1 and not lines
+    if line > len(lines) and not empty_file_finding:
+        return None
+
+    end_line = _strict_positive_line(finding.get("end_line")) or line
+    end_line = min(max(end_line, line), min(len(lines), line + 20))
+    primary_lines = [
+        _normalize_source_line(raw) for raw in lines[line - 1 : end_line] if raw.strip()
+    ]
+    if not primary_lines and not empty_file_finding:
+        return None
+
+    context_start = max(0, line - 3)
+    context_end = min(len(lines), end_line + 2)
+    context_lines = [
+        _normalize_source_line(raw) for raw in lines[context_start:context_end]
+    ]
+
+    rule_id = _rule_id(finding, default_rule_id)
+    if rule_id is None:
+        return None
+    raw_rule_revision = finding.get("rule_revision")
+    # A user/cloud supplied rule can change without the Skylos package version
+    # changing.  Such findings are reusable only when the rule implementation
+    # supplied its own content-derived revision.
+    if section == "custom_rules" and not raw_rule_revision:
+        return None
+    if raw_rule_revision is not None and (
+        not isinstance(raw_rule_revision, str)
+        or raw_rule_revision != raw_rule_revision.strip()
+    ):
+        return None
+    rule_revision = raw_rule_revision or DEFAULT_RULE_REVISION
+    if not _RULE_REVISION_RE.fullmatch(rule_revision):
+        return None
+    language = _language(finding, file_path)
+    symbol = _symbol(finding)
+    severity = str(finding.get("severity") or "").strip().upper()
+    high_risk = category in {"SECURITY", "SECRET", "DEPENDENCY"} or severity in {
+        "HIGH",
+        "CRITICAL",
+    }
+    evidence = _security_evidence(finding) if high_risk else None
+    semantic_source_hash = None
+    semantic_dependency_hash = None
+    dead_code_proof = None
+    dead_code_support_hash = None
+    if category == "DEAD_CODE":
+        dead_code_proof = _dead_code_proof_digest(finding)
+        if dead_code_proof is not None:
+            dead_code_support_hash = _dead_code_symbol_context_hash(
+                project_root,
+                file_path,
+                symbol,
+                source_cache=source_cache,
+                semantic_cache=semantic_cache,
+                dependency_cache=dependency_cache,
+            )
+            if dead_code_support_hash is None:
+                return None
+        else:
+            # Results from older/non-Python analyzers lack a complete proof
+            # slice.  Keep them reviewable, but bind the decision to the full
+            # bounded analyzer-input snapshot.
+            semantic_source_hash = _semantic_source_hash(
+                source, language, Path(file_path).suffix.lower()
+            )
+            if semantic_cache is not None:
+                semantic_cache[file_path] = semantic_source_hash
+            dead_code_support_hash = _repository_semantic_hash(
+                project_root,
+                source_cache=source_cache,
+                semantic_cache=semantic_cache,
+                dependency_cache=dependency_cache,
+            )
+            if dead_code_support_hash is None:
+                return None
+    if high_risk:
+        if semantic_cache is not None and file_path in semantic_cache:
+            semantic_source_hash = semantic_cache[file_path]
+        else:
+            semantic_source_hash = _semantic_source_hash(
+                source, language, Path(file_path).suffix.lower()
+            )
+            if semantic_cache is not None:
+                semantic_cache[file_path] = semantic_source_hash
+        local_dependency_hash = None
+        if language == "python":
+            try:
+                primary_tree = ast.parse(source, type_comments=True)
+            except (MemoryError, RecursionError, SyntaxError, ValueError):
+                return None
+            # A loader recovered from runtime state in the finding's own file
+            # can change without any repository input changing.  Do not mint a
+            # reusable identity for that case.
+            if _python_dynamic_imports(primary_tree) is None:
+                return None
+            local_dependency_hash = _python_dependency_hash(
+                project_root,
+                file_path,
+                source,
+                source_cache=source_cache,
+                semantic_cache=semantic_cache,
+                dependency_cache=dependency_cache,
+            )
+            if local_dependency_hash is None:
+                # A transitive module may contain an unrelated loader or an
+                # import form our closure cannot prove.  The repository input
+                # envelope below still gives a safe, useful exact snapshot.
+                local_dependency_hash = "dependency-closure-incomplete"
+        elif language in {"javascript", "typescript"}:
+            local_dependency_hash = _typescript_dependency_hash(
+                project_root,
+                file_path,
+                source,
+                source_cache=source_cache,
+                semantic_cache=semantic_cache,
+                dependency_cache=dependency_cache,
+            )
+            if local_dependency_hash is None:
+                return None
+        # A forward import closure cannot see startup monkeypatches, reverse
+        # importers, or framework registries.  Retain a fast, bounded envelope
+        # of other analyzer inputs until each language exposes those proof
+        # edges directly.
+        repository_hash = _repository_semantic_hash(
+            project_root,
+            source_cache=source_cache,
+            semantic_cache=semantic_cache,
+            dependency_cache=dependency_cache,
+        )
+        if repository_hash is None:
+            return None
+        semantic_dependency_hash = sha256_value(
+            {
+                "scope": "high-risk-proof-envelope-v2",
+                "local_dependency_hash": local_dependency_hash,
+                "repository_hash": repository_hash,
+            }
+        )
+    assurance = _finding_assurance_context(finding)
+    effective_config_hash = finding.get("_analysis_config_hash")
+    if effective_config_hash is not None and (
+        not isinstance(effective_config_hash, str)
+        or not _HASH_RE.fullmatch(effective_config_hash)
+    ):
+        return None
+    analysis_context_hash = None
+    if (
+        dependency_cache is not None
+        and (review_context := dependency_cache.get("analysis-review-context"))
+        is not None
+    ):
+        analysis_context_hash = review_context_hash_for_category(
+            review_context,
+            category,
+            effective_config_hash=effective_config_hash,
+        )
+        if analysis_context_hash is None:
+            return None
+    anchor_hash = sha256_value(
+        {
+            "primary_lines": primary_lines,
+            "empty_file": empty_file_finding,
+            "security_evidence": evidence,
+            "assurance": assurance,
+        }
+    )
+    stable_fingerprint = sha256_value(
+        {
+            "fingerprint_version": FINGERPRINT_VERSION,
+            "rule_id": rule_id,
+            "rule_revision": rule_revision,
+            "file_path": file_path,
+            "language": language,
+            "category": category,
+            "symbol": symbol,
+            "anchor_hash": anchor_hash,
+        }
+    )
+    context_hash = sha256_value(
+        {
+            "primary_lines": primary_lines,
+            "empty_file": empty_file_finding,
+            "context_lines": None
+            if high_risk or dead_code_proof is not None
+            else context_lines,
+            "security_evidence": evidence,
+            "assurance": assurance,
+            "semantic_source_hash": semantic_source_hash,
+            "semantic_dependency_hash": semantic_dependency_hash,
+            "dead_code_proof": dead_code_proof,
+            "dead_code_support_hash": dead_code_support_hash,
+            "analysis_context_hash": analysis_context_hash,
+            "llm_analysis_context_hash": llm_analysis_context_hash,
+        }
+    )
+    return {
+        "fingerprint_version": FINGERPRINT_VERSION,
+        "stable_fingerprint": stable_fingerprint,
+        "context_hash": context_hash,
+        "rule_revision": rule_revision,
+        "rule_id": rule_id,
+        "file_path": file_path,
+        "language": language,
+        "symbol": symbol,
+        "section": section,
+    }
+
+
+def annotate_result_identities(
+    result: dict[str, Any],
+    project_root: str | Path,
+    *,
+    candidate_keys: set[tuple[str, str | None]] | None = None,
+) -> dict[str, Any]:
+    sanitized = _strip_untrusted_review_fields(result)
+    try:
+        annotated = deepcopy(sanitized)
+    except (MemoryError, RecursionError, TypeError, ValueError):
+        annotated = _bounded_result_copy(sanitized)
+        if not isinstance(annotated, dict):
+            return {}
+    source_cache: dict[str, str | None] = {}
+    semantic_cache: dict[str, str] = {}
+    dependency_cache: dict[str, Any] = {}
+    summary = annotated.get("analysis_summary")
+    review_context = (
+        summary.get("review_context") if isinstance(summary, dict) else None
+    )
+    if isinstance(summary, dict) and "review_context" in summary:
+        if review_context_is_valid(review_context):
+            dependency_cache["analysis-review-context"] = review_context
+        else:
+            dependency_cache["analysis-review-context-invalid"] = True
+
+    def is_candidate(finding: dict[str, Any], default_rule_id: str) -> bool:
+        if candidate_keys is None:
+            return True
+        rule_id = _rule_id(finding, default_rule_id)
+        file_path = normalize_repo_path(
+            finding.get("file_path") or finding.get("file"),
+            project_root,
+            allow_absolute=True,
+        )
+        return (rule_id, file_path) in candidate_keys or (
+            rule_id,
+            None,
+        ) in candidate_keys
+
+    dead_code_symbols: set[str] = set()
+    for section, category, default_rule_id in FINDING_SECTIONS:
+        if category != "DEAD_CODE":
+            continue
+        for finding in annotated.get(section, []) or []:
+            if isinstance(finding, dict) and is_candidate(finding, default_rule_id):
+                dead_code_symbols.add(_symbol(finding))
+    if dead_code_symbols:
+        _prepare_dead_code_symbol_support(
+            project_root,
+            dead_code_symbols,
+            source_cache=source_cache,
+            semantic_cache=semantic_cache,
+            dependency_cache=dependency_cache,
+        )
+
+    for section, category, default_rule_id in FINDING_SECTIONS:
+        findings = annotated.get(section)
+        if not isinstance(findings, list):
+            continue
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            if not is_candidate(finding, default_rule_id):
+                finding.pop("_analysis_config_hash", None)
+                finding.pop("_analysis_worker_config", None)
+                finding.pop("_llm_analysis_context_hash", None)
+                continue
+            identity = finding_identity(
+                finding,
+                section=section,
+                category=category,
+                default_rule_id=default_rule_id,
+                project_root=project_root,
+                source_cache=source_cache,
+                semantic_cache=semantic_cache,
+                dependency_cache=dependency_cache,
+            )
+            finding.pop("_analysis_config_hash", None)
+            finding.pop("_analysis_worker_config", None)
+            finding.pop("_llm_analysis_context_hash", None)
+            if identity:
+                finding.update(identity)
+    return annotated
+
+
+def _bundle_decision_records(bundle: Any) -> list[Any]:
+    if isinstance(bundle, list):
+        return list(bundle)
+    if not isinstance(bundle, dict):
+        return []
+    if bundle.get("schema") not in (None, REVIEW_SCHEMA):
+        return []
+    if bundle.get("version") not in (None, 1, REVIEW_SCHEMA_VERSION):
+        return []
+    records = bundle.get("decisions")
+    if records is None:
+        records = bundle.get("suppressions")
+    return list(records) if isinstance(records, list) else []
+
+
+def _records_for_repository_scope(
+    bundle: Any,
+    project_root: str | Path,
+    repo_subpath: str,
+) -> list[Any]:
+    records = _bundle_decision_records(bundle)
+    if not repo_subpath:
+        return records
+    scoped: list[Any] = []
+    for raw in records:
+        if not isinstance(raw, dict):
+            scoped.append(raw)
+            continue
+        file_path = normalize_repo_path(raw.get("file_path"), project_root)
+        if file_path is None:
+            scoped.append(raw)
+            continue
+        record = dict(raw)
+        if file_path != repo_subpath and not file_path.startswith(f"{repo_subpath}/"):
+            record["file_path"] = f"{repo_subpath}/{file_path}"
+        scoped.append(record)
+    return scoped
+
+
+def _active_decision_targets_dead_code(
+    bundle: Any,
+    project_root: str | Path,
+    *,
+    now: datetime | None,
+) -> bool:
+    """Return whether an active v2 decision needs a dead-code proof identity."""
+    for decision in active_decisions(bundle, project_root, now=now):
+        # Legacy decisions match by location and do not consume the proof digest.
+        if decision.get("_v2_key") is None:
+            continue
+        category = _bounded_string(decision.get("category"), maximum=80)
+        if category is not None:
+            if category.upper().replace("-", "_") == "DEAD_CODE":
+                return True
+            continue
+        section = _bounded_string(decision.get("section"), maximum=80)
+        if section is not None:
+            if section.lower() in _DEAD_CODE_SECTIONS:
+                return True
+            continue
+        rule_id = _bounded_string(decision.get("rule_id"), maximum=120)
+        if rule_id in _DEAD_CODE_RULE_IDS:
+            return True
+    return False
+
+
+def review_scan_requirements(
+    project_root: str | Path,
+    *,
+    environ: dict[str, str] | None = None,
+    now: datetime | None = None,
+) -> tuple[bool, bool]:
+    """Return ``(context, dead-code proof)`` needs for active v2 reviews."""
+    env = environ if environ is not None else os.environ
+    if is_ci_environment(env):
+        return False, False
+    identity_root = _identity_project_root(project_root)
+    if identity_root is None:
+        return False, False
+    repository_identity = _git_remote_identity(identity_root)
+    local_scope = {
+        "repository_identity": repository_identity
+        or "local:" + hashlib.sha256(str(identity_root).encode("utf-8")).hexdigest(),
+        "repo_subpath": "",
+    }
+    local_bundle = _load_local_bundle(
+        identity_root,
+        environ=env,
+        _scope=local_scope,
+        _identity_root=identity_root,
+    )
+    bundles = [local_bundle]
+
+    expected_project_id = _linked_project_id(identity_root, project_root)
+    if repository_identity is not None and expected_project_id is not None:
+        for candidate in _review_scope_candidates(project_root, git_root=identity_root):
+            candidate_scope = _scope_for_project(
+                candidate, identity_root, repository_identity
+            )
+            if candidate_scope is None:
+                continue
+            bundles.append(
+                load_trusted_bundle(
+                    candidate,
+                    environ=env,
+                    expected_project_id=expected_project_id,
+                    now=now,
+                    _scope=candidate_scope,
+                )
+            )
+
+    context_required = False
+    proofs_required = False
+    for bundle in bundles:
+        decisions = active_decisions(bundle, identity_root, now=now)
+        context_required = context_required or any(
+            decision.get("_v2_key") is not None for decision in decisions
+        )
+        proofs_required = proofs_required or _active_decision_targets_dead_code(
+            decisions,
+            identity_root,
+            now=now,
+        )
+    return context_required, proofs_required
+
+
+def review_context_required(
+    project_root: str | Path,
+    *,
+    environ: dict[str, str] | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """Return whether an active v2 decision needs analyzer review context."""
+    required, _proofs_required = review_scan_requirements(
+        project_root,
+        environ=environ,
+        now=now,
+    )
+    return required
+
+
+def review_proofs_required(
+    project_root: str | Path,
+    *,
+    environ: dict[str, str] | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """Return whether an active v2 dead-code review needs graph proofs."""
+    _context_required, required = review_scan_requirements(
+        project_root,
+        environ=environ,
+        now=now,
+    )
+    return required
+
+
+def review_state_revision(
+    project_root: str | Path,
+    *,
+    cache_root: str | Path | None = None,
+    local_cache_root: str | Path | None = None,
+    environ: dict[str, str] | None = None,
+    now: datetime | None = None,
+) -> str | None:
+    """Return a semantic digest of active decisions for cached projections.
+
+    Agent state may be reused while source files are unchanged.  This digest
+    makes review authoring, revocation, Cloud sync, and expiry part of that
+    reuse decision without treating review files as analyzer input.
+    """
+    env = environ if environ is not None else os.environ
+    if is_ci_environment(env):
+        return None
+    identity_root = _identity_project_root(project_root)
+    if identity_root is None:
+        return None
+
+    repository_identity = _git_remote_identity(identity_root)
+    expected_project_id = _linked_project_id(identity_root, project_root)
+    trusted_bundle = None
+    trusted_scope: dict[str, str] | None = None
+    if repository_identity is not None and expected_project_id is not None:
+        for candidate in _review_scope_candidates(project_root, git_root=identity_root):
+            candidate_scope = _scope_for_project(
+                candidate, identity_root, repository_identity
+            )
+            if candidate_scope is None:
+                continue
+            trusted_bundle = load_trusted_bundle(
+                candidate,
+                cache_root=cache_root,
+                environ=env,
+                expected_project_id=expected_project_id,
+                now=now,
+                _scope=candidate_scope,
+            )
+            if trusted_bundle is not None:
+                trusted_scope = candidate_scope
+                break
+
+    local_scope = {
+        "repository_identity": repository_identity
+        or "local:" + hashlib.sha256(str(identity_root).encode("utf-8")).hexdigest(),
+        "repo_subpath": "",
+    }
+    local_bundle = _load_local_bundle(
+        identity_root,
+        cache_root=local_cache_root,
+        environ=env,
+        _scope=local_scope,
+        _identity_root=identity_root,
+    )
+    combined = {
+        "schema": REVIEW_SCHEMA,
+        "version": REVIEW_SCHEMA_VERSION,
+        "decisions": [
+            *_records_for_repository_scope(
+                trusted_bundle,
+                identity_root,
+                (trusted_scope or {}).get("repo_subpath", ""),
+            ),
+            *_bundle_decision_records(local_bundle),
+        ],
+    }
+
+    revision_items: list[dict[str, Any]] = []
+    for decision in active_decisions(combined, identity_root, now=now):
+        expires_at = _parse_timestamp(decision.get("expires_at"))
+        revision_items.append(
+            {
+                # Keep every physical decision in the digest. Duplicate active
+                # identities deliberately change matching from exact to
+                # ambiguous, even if their other semantic fields agree.
+                "decision_id": str(
+                    decision.get("decision_id") or decision.get("id") or ""
+                ),
+                "v2_key": list(decision["_v2_key"])
+                if decision.get("_v2_key") is not None
+                else None,
+                "legacy_key": list(decision["_legacy_key"])
+                if decision.get("_legacy_key") is not None
+                else None,
+                "disposition": decision["disposition"],
+                "expires_at": expires_at.isoformat()
+                if expires_at is not None
+                else None,
+                # These fields decide whether the analyzer must emit a
+                # dead-code proof before applying the same decision set.
+                "category": _bounded_string(decision.get("category"), maximum=80),
+                "section": _bounded_string(decision.get("section"), maximum=80),
+            }
+        )
+    if not revision_items:
+        return None
+    revision_items.sort(key=canonical_json)
+    return sha256_value(
+        {
+            "revision": "skylos-review-state-v1",
+            "decisions": revision_items,
+        }
+    )
+
+
+def apply_trusted_review_decisions(
+    result: dict[str, Any],
+    project_root: str | Path,
+    *,
+    analysis_root: str | Path | None = None,
+    cache_root: str | Path | None = None,
+    local_cache_root: str | Path | None = None,
+    environ: dict[str, str] | None = None,
+    now: datetime | None = None,
+    include_identities: bool = False,
+) -> dict[str, Any]:
+    result = _strip_untrusted_review_fields(result)
+    summary = result.get("analysis_summary")
+    has_review_context = isinstance(summary, dict) and review_context_is_valid(
+        summary.get("review_context")
+    )
+    can_emit_identities = include_identities and has_review_context
+    if (
+        not include_identities
+        and not _cache_root(cache_root).is_dir()
+        and not _local_cache_root(local_cache_root).is_dir()
+    ):
+        return result
+    identity_root = _identity_project_root(project_root)
+    identity_analysis_root = identity_root
+    if analysis_root is not None:
+        try:
+            candidate = Path(analysis_root).expanduser()
+            candidate_stat = candidate.lstat()
+            if stat.S_ISLNK(candidate_stat.st_mode) or not stat.S_ISDIR(
+                candidate_stat.st_mode
+            ):
+                return result
+            identity_analysis_root = candidate.resolve(strict=True)
+        except (OSError, RuntimeError, ValueError):
+            return result
+    if identity_root is None:
+        return (
+            annotate_result_identities(
+                result,
+                identity_analysis_root or project_root,
+            )
+            if can_emit_identities
+            else result
+        )
+    trusted_bundle = None
+    trusted_scope: dict[str, str] | None = None
+    expected_project_id = _linked_project_id(identity_root, project_root)
+    repository_identity = _git_remote_identity(identity_root)
+    # A Cloud cache is only authoritative while the repository is explicitly
+    # linked to the same Cloud project.  The cache itself lives outside the
+    # repository, but a missing link must still behave like an unlink rather
+    # than leaving old policy active indefinitely.
+    if repository_identity is not None and expected_project_id is not None:
+        for candidate in _review_scope_candidates(project_root, git_root=identity_root):
+            candidate_scope = _scope_for_project(
+                candidate, identity_root, repository_identity
+            )
+            if candidate_scope is None:
+                continue
+            trusted_bundle = load_trusted_bundle(
+                candidate,
+                cache_root=cache_root,
+                environ=environ,
+                expected_project_id=expected_project_id,
+                now=now,
+                _scope=candidate_scope,
+            )
+            if trusted_bundle is not None:
+                trusted_scope = candidate_scope
+                break
+    local_scope = {
+        "repository_identity": repository_identity
+        or "local:" + hashlib.sha256(str(identity_root).encode("utf-8")).hexdigest(),
+        "repo_subpath": "",
+    }
+    local_bundle = _load_local_bundle(
+        identity_root,
+        cache_root=local_cache_root,
+        environ=environ,
+        _scope=local_scope,
+        _identity_root=identity_root,
+    )
+    if trusted_bundle is None and local_bundle is None:
+        return (
+            annotate_result_identities(
+                result,
+                identity_analysis_root or identity_root,
+            )
+            if can_emit_identities
+            else result
+        )
+    combined = {
+        "schema": REVIEW_SCHEMA,
+        "version": REVIEW_SCHEMA_VERSION,
+        "decisions": [
+            *_records_for_repository_scope(
+                trusted_bundle,
+                identity_root,
+                (trusted_scope or {}).get("repo_subpath", ""),
+            ),
+            *_bundle_decision_records(local_bundle),
+        ],
+    }
+    if not active_decisions(combined, identity_root, now=now):
+        return (
+            annotate_result_identities(
+                result,
+                identity_analysis_root or identity_root,
+            )
+            if can_emit_identities
+            else result
+        )
+    return apply_review_decisions(
+        result,
+        combined,
+        identity_analysis_root or identity_root,
+        now=now,
+        include_identities=can_emit_identities,
+        require_review_context=True,
+    )
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    if (
+        not isinstance(value, str)
+        or len(value) > 80
+        or not _RFC3339_RE.fullmatch(value)
+    ):
+        return None
+    raw = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _now_utc(now: datetime | None) -> datetime:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        return current.replace(tzinfo=timezone.utc)
+    return current.astimezone(timezone.utc)
+
+
+def _active_disposition(record: dict[str, Any], now: datetime) -> str | None:
+    if record.get("revoked_at") is not None:
+        return None
+    status = record.get("status")
+    if status is not None and status != "active":
+        return None
+    disposition = record.get("disposition")
+    if not _has_v2_fields(record) and disposition is None:
+        disposition = record.get("type")
+    if not isinstance(disposition, str) or disposition not in KNOWN_DISPOSITIONS:
+        return None
+    if disposition not in SUPPRESSING_DISPOSITIONS:
+        return None
+    expires_raw = record.get("expires_at")
+    expires_at = _parse_timestamp(expires_raw)
+    if expires_raw is not None and expires_at is None:
+        return None
+    if disposition == "risk_accepted" and expires_at is None:
+        return None
+    if expires_at is not None and expires_at <= now:
+        return None
+    return disposition
+
+
+def _v2_key(record: dict[str, Any]) -> tuple[str, str, str, str, str] | None:
+    fields = (
+        record.get("fingerprint_version"),
+        record.get("stable_fingerprint"),
+        record.get("context_hash"),
+        record.get("rule_revision"),
+        record.get("rule_id"),
+    )
+    if not all(isinstance(value, str) and value.strip() for value in fields):
+        return None
+    version, stable, context, revision, rule_id = (
+        str(value).strip() for value in fields
+    )
+    if version != FINGERPRINT_VERSION:
+        return None
+    if not _HASH_RE.fullmatch(stable) or not _HASH_RE.fullmatch(context):
+        return None
+    raw_rule_id = record.get("rule_id")
+    raw_revision = record.get("rule_revision")
+    if (
+        not _RULE_REVISION_RE.fullmatch(revision)
+        or not isinstance(raw_revision, str)
+        or raw_revision != revision
+        or not isinstance(raw_rule_id, str)
+        or _valid_rule_id(raw_rule_id) != rule_id
+    ):
+        return None
+    return version, stable, context, revision, rule_id
+
+
+def _has_v2_fields(record: dict[str, Any]) -> bool:
+    return any(
+        record.get(key) is not None
+        for key in (
+            "fingerprint_version",
+            "stable_fingerprint",
+            "context_hash",
+            "rule_revision",
+        )
+    )
+
+
+def _legacy_key(
+    record: dict[str, Any], project_root: str | Path
+) -> tuple[str, str, int] | None:
+    if _has_v2_fields(record):
+        return None
+    rule_id = _valid_rule_id(record.get("rule_id"))
+    file_path = normalize_repo_path(record.get("file_path"), project_root)
+    line = _positive_line(record.get("line_number") or record.get("line"))
+    if rule_id is None or file_path is None or line is None:
+        return None
+    return rule_id, file_path, line
+
+
+def active_decisions(
+    bundle: Any,
+    project_root: str | Path,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    if isinstance(bundle, list):
+        records = bundle
+    elif isinstance(bundle, dict):
+        if bundle.get("schema") not in (None, REVIEW_SCHEMA):
+            return []
+        if bundle.get("version") not in (None, 1, REVIEW_SCHEMA_VERSION):
+            return []
+        records = bundle.get("decisions")
+        if records is None:
+            records = bundle.get("suppressions")
+    else:
+        return []
+    if not isinstance(records, list) or len(records) > MAX_DECISIONS:
+        return []
+
+    current = _now_utc(now)
+    valid: list[dict[str, Any]] = []
+    for raw in records:
+        if not isinstance(raw, dict):
+            continue
+        try:
+            if len(canonical_json(raw).encode("utf-8")) > 20_000:
+                continue
+        except (MemoryError, RecursionError, TypeError, ValueError):
+            continue
+        disposition = _active_disposition(raw, current)
+        if disposition is None:
+            continue
+        v2_key = _v2_key(raw)
+        legacy_key = _legacy_key(raw, project_root)
+        if v2_key is not None and (
+            _decision_id(raw.get("decision_id") or raw.get("id")) is None
+            or _strict_positive_line(raw.get("line_number") or raw.get("line")) is None
+            or normalize_repo_path(raw.get("file_path"), project_root) is None
+        ):
+            continue
+        if v2_key is None and legacy_key is None:
+            continue
+        record = dict(raw)
+        record["disposition"] = disposition
+        record["_v2_key"] = v2_key
+        record["_legacy_key"] = legacy_key
+        valid.append(record)
+    return valid
+
+
+def _finding_legacy_key(
+    finding: dict[str, Any], project_root: str | Path, default_rule_id: str
+) -> tuple[str, str, int] | None:
+    path = normalize_repo_path(
+        finding.get("file_path") or finding.get("file"),
+        project_root,
+        allow_absolute=True,
+    )
+    line = _positive_line(finding.get("line_number") or finding.get("line"))
+    if path is None or line is None:
+        return None
+    rule_id = _rule_id(finding, default_rule_id)
+    if rule_id is None:
+        return None
+    return rule_id, path, line
+
+
+def _decision_audit(record: dict[str, Any], match_mode: str) -> dict[str, Any]:
+    audit = {
+        "decision_id": str(record.get("decision_id") or record.get("id") or "")[:200],
+        "disposition": record["disposition"],
+        "reason": str(record.get("reason") or "")[:2_000],
+        "created_at": record.get("created_at"),
+        "created_by": str(record.get("created_by") or "")[:200],
+        "expires_at": record.get("expires_at"),
+        "match_mode": match_mode,
+    }
+    return {key: value for key, value in audit.items() if value not in (None, "")}
+
+
+def apply_review_decisions(
+    result: dict[str, Any],
+    bundle: Any,
+    project_root: str | Path,
+    *,
+    now: datetime | None = None,
+    include_identities: bool = True,
+    require_review_context: bool = False,
+) -> dict[str, Any]:
+    decisions = active_decisions(bundle, project_root, now=now)
+    if require_review_context:
+        summary = result.get("analysis_summary")
+        has_review_context = isinstance(summary, dict) and review_context_is_valid(
+            summary.get("review_context")
+        )
+        if not has_review_context:
+            decisions = [
+                decision for decision in decisions if decision.get("_v2_key") is None
+            ]
+    candidate_keys: set[tuple[str, str | None]] | None = None
+    if not include_identities:
+        candidate_keys = set()
+        for decision in decisions:
+            rule_id = str(decision.get("rule_id") or "")
+            file_path = normalize_repo_path(decision.get("file_path"), project_root)
+            candidate_keys.add((rule_id, file_path))
+    projected = annotate_result_identities(
+        result,
+        project_root,
+        candidate_keys=candidate_keys,
+    )
+
+    current_v2_counts: Counter[tuple[str, str, str, str, str]] = Counter()
+    current_legacy_counts: Counter[tuple[str, str, int]] = Counter()
+    for section, _category, default_rule_id in FINDING_SECTIONS:
+        for finding in projected.get(section, []) or []:
+            if not isinstance(finding, dict):
+                continue
+            if (key := _v2_key(finding)) is not None:
+                current_v2_counts[key] += 1
+            legacy_key = _finding_legacy_key(finding, project_root, default_rule_id)
+            if legacy_key is not None:
+                current_legacy_counts[legacy_key] += 1
+
+    v2_records: dict[tuple[str, str, str, str, str], list[dict[str, Any]]] = (
+        defaultdict(list)
+    )
+    legacy_records: dict[tuple[str, str, int], list[dict[str, Any]]] = defaultdict(list)
+    for decision in decisions:
+        if decision["_v2_key"] is not None:
+            v2_records[decision["_v2_key"]].append(decision)
+        elif decision["_legacy_key"] is not None:
+            legacy_records[decision["_legacy_key"]].append(decision)
+
+    reviewed: list[dict[str, Any]] = []
+    ambiguous = 0
+    for section, category, default_rule_id in FINDING_SECTIONS:
+        findings = projected.get(section)
+        if not isinstance(findings, list):
+            continue
+        active: list[Any] = []
+        for item in findings:
+            if not isinstance(item, dict):
+                active.append(item)
+                continue
+            decision = None
+            match_mode = ""
+            v2_ambiguous = False
+            v2_key = _v2_key(item)
+            if v2_key is not None and current_v2_counts[v2_key] == 1:
+                matches = v2_records.get(v2_key, [])
+                if len(matches) == 1:
+                    decision = matches[0]
+                    match_mode = "v2_exact_context"
+                elif len(matches) > 1:
+                    ambiguous += 1
+                    v2_ambiguous = True
+            elif v2_key is not None and current_v2_counts[v2_key] > 1:
+                ambiguous += 1
+                v2_ambiguous = True
+
+            severity = str(item.get("severity") or "").strip().upper()
+            legacy_can_suppress = category not in {
+                "SECURITY",
+                "SECRET",
+                "DEPENDENCY",
+            } and severity not in {"HIGH", "CRITICAL"}
+            if decision is None and not v2_ambiguous and legacy_can_suppress:
+                legacy_key = _finding_legacy_key(item, project_root, default_rule_id)
+                matches = legacy_records.get(legacy_key, []) if legacy_key else []
+                if legacy_key is not None and current_legacy_counts[legacy_key] > 1:
+                    ambiguous += 1
+                elif len(matches) == 1:
+                    decision = matches[0]
+                    match_mode = "legacy_exact_location"
+                elif len(matches) > 1:
+                    ambiguous += 1
+
+            if decision is None:
+                active.append(item)
+                continue
+
+            suppressed = dict(item)
+            suppressed["category"] = category
+            suppressed["review_decision"] = _decision_audit(decision, match_mode)
+            suppressed["_skylos_trusted_review"] = True
+            reviewed.append(suppressed)
+        projected[section] = active
+
+    projected["reviewed_findings"] = reviewed
+    projected["reviewed_findings_summary"] = {
+        "suppressed_count": len(reviewed),
+        "active_decision_count": len(decisions),
+        "ambiguous_match_count": ambiguous,
+    }
+    summary = projected.get("analysis_summary")
+    if isinstance(summary, dict):
+        for section, count_key in _SUMMARY_COUNT_KEYS.items():
+            if section in projected:
+                summary[count_key] = len(projected.get(section) or [])
+        summary["reviewed_findings"] = dict(projected["reviewed_findings_summary"])
+        if reviewed:
+            summary.pop("by_directory", None)
+            summary.pop("dead_code_evidence", None)
+    if reviewed:
+        # These aggregates describe the unprojected finding set. Omitting them
+        # is safer than presenting a score or provenance count that no longer
+        # agrees with the visible results.
+        projected.pop("grade", None)
+        projected.pop("ai_security_stats", None)
+        projected.pop("provenance_summary", None)
+    return projected

--- a/skylos/core/safe_cache_io.py
+++ b/skylos/core/safe_cache_io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import shutil
 import stat
 import time
 from collections.abc import Iterator
@@ -354,6 +355,59 @@ def write_text_no_symlink(
         return False
     finally:
         _close_file_descriptor(fd)
+
+
+def remove_project_tree_no_symlink(
+    project_root: str | Path,
+    tree_path: str | Path,
+) -> bool:
+    """Remove an in-project directory without following symlink components."""
+
+    if not shutil.rmtree.avoids_symlink_attacks:
+        return False
+    if os.open not in os.supports_dir_fd or os.stat not in os.supports_dir_fd:
+        return False
+    if os.stat not in os.supports_follow_symlinks:
+        return False
+
+    resolved = _resolve_project_cache_path(project_root, tree_path)
+    if resolved is None:
+        return False
+    root, path = resolved
+    try:
+        relative = path.relative_to(root)
+    except ValueError:
+        return False
+    if not relative.parts:
+        return False
+
+    directory_fd: int | None = None
+    try:
+        directory_fd = os.open(root, _directory_open_flags())
+        for component in relative.parts[:-1]:
+            component_name = Path(component).name
+            if component_name != component or component_name in {"", ".", ".."}:
+                return False
+            next_fd = os.open(
+                component_name,
+                _directory_open_flags(),
+                dir_fd=directory_fd,
+            )
+            os.close(directory_fd)
+            directory_fd = next_fd
+
+        tree_name = relative.name
+        if tree_name in {"", ".", ".."}:
+            return False
+        tree_stat = os.stat(tree_name, dir_fd=directory_fd, follow_symlinks=False)
+        if not stat.S_ISDIR(tree_stat.st_mode):
+            return False
+        shutil.rmtree(tree_name, dir_fd=directory_fd)
+        return True
+    except (FileNotFoundError, NotADirectoryError, OSError):
+        return False
+    finally:
+        _close_file_descriptor(directory_fd)
 
 
 def _project_cache_path(

--- a/skylos/core/suite.py
+++ b/skylos/core/suite.py
@@ -197,6 +197,7 @@ def run_suite(
     no_provenance: bool = False,
     diff_base: str | None = None,
     get_git_root_func=None,
+    include_review_identities: bool = False,
 ) -> dict[str, Any]:
     """
     Build the combined static, debt, defense, and provenance suite report.
@@ -210,6 +211,15 @@ def run_suite(
     """
     target_path = Path(target).resolve()
     exclude = set(exclude_folders or [])
+
+    from skylos.core.review_decisions import (
+        apply_trusted_review_decisions,
+        review_scan_requirements,
+    )
+
+    review_context_needed, review_proofs_needed = review_scan_requirements(target_path)
+    include_review_context = include_review_identities or review_context_needed
+    include_review_proofs = include_review_identities or review_proofs_needed
 
     from skylos.debt import build_debt_snapshot
     from skylos.defend.engine import run_defense_checks
@@ -236,7 +246,10 @@ def run_suite(
                 enable_danger=True,
                 enable_quality=True,
                 enable_ai_defects=True,
+                enable_sca=True,
                 exclude_folders=sorted(exclude),
+                include_review_proofs=include_review_proofs,
+                include_review_context=include_review_context,
             )
     finally:
         analyzer_logger.setLevel(original_level)
@@ -245,23 +258,11 @@ def run_suite(
         json.loads(static_raw) if isinstance(static_raw, str) else static_raw
     )
 
-    try:
-        from skylos.rules.sca.vulnerability_scanner import scan_dependencies
-
-        sca_findings = scan_dependencies(target_path)
-        if sca_findings:
-            try:
-                from skylos.rules.sca.reachability import enrich_with_reachability
-
-                sca_findings = enrich_with_reachability(sca_findings, target_path)
-            except Exception:
-                pass
-            static_result["dependency_vulnerabilities"] = sca_findings
-            static_result.setdefault("analysis_summary", {})["sca_count"] = len(
-                sca_findings
-            )
-    except Exception:
-        pass
+    static_result = apply_trusted_review_decisions(
+        static_result,
+        target_path,
+        include_identities=include_review_identities,
+    )
 
     debt_snapshot = build_debt_snapshot(static_result, project_root=target_path)
     try:

--- a/skylos/deadcode/review_proof.py
+++ b/skylos/deadcode/review_proof.py
@@ -1,0 +1,345 @@
+"""Bounded, analyzer-owned proof snapshots for reusable dead-code reviews."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from skylos.core.review_context import review_config_projection
+from skylos.deadcode.evidence import CLASSIFICATION_POLICY
+
+
+PROOF_SCHEMA = "skylos.dead-code-review-proof-v1"
+_MAX_SLICE_NODES = 4_096
+_MAX_SLICE_EDGES = 16_384
+_MAX_SLICE_REFERENCES = 16_384
+_MAX_INDEX_ITEMS = 2_000_000
+
+
+@dataclass(frozen=True)
+class DeadCodeReviewProofContext:
+    report: Any | None
+    root: Path | None
+    reverse_edges: Mapping[str, frozenset[str]]
+    references_by_node: Mapping[str, tuple[dict[str, Any], ...]]
+    incomplete_reason: str | None = None
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _strings(values: Any, *, maximum: int = 1_024) -> list[str]:
+    if not isinstance(values, (list, tuple, set, frozenset)):
+        return []
+    result = sorted({str(value)[:500] for value in values})
+    return result[:maximum]
+
+
+def _mapping(value: Any, *, maximum: int = 1_024) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    result: dict[str, Any] = {}
+    for key in sorted(value, key=lambda item: str(item))[:maximum]:
+        item = value[key]
+        if item is None or isinstance(item, (bool, int, float, str)):
+            result[str(key)[:500]] = item if not isinstance(item, str) else item[:2_000]
+    return result
+
+
+def _relative_path(value: Any, root: Path) -> str | None:
+    try:
+        path = Path(str(value)).resolve(strict=False)
+        return path.relative_to(root).as_posix()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def prepare_dead_code_review_proofs(analyzer: Any) -> DeadCodeReviewProofContext:
+    """Index shared graph inputs once for all findings in an analysis."""
+    report = getattr(analyzer, "_python_reachability_report", None)
+    if report is None:
+        return DeadCodeReviewProofContext(None, None, {}, {})
+    try:
+        root = Path(report.project_root).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return DeadCodeReviewProofContext(
+            report, None, {}, {}, "invalid_project_root"
+        )
+
+    reverse: dict[str, set[str]] = defaultdict(set)
+    edge_count = 0
+    for edge_map in (report.graph.edges, report.graph.uncertain_edges):
+        for owner, destinations in edge_map.items():
+            for destination in destinations:
+                edge_count += 1
+                if edge_count > _MAX_INDEX_ITEMS:
+                    return DeadCodeReviewProofContext(
+                        report, root, {}, {}, "proof_graph_limit_exceeded"
+                    )
+                reverse[str(destination)].add(str(owner))
+
+    references_by_node: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    reference_count = 0
+    for (path, _line), references in report.graph.references.items():
+        relative = _relative_path(path, root)
+        if relative is None:
+            return DeadCodeReviewProofContext(
+                report, root, {}, {}, "invalid_reference_path"
+            )
+        for reference in references:
+            target = getattr(reference, "target", None)
+            owner = getattr(reference, "owner", None)
+            record = {
+                # Line numbers are deliberately omitted so formatting-only
+                # movement leaves the ownership/resolution proof unchanged.
+                "file": relative,
+                "name": str(getattr(reference, "name", ""))[:500],
+                "target": str(target) if target is not None else None,
+                "owner": str(owner) if owner is not None else None,
+            }
+            for node in {record["target"], record["owner"]} - {None}:
+                references_by_node[str(node)].append(record)
+            reference_count += 1
+            if reference_count > _MAX_INDEX_ITEMS:
+                return DeadCodeReviewProofContext(
+                    report,
+                    root,
+                    {},
+                    {},
+                    "proof_reference_index_limit_exceeded",
+                )
+
+    return DeadCodeReviewProofContext(
+        report=report,
+        root=root,
+        reverse_edges={key: frozenset(value) for key, value in reverse.items()},
+        references_by_node={
+            key: tuple(value) for key, value in references_by_node.items()
+        },
+    )
+
+
+def _inbound_slice(
+    context: DeadCodeReviewProofContext, target: str
+) -> tuple[set[str], bool]:
+
+    nodes = {target}
+    pending = deque([target])
+    while pending:
+        destination = pending.popleft()
+        for owner in context.reverse_edges.get(destination, ()):
+            if owner in nodes:
+                continue
+            nodes.add(owner)
+            if len(nodes) > _MAX_SLICE_NODES:
+                return set(), False
+            pending.append(owner)
+    return nodes, True
+
+
+def _edge_records(edge_map: Any, nodes: set[str]) -> list[list[str]] | None:
+    records: list[list[str]] = []
+    for owner in sorted(nodes):
+        for destination in sorted(edge_map.get(owner, ())):
+            if destination in nodes:
+                records.append([owner, str(destination)])
+                if len(records) > _MAX_SLICE_EDGES:
+                    return None
+    return records
+
+
+def _reference_records(
+    context: DeadCodeReviewProofContext, nodes: set[str]
+) -> list[dict[str, Any]] | None:
+    unique: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+    for node in nodes:
+        for record in context.references_by_node.get(node, ()):
+            key = (
+                record["file"],
+                record["name"],
+                record["target"] or "",
+                record["owner"] or "",
+            )
+            unique[key] = record
+            if len(unique) > _MAX_SLICE_REFERENCES:
+                return None
+    records = list(unique.values())
+    records.sort(
+        key=lambda item: (
+            item["file"],
+            item["name"],
+            item["target"] or "",
+            item["owner"] or "",
+        )
+    )
+    return records
+
+
+def build_dead_code_review_proof(
+    analyzer: Any,
+    key: str,
+    definition: Any,
+    evidence_entry: Mapping[str, Any] | None,
+    *,
+    threshold: int,
+    context: DeadCodeReviewProofContext | None = None,
+    review_config: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Snapshot the exact Python graph facts used for one reported symbol.
+
+    Unsupported languages or incomplete graphs receive ``complete: false``;
+    the review layer can then use a conservative repository fallback or refuse
+    to persist the decision.
+    """
+    context = context or prepare_dead_code_review_proofs(analyzer)
+    report = context.report
+    suffix = Path(str(getattr(definition, "filename", ""))).suffix.lower()
+    reasons: list[str] = []
+    if suffix not in {".py", ".pyi", ".pyw"}:
+        reasons.append("language_has_no_review_proof_slice")
+    if report is None:
+        reasons.append("python_reachability_unavailable")
+    elif context.incomplete_reason:
+        reasons.append(context.incomplete_reason)
+    elif not bool(getattr(report, "complete", False)):
+        reasons.extend(
+            str(reason)[:500]
+            for reason in getattr(report, "incomplete_reasons", ())
+        )
+    elif key not in getattr(report.index, "candidates", {}):
+        reasons.append("definition_not_in_reachability_graph")
+    if reasons:
+        return {
+            "schema": PROOF_SCHEMA,
+            "complete": False,
+            "reasons": sorted(set(reasons)),
+        }
+
+    nodes, bounded = _inbound_slice(context, key)
+    proven_edges = _edge_records(report.graph.edges, nodes) if bounded else None
+    uncertain_edges = (
+        _edge_records(report.graph.uncertain_edges, nodes) if bounded else None
+    )
+    root = context.root
+    references = _reference_records(context, nodes) if bounded else None
+    if (
+        not bounded
+        or root is None
+        or proven_edges is None
+        or uncertain_edges is None
+        or references is None
+    ):
+        return {
+            "schema": PROOF_SCHEMA,
+            "complete": False,
+            "reasons": ["proof_slice_limit_exceeded"],
+        }
+
+    decision = evidence_entry.get("decision") if isinstance(evidence_entry, Mapping) else None
+    analysis_scope = getattr(analyzer, "_analysis_scope", None)
+    normalized_scope: dict[str, Any] = {}
+    if isinstance(analysis_scope, Mapping):
+        scan_path = _relative_path(analysis_scope.get("scan_path"), root)
+        normalized_scope = {
+            "kind": str(analysis_scope.get("kind") or "")[:120],
+            "scan_path": scan_path,
+            "complete_repository": bool(
+                analysis_scope.get("complete_repository", False)
+            ),
+            "changed_files_only": bool(
+                analysis_scope.get("changed_files_only", False)
+            ),
+            "excluded_folders": _strings(
+                analysis_scope.get("excluded_folders", ())
+            ),
+        }
+    try:
+        dead_code_config = review_config_projection(
+            dict(review_config) if isinstance(review_config, Mapping) else {},
+            "dead_code",
+        )
+    except (MemoryError, RecursionError, TypeError, ValueError):
+        return {
+            "schema": PROOF_SCHEMA,
+            "complete": False,
+            "reasons": ["review_config_not_canonical"],
+        }
+
+    payload = {
+        "schema": PROOF_SCHEMA,
+        "policy": CLASSIFICATION_POLICY,
+        "definition": {
+            "key": str(key),
+            "name": str(getattr(definition, "name", "")),
+            "kind": str(getattr(definition, "type", "")),
+            "file": _relative_path(getattr(definition, "filename", ""), root),
+            "references": int(getattr(definition, "references", 0) or 0),
+            "exported": bool(getattr(definition, "is_exported", False)),
+            "confidence": int(getattr(definition, "confidence", 0) or 0),
+            "threshold": int(threshold),
+            "calls": _strings(getattr(definition, "calls", ())),
+            "called_by": _strings(getattr(definition, "called_by", ())),
+            "decorators": _strings(getattr(definition, "decorators", ())),
+            "heuristic_refs": _mapping(
+                getattr(definition, "heuristic_refs", {})
+            ),
+            "dynamic_signals": _strings(
+                getattr(definition, "dynamic_signals", ())
+            ),
+            "framework_signals": _strings(
+                getattr(definition, "framework_signals", ())
+            ),
+            "uncertainty": _strings(
+                getattr(definition, "why_confidence_reduced", ())
+            ),
+        },
+        "decision": decision if isinstance(decision, Mapping) else {},
+        "analysis": {
+            "scope": normalized_scope,
+            "config": dead_code_config,
+            "dead_code_liveness": str(
+                os.environ.get("SKYLOS_DEAD_CODE_LIVENESS", "1")
+            )[:40],
+        },
+        "graph": {
+            "nodes": sorted(nodes),
+            "proven_edges": proven_edges,
+            "uncertain_edges": uncertain_edges,
+            "roots": sorted(nodes.intersection(report.graph.roots)),
+            "uncertain_roots": sorted(
+                nodes.intersection(report.graph.uncertain_roots)
+            ),
+            "opaque_owners": sorted(nodes.intersection(report.graph.opaque_owners)),
+            "reachable": sorted(nodes.intersection(report.reachable_keys)),
+            "proven_reachable": sorted(
+                nodes.intersection(report.proven_reachable_keys)
+            ),
+            "protected": sorted(nodes.intersection(report.protected_keys)),
+            "protected_callbacks": sorted(
+                nodes.intersection(report.protected_callback_keys)
+            ),
+            "unreachable": sorted(nodes.intersection(report.unreachable_keys)),
+            "references": references,
+        },
+    }
+    try:
+        digest = _canonical_digest(payload)
+    except (MemoryError, RecursionError, TypeError, ValueError):
+        return {
+            "schema": PROOF_SCHEMA,
+            "complete": False,
+            "reasons": ["proof_payload_not_canonical"],
+        }
+    return {"schema": PROOF_SCHEMA, "complete": True, "digest": digest}

--- a/skylos/debt/engine.py
+++ b/skylos/debt/engine.py
@@ -298,15 +298,32 @@ def run_debt_analysis(
     target = Path(path).resolve()
     project_root = _project_root(target)
 
+    from skylos.core.review_decisions import (
+        apply_trusted_review_decisions,
+        review_scan_requirements,
+    )
+
+    include_review_context, include_review_proofs = review_scan_requirements(
+        project_root
+    )
+    analysis_options = {
+        "conf": conf,
+        "enable_quality": True,
+        "enable_danger": False,
+        "enable_secrets": False,
+        "exclude_folders": list(exclude_folders or []),
+    }
+    if include_review_context:
+        analysis_options["include_review_context"] = True
+    if include_review_proofs:
+        analysis_options["include_review_proofs"] = True
+
     raw = run_analyze(
         str(target),
-        conf=conf,
-        enable_quality=True,
-        enable_danger=False,
-        enable_secrets=False,
-        exclude_folders=list(exclude_folders or []),
+        **analysis_options,
     )
     result = json.loads(raw) if isinstance(raw, str) else raw
+    result = apply_trusted_review_decisions(result, project_root)
 
     return build_debt_snapshot(
         result,

--- a/skylos/llm/orchestrator.py
+++ b/skylos/llm/orchestrator.py
@@ -134,18 +134,41 @@ class RemediationAgent:
     def _scan(self, path: Path) -> dict:
         import json
         from skylos.analyzer import analyze as run_analyze
-
-        raw = run_analyze(
-            str(path),
-            conf=0,
-            enable_danger=True,
-            enable_quality=True,
-            enable_ai_defects=True,
-            enable_secrets=True,
+        from skylos.config import load_config, resolve_config_file_path
+        from skylos.constants import parse_exclude_folders
+        from skylos.core.review_decisions import (
+            apply_trusted_review_decisions,
+            review_scan_requirements,
         )
+
+        project_root = _project_root_for_path(path)
+        config_file = resolve_config_file_path()
+        project_config = load_config(project_root, config_file=config_file)
+        exclude_folders = parse_exclude_folders(
+            config_exclude_folders=project_config.get("exclude"),
+        )
+        options = {
+            "conf": 0,
+            "enable_danger": True,
+            "enable_quality": True,
+            "enable_ai_defects": True,
+            "enable_secrets": True,
+            "exclude_folders": list(exclude_folders),
+            "config_file": config_file,
+        }
+        include_review_context, include_review_proofs = review_scan_requirements(
+            project_root
+        )
+        if include_review_context:
+            options["include_review_context"] = True
+        if include_review_proofs:
+            options["include_review_proofs"] = True
+        raw = run_analyze(str(path), **options)
         if isinstance(raw, str):
-            return json.loads(raw)
-        return raw
+            result = json.loads(raw)
+        else:
+            result = raw
+        return apply_trusted_review_decisions(result, project_root)
 
     def _create_fixer(self):
         from .agents import FixerAgent, AgentConfig
@@ -220,9 +243,7 @@ class RemediationAgent:
             executor.revert_fix(file_path)
             batch.status = "not_resolved"
             if verify.verification_error:
-                batch.fix_description = (
-                    f"Could not verify fix after remediation: {verify.verification_error}"
-                )
+                batch.fix_description = f"Could not verify fix after remediation: {verify.verification_error}"
             else:
                 batch.fix_description = (
                     f"Finding still present after fix: {verify.remaining_rule_ids}"

--- a/skylos/llm/prompts.py
+++ b/skylos/llm/prompts.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from pathlib import Path
 
 from .context import FewShotExamples
@@ -355,7 +357,9 @@ def user_analyze(context, issue_types, include_examples=True):
             "`security_details` must be an object with `attack_path`, `impact`, `fix`, `evidence_lines`, and `unsafe_if`. Use `evidence_lines` for exact lines that prove source, sink, or missing guard. `unsafe_if` should state what condition keeps the finding exploitable or what proof would be needed to refute it."
         )
     else:
-        prompt_parts.append("For non-security findings, set `security_details` to null.")
+        prompt_parts.append(
+            "For non-security findings, set `security_details` to null."
+        )
     prompt_parts.append('OUTPUT: JSON object only: {"findings": [...]}')
     prompt_parts.append('If no issues: {"findings": []}')
 
@@ -413,6 +417,53 @@ def build_review_prompt(
         ["security", "quality", "bug", "performance"],
         include_examples,
     )
+
+
+def analysis_prompt_revision(
+    kind="review",
+    *,
+    templates=None,
+    template_root=None,
+):
+    """Hash every prompt variant that can shape an analyzer finding."""
+    builders = {
+        "security": build_security_prompt,
+        "quality": build_quality_prompt,
+        "security_audit": build_security_audit_prompt,
+        "review": build_review_prompt,
+    }
+    builder = builders.get(kind)
+    if builder is None:
+        return None
+    try:
+        variants = []
+        for include_examples in (False, True):
+            system, user = builder(
+                "__SKYLOS_UNTRUSTED_CODE_CONTEXT__",
+                include_examples=include_examples,
+                templates=templates,
+                template_root=template_root,
+            )
+            variants.append(
+                {
+                    "include_examples": include_examples,
+                    "system": system,
+                    "user": user,
+                }
+            )
+        encoded = json.dumps(
+            {
+                "schema": "skylos-llm-analysis-prompt-v1",
+                "kind": kind,
+                "variants": variants,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    except (MemoryError, OSError, TypeError, ValueError):
+        return None
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
 
 
 def build_pr_description(plan_summary: dict) -> str:

--- a/skylos/pipeline.py
+++ b/skylos/pipeline.py
@@ -315,6 +315,8 @@ def run_static_on_files(
     enable_quality=True,
     enable_ai_defects=True,
     exclude_folders=None,
+    include_review_context=False,
+    include_review_proofs=False,
 ):
     import os
 
@@ -368,6 +370,8 @@ def run_static_on_files(
                 )
             ),
             changed_files=sorted(target_files),
+            include_review_proofs=include_review_proofs,
+            include_review_context=include_review_context,
         )
         full_result = json.loads(result_json)
     except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as exc:
@@ -413,6 +417,10 @@ def run_pipeline(
     changed_files=None,
     exclude_folders=None,
     stats_out=None,
+    provider=None,
+    base_url=None,
+    project_root=None,
+    project_config=None,
 ):
     """
     Run agent scan pipeline across static and LLM phases.
@@ -439,6 +447,30 @@ def run_pipeline(
         console.print(f"[warn]Skipping symlinked pipeline path: {path}[/warn]")
         return []
     root = path.resolve() if path.is_dir() else path.parent.resolve()
+    try:
+        review_project_root = (
+            pathlib.Path(project_root).expanduser().resolve(strict=True)
+            if project_root is not None
+            else root
+        )
+        if review_project_root.is_file():
+            review_project_root = review_project_root.parent
+        root.relative_to(review_project_root)
+    except (OSError, RuntimeError, ValueError):
+        review_project_root = root
+    resolved_provider = provider or getattr(agent_args, "provider", None)
+    resolved_base_url = base_url or getattr(agent_args, "base_url", None)
+    from skylos.core.review_decisions import review_scan_requirements
+
+    review_context_needed, review_proofs_needed = review_scan_requirements(
+        review_project_root
+    )
+    include_review_context = (
+        bool(getattr(agent_args, "upload", False)) or review_context_needed
+    )
+    include_review_proofs = (
+        bool(getattr(agent_args, "upload", False)) or review_proofs_needed
+    )
     safe_changed_files = (
         _resolve_pipeline_files(changed_files, root) if changed_files else None
     )
@@ -461,6 +493,9 @@ def run_pipeline(
         "phase_2b_seconds": 0.0,
         "phase_3_seconds": 0.0,
     }
+    analysis_review_context = None
+    llm_review_context = None
+    hybrid_llm_context_hashes: dict[str, str] = {}
     pipeline_start = time.time()
 
     if not getattr(agent_args, "llm_only", False):
@@ -486,6 +521,8 @@ def run_pipeline(
                         enable_quality=True,
                         enable_ai_defects=True,
                         exclude_folders=exclude_folders,
+                        include_review_context=include_review_context,
+                        include_review_proofs=include_review_proofs,
                     )
                 else:
                     from skylos.constants import parse_exclude_folders
@@ -497,6 +534,8 @@ def run_pipeline(
                         enable_danger=True,
                         enable_quality=True,
                         enable_ai_defects=True,
+                        include_review_context=include_review_context,
+                        include_review_proofs=include_review_proofs,
                         exclude_folders=list(
                             exclude_folders
                             or parse_exclude_folders(
@@ -508,6 +547,11 @@ def run_pipeline(
                         ),
                     )
                     static_result = json.loads(result_json)
+            static_summary = static_result.get("analysis_summary")
+            if isinstance(static_summary, dict) and isinstance(
+                static_summary.get("review_context"), dict
+            ):
+                analysis_review_context = dict(static_summary["review_context"])
             phase_stats["phase_1_seconds"] = round(time.time() - phase_1_start, 1)
 
             defs_map = static_result.get("definitions", {}) or {}
@@ -570,12 +614,14 @@ def run_pipeline(
         safe_path = _resolve_pipeline_file(path, root)
         files = [safe_path] if safe_path and safe_path.suffix.lower() == ".py" else []
         source_cache_files = [safe_path] if safe_path else []
+        llm_exclude_folders = list(exclude_folders or [])
     else:
         _exc = (
             set(exclude_folders)
             if exclude_folders
             else {"__pycache__", ".git", "venv", ".venv"}
         )
+        llm_exclude_folders = sorted(_exc)
         files = _resolve_pipeline_files(
             discover_source_files(path, [".py"], exclude_folders=_exc),
             root,
@@ -614,6 +660,111 @@ def run_pipeline(
         if safe_changed_files is not None
         else review_index.force_full_file_paths_for(phase_2b_files)
     )
+    llm_prompt_templates = getattr(agent_args, "prompt_templates", None)
+    llm_prompt_template_root = getattr(agent_args, "prompt_template_root", None)
+    llm_min_confidence = getattr(agent_args, "min_confidence", "low")
+    llm_smart_filter = not path.is_file()
+    llm_full_file_review = path.is_file()
+    llm_agent_route = "full"
+    llm_temperature = 0.0
+    llm_max_tokens = 4_096
+    llm_strict_validation = False
+    llm_stream = True
+    llm_max_chunk_tokens = 1_000
+    llm_batch_functions = True
+    llm_batch_size = 10
+    llm_complexity_threshold = 5
+    llm_parallel = True
+    llm_is_rate_limited = any(
+        (model or "").strip().lower().startswith(prefix)
+        for prefix in ("groq/", "gemini/", "ollama/", "mistral/")
+    )
+    llm_max_workers = 2 if llm_is_rate_limited else 4
+
+    from skylos.llm.prompts import analysis_prompt_revision
+
+    llm_prompt_revision = analysis_prompt_revision(
+        "review",
+        templates=llm_prompt_templates,
+        template_root=llm_prompt_template_root,
+    )
+    llm_only_mode = bool(getattr(agent_args, "llm_only", False))
+    if include_review_context and not getattr(agent_args, "static_only", False):
+        from skylos.core.review_context import (
+            LLM_REVIEW_CONTEXT_SCHEMA,
+            build_llm_review_context,
+            review_context_hash_for_category,
+        )
+
+        try:
+            effective_config = (
+                project_config
+                if isinstance(project_config, dict)
+                else load_config(path)
+            )
+        except (MemoryError, OSError, RuntimeError, TypeError, ValueError):
+            effective_config = None
+        try:
+            resolved_path = path.resolve(strict=True)
+            complete_target = (
+                path.is_dir()
+                and safe_changed_files is None
+                and resolved_path == review_project_root
+            )
+        except (OSError, RuntimeError):
+            complete_target = False
+        if effective_config is None:
+            llm_review_context = {
+                "schema": LLM_REVIEW_CONTEXT_SCHEMA,
+                "complete": False,
+            }
+        else:
+            llm_review_context = build_llm_review_context(
+                review_project_root,
+                path,
+                mode="agent_llm_only" if llm_only_mode else "agent_hybrid_llm",
+                config=effective_config,
+                exclude_folders=llm_exclude_folders,
+                requested_changed_files=(
+                    changed_files if changed_files is not None else None
+                ),
+                effective_files=phase_2b_files,
+                repo_context_map=phase_2b_repo_context,
+                force_full_file_paths=force_full_file_paths,
+                definitions=defs_map,
+                scan_kind="file" if path.is_file() else "directory",
+                complete_target=complete_target,
+                model=model,
+                provider=resolved_provider,
+                base_url=resolved_base_url,
+                min_confidence=llm_min_confidence,
+                prompt_revision=llm_prompt_revision,
+                enable_security=True,
+                enable_quality=True,
+                temperature=llm_temperature,
+                max_tokens=llm_max_tokens,
+                strict_validation=llm_strict_validation,
+                stream=llm_stream,
+                smart_filter=llm_smart_filter,
+                full_file_review=llm_full_file_review,
+                parallel=llm_parallel,
+                max_workers=llm_max_workers,
+                max_chunk_tokens=llm_max_chunk_tokens,
+                batch_functions=llm_batch_functions,
+                batch_size=llm_batch_size,
+                complexity_threshold=llm_complexity_threshold,
+                agent_route=llm_agent_route,
+            )
+        if llm_only_mode:
+            analysis_review_context = llm_review_context
+        else:
+            for category in ("AI_DEFECT", "QUALITY", "RELIABILITY", "SECURITY"):
+                context_hash = review_context_hash_for_category(
+                    llm_review_context,
+                    category,
+                )
+                if context_hash is not None:
+                    hybrid_llm_context_hashes[category] = context_hash
 
     low_conf = [f for f in dead_code_findings if f.get("confidence", 100) < 20]
     if low_conf:
@@ -639,13 +790,11 @@ def run_pipeline(
         try:
             from skylos.llm.agents import create_dead_code_agent
 
-            provider = getattr(agent_args, "provider", None)
-            base_url = getattr(agent_args, "base_url", None)
             dead_code_agent = create_dead_code_agent(
                 model=model,
                 api_key=api_key,
-                provider=provider,
-                base_url=base_url,
+                provider=resolved_provider,
+                base_url=resolved_base_url,
             )
 
             console.print("[brand]Testing LLM API connection...[/brand]")
@@ -706,6 +855,8 @@ def run_pipeline(
                     f["_source"] = "static+llm"
                     f["_confidence"] = "high"
                     f["_suppressed"] = False
+                    f["model"] = model
+                    f["provider"] = resolved_provider
                     results.append(f)
                 elif verdict == "UNCERTAIN":
                     f["_source"] = "static"
@@ -721,6 +872,8 @@ def run_pipeline(
             for f in new_dead:
                 f["_confidence"] = "high"
                 f["_suppressed"] = False
+                f["model"] = model
+                f["provider"] = resolved_provider
                 results.append(f)
 
         except Exception as e:
@@ -749,12 +902,6 @@ def run_pipeline(
                 f"[dim]Scoped LLM audit to {len(phase_2b_files)}/{len(files)} Python files[/dim]"
             )
 
-        _is_rate_limited = any(
-            (model or "").strip().lower().startswith(p)
-            for p in ("groq/", "gemini/", "ollama/", "mistral/")
-        )
-        _max_workers = 2 if _is_rate_limited else 4
-
         min_conf_map = {
             "high": Confidence.HIGH,
             "medium": Confidence.MEDIUM,
@@ -763,18 +910,29 @@ def run_pipeline(
         config = AnalyzerConfig(
             model=model,
             api_key=api_key,
-            provider=getattr(agent_args, "provider", None),
-            base_url=getattr(agent_args, "base_url", None),
+            provider=resolved_provider,
+            base_url=resolved_base_url,
+            temperature=llm_temperature,
+            max_tokens=llm_max_tokens,
+            enable_security=True,
+            enable_quality=True,
+            strict_validation=llm_strict_validation,
             quiet=getattr(agent_args, "quiet", False),
-            min_confidence=min_conf_map.get(
-                getattr(agent_args, "min_confidence", "low"), Confidence.LOW
-            ),
-            parallel=True,
-            max_workers=_max_workers,
-            smart_filter=not path.is_file(),
-            full_file_review=path.is_file(),
+            stream=llm_stream,
+            min_confidence=min_conf_map.get(llm_min_confidence, Confidence.LOW),
+            parallel=llm_parallel,
+            max_workers=llm_max_workers,
+            max_chunk_tokens=llm_max_chunk_tokens,
+            smart_filter=llm_smart_filter,
+            complexity_threshold=llm_complexity_threshold,
+            batch_functions=llm_batch_functions,
+            batch_size=llm_batch_size,
+            full_file_review=llm_full_file_review,
             repo_context_map=phase_2b_repo_context,
             force_full_file_paths=force_full_file_paths,
+            prompt_templates=llm_prompt_templates,
+            prompt_template_root=llm_prompt_template_root,
+            agent_route=llm_agent_route,
         )
         analyzer = SkylosLLM(config)
 
@@ -815,7 +973,21 @@ def run_pipeline(
                     "_confidence": "medium",
                     "_needs_review": True,
                     "_ci_blocking": False,
+                    "model": model,
+                    "provider": resolved_provider,
+                    "prompt_revision": llm_prompt_revision,
                 }
+                if llm_prompt_revision is None:
+                    llm_finding["_review_identity_incomplete"] = True
+                if not llm_only_mode:
+                    identity_category = (
+                        "SECURITY" if issue_type == "security" else "QUALITY"
+                    )
+                    llm_context_hash = hybrid_llm_context_hashes.get(identity_category)
+                    if llm_context_hash is None:
+                        llm_finding["_review_identity_incomplete"] = True
+                    else:
+                        llm_finding["_llm_analysis_context_hash"] = llm_context_hash
                 if issue_type == "security":
                     annotate_security_finding(llm_finding)
                 results.append(llm_finding)
@@ -950,8 +1122,8 @@ def run_pipeline(
                 source_cache,
                 model,
                 api_key,
-                provider=getattr(agent_args, "provider", None),
-                base_url=getattr(agent_args, "base_url", None),
+                provider=resolved_provider,
+                base_url=resolved_base_url,
             )
             enriched = sum(1 for f in enrich_findings if f.get("fixed_code"))
             phase_stats["phase_3_seconds"] = round(time.time() - phase_3_start, 1)
@@ -970,6 +1142,8 @@ def run_pipeline(
 
     if stats_out is not None:
         stats_out.update(phase_stats)
+        if analysis_review_context is not None:
+            stats_out["review_context"] = analysis_review_context
         stats_out.update(
             {
                 "elapsed_seconds": round(time.time() - pipeline_start, 1),

--- a/skylos/reporting/dead_code_result.py
+++ b/skylos/reporting/dead_code_result.py
@@ -89,11 +89,7 @@ def _evidence_for_definition(evidence_by_name, definition):
             return None
         if entry.get("kind") and str(entry["kind"]) != definition_kind:
             return None
-        if (
-            entry.get("line")
-            and definition_line
-            and entry["line"] != definition_line
-        ):
+        if entry.get("line") and definition_line and entry["line"] != definition_line:
             return None
         return entry
 
@@ -198,8 +194,20 @@ def unused_definitions(analyzer, thr, dead_code_evidence_payload):
     return reported
 
 
-def dead_code_candidate_decisions(analyzer, thr, dead_code_evidence_payload):
+def dead_code_candidate_decisions(
+    analyzer,
+    thr,
+    dead_code_evidence_payload,
+    *,
+    review_config=None,
+    include_review_proofs=False,
+):
+    from skylos.deadcode.review_proof import prepare_dead_code_review_proofs
+
     evidence_by_name = _evidence_by_name(dead_code_evidence_payload)
+    review_proof_context = (
+        prepare_dead_code_review_proofs(analyzer) if include_review_proofs else None
+    )
     scoped_keys = getattr(analyzer, "_dead_code_scope_keys", None)
     dispositions = {}
     for key, definition in analyzer.defs.items():
@@ -218,8 +226,7 @@ def dead_code_candidate_decisions(analyzer, thr, dead_code_evidence_payload):
     reported_classes = {
         key
         for key, definition in analyzer.defs.items()
-        if definition.type in ("class", "type")
-        and dispositions.get(key) == "reported"
+        if definition.type in ("class", "type") and dispositions.get(key) == "reported"
     }
     class_keys = _class_key_by_name_file(analyzer)
     for key, definition in analyzer.defs.items():
@@ -230,9 +237,34 @@ def dead_code_candidate_decisions(analyzer, thr, dead_code_evidence_payload):
         if disposition == "reported" and owner_key in reported_classes:
             continue
         item = definition.to_dict()
+        if disposition == "reported":
+            review_file_configs = getattr(analyzer, "_review_file_configs", None)
+            if isinstance(review_file_configs, dict):
+                try:
+                    definition_path = str(Path(definition.filename).resolve())
+                except (OSError, RuntimeError, ValueError):
+                    item["_analysis_worker_config"] = "invalid"
+                else:
+                    item["_analysis_worker_config"] = review_file_configs.get(
+                        definition_path,
+                        "invalid",
+                    )
         _attach_evidence(item, definition, evidence_by_name)
         item["dead_code_disposition"] = disposition
-        if disposition == "reported":
+        if disposition == "reported" and include_review_proofs:
+            from skylos.deadcode.review_proof import build_dead_code_review_proof
+
+            item["dead_code_review_proof"] = build_dead_code_review_proof(
+                analyzer,
+                key,
+                definition,
+                _evidence_for_definition(evidence_by_name, definition),
+                threshold=thr,
+                context=review_proof_context,
+                review_config=review_config,
+            )
+            reported.append(item)
+        elif disposition == "reported":
             reported.append(item)
         elif disposition == "rescued":
             rescued.append(item)

--- a/skylos/reporting/provenance.py
+++ b/skylos/reporting/provenance.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from skylos.constants import NETWORK_TIMEOUT_SHORT, SUBPROCESS_TIMEOUT
+from skylos.core.git_safety import (
+    read_only_git_command,
+    read_only_git_environment,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -136,8 +140,9 @@ def _git_merge_base(git_root, base_ref):
     try:
         return (
             subprocess.check_output(
-                ["git", "merge-base", base_ref, "HEAD"],
+                read_only_git_command(["merge-base", base_ref, "HEAD"]),
                 cwd=git_root,
+                env=read_only_git_environment(),
                 stderr=subprocess.DEVNULL,
                 timeout=NETWORK_TIMEOUT_SHORT,
             )
@@ -169,13 +174,15 @@ def analyze_provenance(git_root, base_ref=None):
 
     try:
         log_output = subprocess.check_output(
-            [
-                "git",
-                "log",
-                "--format=%H|%an|%ae|%s|%(trailers:key=Co-authored-by,valueonly,separator=%x00)",
-                range_spec,
-            ],
+            read_only_git_command(
+                [
+                    "log",
+                    "--format=%H|%an|%ae|%s|%(trailers:key=Co-authored-by,valueonly,separator=%x00)",
+                    range_spec,
+                ]
+            ),
             cwd=git_root,
+            env=read_only_git_environment(),
             stderr=subprocess.DEVNULL,
             timeout=SUBPROCESS_TIMEOUT,
         ).decode("utf-8", errors="ignore")
@@ -255,8 +262,19 @@ def analyze_provenance(git_root, base_ref=None):
     for commit_sha in ai_commits:
         try:
             diff_output = subprocess.check_output(
-                ["git", "diff-tree", "-p", "-r", "--no-commit-id", commit_sha],
+                read_only_git_command(
+                    [
+                        "diff-tree",
+                        "--no-ext-diff",
+                        "--no-textconv",
+                        "-p",
+                        "-r",
+                        "--no-commit-id",
+                        commit_sha,
+                    ]
+                ),
                 cwd=git_root,
+                env=read_only_git_environment(),
                 stderr=subprocess.DEVNULL,
                 timeout=SUBPROCESS_TIMEOUT,
             ).decode("utf-8", errors="ignore")
@@ -290,8 +308,17 @@ def analyze_provenance(git_root, base_ref=None):
 
     try:
         all_files_output = subprocess.check_output(
-            ["git", "diff", "--name-only", range_spec],
+            read_only_git_command(
+                [
+                    "diff",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "--name-only",
+                    range_spec,
+                ]
+            ),
             cwd=git_root,
+            env=read_only_git_environment(),
             stderr=subprocess.DEVNULL,
             timeout=SUBPROCESS_TIMEOUT,
         ).decode("utf-8", errors="ignore")

--- a/skylos/reporting/result_builder.py
+++ b/skylos/reporting/result_builder.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from skylos.config import load_config
 from skylos.core.evidence_contract import attach_evidence_contract
+from skylos.core.review_context import review_config_hash_for_category
 from skylos.reporting.architecture_result import attach_circular_and_architecture
 from skylos.reporting.dead_code_result import (
     dead_code_candidate_decisions,
@@ -76,12 +77,19 @@ def build_analysis_result(
     pyproject_entrypoint_modules=None,
     config_file=None,
     analysis_errors=None,
+    include_review_proofs=False,
+    review_config=None,
 ):
     """Assemble the final result dict from analysis outputs."""
     architecture_main_guard_modules = _normal_set(architecture_main_guard_modules)
     pyproject_entrypoint_qnames = _normal_set(pyproject_entrypoint_qnames)
     pyproject_entrypoint_modules = _normal_set(pyproject_entrypoint_modules)
 
+    project_cfg = (
+        dict(review_config)
+        if isinstance(review_config, dict)
+        else load_config(_primary_path(path), config_file=config_file)
+    )
     ledger, evidence = dead_code_evidence(
         analyzer,
         path,
@@ -92,6 +100,8 @@ def build_analysis_result(
         analyzer,
         thr,
         evidence,
+        review_config=project_cfg,
+        include_review_proofs=include_review_proofs,
     )
     context_map = definition_context(analyzer, thr, evidence)
     whitelisted = whitelisted_definitions(analyzer, all_suppressed)
@@ -129,7 +139,6 @@ def build_analysis_result(
     _bucket_unused_definitions(result, unused)
     _attach_unused_ts_exports(result, unused_ts_exports)
 
-    project_cfg = load_config(_primary_path(path), config_file=config_file)
     attach_circular_and_architecture(
         result,
         project_cfg,
@@ -144,6 +153,8 @@ def build_analysis_result(
         pyproject_entrypoint_qnames,
         pyproject_entrypoint_modules,
     )
+    if isinstance(getattr(analyzer, "_review_context", None), dict):
+        _attach_effective_review_config_hashes(result, project_cfg)
     _attach_grade(
         result,
         files,
@@ -155,6 +166,42 @@ def build_analysis_result(
     )
     attach_directory_rollups(result, getattr(analyzer, "_project_root", None))
     return result
+
+
+def _attach_effective_review_config_hashes(result, root_config):
+    """Bind worker findings to the config their worker actually consumed."""
+    from skylos.core.review_decisions import FINDING_SECTIONS
+
+    root_hashes: dict[str, str | None] = {}
+    effective_hashes: dict[tuple[int, str], str | None] = {}
+    for section, category, _default_rule_id in FINDING_SECTIONS:
+        findings = result.get(section)
+        if not isinstance(findings, list):
+            continue
+        root_hash = root_hashes.setdefault(
+            category,
+            review_config_hash_for_category(root_config, category),
+        )
+        for finding in findings:
+            if not isinstance(finding, dict):
+                continue
+            if "_analysis_worker_config" not in finding:
+                continue
+            effective_config = finding.pop("_analysis_worker_config")
+            if root_hash is None or not isinstance(effective_config, dict):
+                finding["_analysis_config_hash"] = "invalid"
+                continue
+            cache_key = (id(effective_config), category)
+            if cache_key not in effective_hashes:
+                effective_hashes[cache_key] = review_config_hash_for_category(
+                    effective_config,
+                    category,
+                )
+            effective_hash = effective_hashes[cache_key]
+            if effective_hash is None:
+                finding["_analysis_config_hash"] = "invalid"
+            elif effective_hash != root_hash:
+                finding["_analysis_config_hash"] = effective_hash
 
 
 def _base_result(
@@ -205,6 +252,10 @@ def _base_result(
 
 
 def _attach_analysis_reports(analyzer, result):
+    review_context = getattr(analyzer, "_review_context", None)
+    if isinstance(review_context, dict):
+        result["analysis_summary"]["review_context"] = dict(review_context)
+
     analysis_scope = getattr(analyzer, "_analysis_scope", None)
     if isinstance(analysis_scope, dict):
         result["analysis_summary"]["comparison_scope"] = dict(analysis_scope)

--- a/skylos/reporting/sarif.py
+++ b/skylos/reporting/sarif.py
@@ -229,6 +229,16 @@ class SarifExporter:
 
             properties = {"category": category}
 
+            review_decision = (
+                finding.get("review_decision")
+                if self.analyzer_owned and finding.get("_skylos_trusted_review") is True
+                else None
+            )
+            if isinstance(review_decision, dict):
+                safe_review = _sanitize_sarif_payload(review_decision)
+                if safe_review:
+                    properties["skylos_review_decision"] = safe_review
+
             kind = finding.get("kind")
             if kind:
                 properties["kind"] = sanitize_untrusted_text(kind, max_length=120)
@@ -287,6 +297,20 @@ class SarifExporter:
                 result_obj["locations"][0]["physicalLocation"]["region"]["snippet"] = {
                     "text": snippet_text
                 }
+
+            if isinstance(review_decision, dict):
+                justification = sanitize_untrusted_text(
+                    review_decision.get("reason") or "Reviewed in Skylos",
+                    max_length=_MAX_SARIF_METADATA_TEXT_LENGTH,
+                    markdown=False,
+                )
+                result_obj["suppressions"] = [
+                    {
+                        "kind": "external",
+                        "status": "accepted",
+                        "justification": justification,
+                    }
+                ]
 
             results.append(result_obj)
 

--- a/skylos/rules/custom.py
+++ b/skylos/rules/custom.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import ast
 import fnmatch
+import hashlib
+import json
 from pathlib import Path
 from skylos.rules.base import SkylosRule
 
@@ -15,6 +17,13 @@ class YAMLRule(SkylosRule):
         self.message = config.get("yaml_config", {}).get(
             "message", "Custom rule violation"
         )
+        rule_bytes = json.dumps(
+            config,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        self.rule_revision = "custom:" + hashlib.sha256(rule_bytes).hexdigest()
         # Taint tracking state: maps variable names to taint status within function scope
         self._taint_state: dict[str, bool] = {}
 
@@ -320,6 +329,7 @@ class YAMLRule(SkylosRule):
             "category": self.category,
             "severity": self.severity,
             "message": self.message,
+            "rule_revision": self.rule_revision,
             "name": name or "<custom>",
             "simple_name": name or "<custom>",
             "value": "-",

--- a/skylos/security/contracts.py
+++ b/skylos/security/contracts.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import os
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -220,14 +219,7 @@ def _read_file_at_ref(
     repo_path = context.relative_path(Path(project_root).resolve() / relpath)
     if repo_path is None:
         return None
-    result = subprocess.run(
-        ["git", "show", f"{ref}:{repo_path}"],
-        capture_output=True,
-        text=True,
-        cwd=str(context.root),
-        env=context.env,
-        timeout=10,
-    )
+    result = context.run("show", f"{ref}:{repo_path}")
     if result.returncode == 0:
         return result.stdout
     return None
@@ -235,14 +227,7 @@ def _read_file_at_ref(
 
 def _git_ref_exists(project_root: str | os.PathLike[str], ref: str) -> bool:
     context = GitContext.from_path(project_root)
-    result = subprocess.run(
-        ["git", "rev-parse", "--verify", ref],
-        capture_output=True,
-        text=True,
-        cwd=str(context.root),
-        env=context.env,
-        timeout=10,
-    )
+    result = context.run("rev-parse", "--verify", ref)
     return result.returncode == 0
 
 

--- a/skylos/ui/help.py
+++ b/skylos/ui/help.py
@@ -32,6 +32,17 @@ COMMANDS = [
         "group": "AI Agent",
     },
     {
+        "name": "skylos review [path]",
+        "desc": "Review a finding and remember the local decision",
+        "details": [
+            "Interactive: scan, select a finding, then mark it false positive or accept risk temporarily",
+            "list [path]: show local decisions and their expiry",
+            "restore <decision-id> [path]: revoke a decision and show the finding again",
+            "Local decisions are operator-owned and ignored in CI",
+        ],
+        "group": "Core Analysis",
+    },
+    {
         "name": "skylos discover <path>",
         "desc": "Inventory LLM/AI integrations and agent tools",
         "group": "Core Analysis",

--- a/test/test_agent_center_review_memory.py
+++ b/test/test_agent_center_review_memory.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from skylos.agents import center
+from skylos.commands import review_cmd
+from skylos.core import review_decisions
+
+
+def test_watch_projects_reviewed_findings_before_building_actions(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def orphan():\n    return 1\n", encoding="utf-8")
+    raw_result = {
+        "unused_functions": [
+            {
+                "rule_id": "SKY-U001",
+                "name": "orphan",
+                "file": str(source),
+                "line": 1,
+                "confidence": 100,
+            }
+        ]
+    }
+    projected_result = {
+        **raw_result,
+        "unused_functions": [],
+        "reviewed_findings": raw_result["unused_functions"],
+    }
+
+    with (
+        patch(
+            "skylos.agents.center.run_analyze",
+            return_value=json.dumps(raw_result),
+        ) as run_analyze,
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(True, True),
+        ),
+        patch(
+            "skylos.core.review_decisions.apply_trusted_review_decisions",
+            return_value=projected_result,
+        ) as apply_reviews,
+        patch("skylos.agents.center.collect_debt_signals", return_value=[]),
+    ):
+        findings = center._run_refresh_analysis(
+            tmp_path,
+            conf=60,
+            enable_secrets=True,
+            enable_danger=True,
+            enable_quality=True,
+            enable_ai_defects=True,
+            include_dead_code=True,
+            use_baseline=False,
+            changed_files=[],
+        )
+
+    assert findings == []
+    assert run_analyze.call_args.kwargs["include_review_proofs"] is True
+    apply_reviews.assert_called_once_with(raw_result, tmp_path)
+
+
+def test_watch_rescans_when_only_review_state_changes(tmp_path):
+    project = tmp_path / "repo"
+    project.mkdir()
+    (project / "app.py").write_text("print('ok')\n", encoding="utf-8")
+
+    with (
+        patch(
+            "skylos.agents.center._current_review_state_revision",
+            side_effect=["review:one", "review:two", "review:two"],
+        ),
+        patch(
+            "skylos.agents.center._run_refresh_analysis",
+            side_effect=[[], []],
+        ) as analyze,
+        patch(
+            "skylos.agents.center._load_refresh_baselines",
+            return_value=(None, None, set(), set()),
+        ),
+    ):
+        first, first_updated = center.refresh_agent_state(
+            project,
+            force=True,
+            use_baseline=False,
+        )
+        second, second_updated = center.refresh_agent_state(
+            project,
+            use_baseline=False,
+        )
+        reused, third_updated = center.refresh_agent_state(
+            project,
+            use_baseline=False,
+        )
+
+    assert first_updated is True
+    assert first["review_state_revision"] == "review:one"
+    assert second_updated is True
+    assert second["review_state_revision"] == "review:two"
+    assert third_updated is False
+    assert reused == second
+    assert analyze.call_count == 2
+
+
+def test_triage_only_rebuild_preserves_review_state_revision(tmp_path):
+    state = center.compose_agent_state(
+        tmp_path,
+        signatures={},
+        findings=[],
+        changed_files=[],
+        baseline_present=False,
+        review_state_revision="review:one",
+    )
+
+    rebuilt = center.rebuild_agent_state_from_existing(state, triage={})
+
+    assert rebuilt["review_state_revision"] == "review:one"
+
+
+def test_new_review_decision_invalidates_watch_without_a_source_change(
+    tmp_path,
+    monkeypatch,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    source = repo / "app.py"
+    source.write_text("def orphan():\n    return 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "app.py"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Skylos Test",
+            "-c",
+            "user.email=skylos-test@example.invalid",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+        check=True,
+    )
+    cloud_cache = tmp_path / "reviewed-findings"
+    local_cache = tmp_path / "local-review-decisions"
+    monkeypatch.setattr(
+        review_decisions,
+        "_cache_root",
+        lambda value=None: (
+            Path(value).expanduser() if value is not None else cloud_cache
+        ),
+    )
+    monkeypatch.setattr(
+        review_decisions,
+        "_local_cache_root",
+        lambda value=None: (
+            Path(value).expanduser() if value is not None else local_cache
+        ),
+    )
+    monkeypatch.delenv("CI", raising=False)
+    for _provider, key in review_decisions._CI_RUN_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    first, first_updated = center.refresh_agent_state(
+        repo,
+        conf=60,
+        force=True,
+        use_baseline=False,
+    )
+    first_signatures = first["file_signatures"]
+    assert first_updated is True
+    assert any(
+        finding.get("message") == "Unused function: orphan"
+        for finding in first["findings"]
+    )
+    assert first["review_state_revision"] is None
+
+    def choose_dead(_console, findings, _input_fn):
+        return next(
+            finding
+            for finding in findings
+            if finding.get("_review_category") == "DEAD_CODE"
+            and finding.get("symbol") == "orphan"
+        )
+
+    monkeypatch.setattr(review_cmd, "_choose_finding", choose_dead)
+    answers = iter(["1", "registered runtime callback"])
+    assert (
+        review_cmd.run_review_command(
+            [str(repo)],
+            input_fn=lambda _prompt: next(answers),
+            environ={},
+        )
+        == 0
+    )
+
+    second, second_updated = center.refresh_agent_state(
+        repo,
+        conf=60,
+        use_baseline=False,
+    )
+    reused, third_updated = center.refresh_agent_state(
+        repo,
+        conf=60,
+        use_baseline=False,
+    )
+
+    assert second_updated is True
+    assert second["file_signatures"] == first_signatures
+    assert second["review_state_revision"] is not None
+    assert all(
+        finding.get("message") != "Unused function: orphan"
+        for finding in second["findings"]
+    )
+    assert all(
+        action.get("message") != "Unused function: orphan"
+        for action in second["actions"]
+    )
+    assert third_updated is False
+    assert reused == second
+    assert source.read_text(encoding="utf-8") == "def orphan():\n    return 1\n"

--- a/test/test_agent_llm_review_context.py
+++ b/test/test_agent_llm_review_context.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import skylos.cli as cli
+from skylos.core.review_context import (
+    LLM_REVIEW_CONTEXT_SCHEMA,
+    build_analysis_review_context,
+    review_context_is_valid,
+)
+from skylos.core.review_decisions import (
+    REVIEW_SCHEMA,
+    REVIEW_SCHEMA_VERSION,
+    annotate_result_identities,
+    apply_review_decisions,
+)
+from skylos.llm.schemas import (
+    CodeLocation,
+    Confidence,
+    Finding,
+    IssueType,
+    Severity,
+)
+from skylos.pipeline import run_pipeline
+
+
+def _agent_args(**overrides):
+    values = {
+        "upload": True,
+        "llm_only": True,
+        "static_only": False,
+        "skip_verification": True,
+        "with_fixes": False,
+        "quiet": True,
+        "provider": None,
+        "base_url": None,
+        "min_confidence": "low",
+        "verification_mode": "production",
+        "prompt_templates": None,
+        "prompt_template_root": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _quality_finding(source: Path) -> Finding:
+    return Finding(
+        rule_id="SKY-Q401",
+        issue_type=IssueType.QUALITY,
+        severity=Severity.MEDIUM,
+        message="Blocking operation in async handler",
+        location=CodeLocation(file=str(source), line=2),
+        confidence=Confidence.HIGH,
+        symbol="handler",
+        explanation="The call blocks the event loop.",
+        suggestion="Use the asynchronous API.",
+    )
+
+
+def _run_llm_only(repo: Path):
+    source = repo / "app.py"
+    source.write_text("async def handler():\n    blocking_call()\n", encoding="utf-8")
+    llm = MagicMock()
+    llm.return_value.analyze_files.return_value = MagicMock(
+        findings=[_quality_finding(source)]
+    )
+    stats = {}
+    with (
+        patch("skylos.analyzer.analyze") as static_analyze,
+        patch("skylos.llm.analyzer.SkylosLLM", llm),
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(False, False),
+        ),
+    ):
+        findings = run_pipeline(
+            path=str(repo),
+            model="gpt-4.1",
+            api_key="fake-key",
+            agent_args=_agent_args(),
+            console=MagicMock(),
+            exclude_folders=[".git", "vendor"],
+            stats_out=stats,
+            provider="openai",
+            base_url="https://api.example.test/v1",
+            project_root=repo,
+            project_config={"exclude": ["vendor"], "complexity": 10},
+        )
+    static_analyze.assert_not_called()
+    return findings, stats, llm
+
+
+def _static_review_context(repo: Path):
+    return build_analysis_review_context(
+        repo,
+        repo,
+        config={},
+        threshold=10,
+        exclude_folders=[],
+        requested_changed_files=None,
+        effective_changed_files=None,
+        enable_secrets=True,
+        enable_danger=True,
+        enable_quality=True,
+        enable_ai_defects=True,
+        enable_sca=False,
+        enable_dependency_hallucinations=False,
+        grep_verify=True,
+        trace_file=None,
+        required_config_rules=None,
+        dependency_bump_diff_base=None,
+        custom_rules_data=None,
+        extra_visitors=None,
+        analysis_scope={"kind": "repository", "complete_repository": True},
+        environ={},
+    )
+
+
+def _hybrid_static_result(repo: Path, review_context):
+    source = repo / "app.py"
+    return {
+        "definitions": {
+            "app.handler": {
+                "name": "handler",
+                "file": str(source),
+                "line": 1,
+                "type": "function",
+            }
+        },
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_parameters": [],
+        "unused_classes": [],
+        "danger": [],
+        "reliability": [],
+        "ai_defects": [],
+        "quality": [
+            {
+                "file": str(source),
+                "line": 5,
+                "name": "helper",
+                "message": "Helper has avoidable branching",
+                "rule_id": "SKY-Q301",
+                "severity": "MEDIUM",
+                "confidence": 80,
+            }
+        ],
+        "secrets": [],
+        "analysis_summary": {"review_context": review_context},
+    }
+
+
+def _run_hybrid(repo: Path, review_context):
+    source = repo / "app.py"
+    static_result = _hybrid_static_result(repo, review_context)
+    llm = MagicMock()
+    llm.return_value.analyze_files.return_value = MagicMock(
+        findings=[_quality_finding(source)]
+    )
+    stats = {}
+    with (
+        patch("skylos.analyzer.analyze", return_value=json.dumps(static_result)),
+        patch("skylos.llm.analyzer.SkylosLLM", llm),
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(False, False),
+        ),
+    ):
+        findings = run_pipeline(
+            path=str(repo),
+            model="gpt-4.1",
+            api_key="fake-key",
+            agent_args=_agent_args(llm_only=False),
+            console=MagicMock(),
+            stats_out=stats,
+            provider="openai",
+            project_root=repo,
+            project_config={},
+        )
+    return findings, stats, static_result
+
+
+def _decision_from_identity(identity, decision_id):
+    return {
+        "decision_id": decision_id,
+        "fingerprint_version": identity["fingerprint_version"],
+        "stable_fingerprint": identity["stable_fingerprint"],
+        "context_hash": identity["context_hash"],
+        "rule_revision": identity["rule_revision"],
+        "rule_id": identity["rule_id"],
+        "file_path": identity["file_path"],
+        "line_number": identity["line_number"],
+        "disposition": "false_positive",
+        "reason": "Reviewed in Cloud",
+        "created_at": "2026-09-12T00:00:00Z",
+        "language": identity["language"],
+        "symbol": identity["symbol"],
+        "section": identity["section"],
+        "category": "QUALITY",
+    }
+
+
+def test_llm_only_upload_emits_context_bound_v2_identity(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+
+    findings, stats, llm = _run_llm_only(repo)
+
+    context = stats["review_context"]
+    assert context["schema"] == LLM_REVIEW_CONTEXT_SCHEMA
+    assert review_context_is_valid(context)
+    assert context["scope"]["effective_files"]["count"] == 1
+    assert context["analyzer"]["model"] == "gpt-4.1"
+    assert context["analyzer"]["provider"] == "openai"
+    assert findings[0]["provider"] == "openai"
+    assert findings[0]["prompt_revision"].startswith("sha256:")
+    config = llm.call_args.args[0]
+    assert config.provider == "openai"
+    assert config.prompt_templates == {}
+
+    result = cli._agent_findings_to_result_json(
+        findings,
+        review_context=context,
+    )
+    annotated = annotate_result_identities(result, repo)
+    identity = annotated["quality"][0]
+    assert identity["fingerprint_version"] == "skylos-finding-v2"
+
+    decision = {
+        "decision_id": "cloud-llm-review-1",
+        "fingerprint_version": identity["fingerprint_version"],
+        "stable_fingerprint": identity["stable_fingerprint"],
+        "context_hash": identity["context_hash"],
+        "rule_revision": identity["rule_revision"],
+        "rule_id": identity["rule_id"],
+        "file_path": identity["file_path"],
+        "line_number": identity["line_number"],
+        "disposition": "false_positive",
+        "reason": "Reviewed in Cloud",
+        "created_at": "2026-09-12T00:00:00Z",
+        "language": identity["language"],
+        "symbol": identity["symbol"],
+        "section": identity["section"],
+        "category": "QUALITY",
+    }
+    next_findings, next_stats, _next_llm = _run_llm_only(repo)
+    assert next_stats["review_context"] == context
+    next_result = cli._agent_findings_to_result_json(
+        next_findings,
+        review_context=next_stats["review_context"],
+    )
+    projected = apply_review_decisions(
+        next_result,
+        {
+            "schema": REVIEW_SCHEMA,
+            "version": REVIEW_SCHEMA_VERSION,
+            "decisions": [decision],
+        },
+        repo,
+        require_review_context=True,
+    )
+    assert projected["quality"] == []
+    assert projected["reviewed_findings"][0]["review_decision"]["decision_id"] == (
+        "cloud-llm-review-1"
+    )
+
+
+def test_hybrid_llm_identity_matches_unchanged_run_without_changing_static_identity(
+    tmp_path,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    source = repo / "app.py"
+    source.write_text(
+        "async def handler():\n"
+        "    blocking_call()\n"
+        "\n"
+        "\n"
+        "def helper():\n"
+        "    if enabled():\n"
+        "        return 1\n"
+        "    return 0\n",
+        encoding="utf-8",
+    )
+    static_context = _static_review_context(repo)
+
+    findings, stats, raw_static = _run_hybrid(repo, static_context)
+
+    assert stats["review_context"] == static_context
+    static_finding = next(item for item in findings if item["_source"] == "static")
+    llm_finding = next(item for item in findings if item["_source"] == "llm")
+    assert "_llm_analysis_context_hash" not in static_finding
+    assert llm_finding["_llm_analysis_context_hash"].startswith("sha256:")
+
+    hybrid_result = cli._agent_findings_to_result_json(
+        findings,
+        review_context=static_context,
+    )
+    hybrid_annotated = annotate_result_identities(hybrid_result, repo)
+    hybrid_by_rule = {item["rule_id"]: item for item in hybrid_annotated["quality"]}
+    ordinary_static = annotate_result_identities(raw_static, repo)["quality"][0]
+    assert (
+        hybrid_by_rule["SKY-Q301"]["stable_fingerprint"]
+        == ordinary_static["stable_fingerprint"]
+    )
+    assert hybrid_by_rule["SKY-Q301"]["context_hash"] == ordinary_static["context_hash"]
+
+    llm_identity = hybrid_by_rule["SKY-Q401"]
+    decision = _decision_from_identity(llm_identity, "cloud-hybrid-review-1")
+    next_findings, next_stats, _ = _run_hybrid(repo, static_context)
+    next_result = cli._agent_findings_to_result_json(
+        next_findings,
+        review_context=next_stats["review_context"],
+    )
+    projected = apply_review_decisions(
+        next_result,
+        {
+            "schema": REVIEW_SCHEMA,
+            "version": REVIEW_SCHEMA_VERSION,
+            "decisions": [decision],
+        },
+        repo,
+        require_review_context=True,
+    )
+    assert [item["rule_id"] for item in projected["quality"]] == ["SKY-Q301"]
+    assert projected["reviewed_findings"][0]["rule_id"] == "SKY-Q401"
+
+
+def test_hybrid_llm_identity_resurfaces_when_selected_source_input_changes(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    source = repo / "app.py"
+    source.write_text(
+        "async def handler():\n"
+        "    blocking_call()\n"
+        "\n"
+        "\n"
+        "def helper():\n"
+        "    value = 1\n"
+        "    value += 2\n"
+        "    return value\n",
+        encoding="utf-8",
+    )
+    static_context = _static_review_context(repo)
+    findings, _stats, _raw_static = _run_hybrid(repo, static_context)
+    first_llm_finding = next(item for item in findings if item["_source"] == "llm")
+    first_llm_context = first_llm_finding["_llm_analysis_context_hash"]
+    first_result = cli._agent_findings_to_result_json(
+        findings,
+        review_context=static_context,
+    )
+    first_identity = next(
+        item
+        for item in annotate_result_identities(first_result, repo)["quality"]
+        if item["rule_id"] == "SKY-Q401"
+    )
+    decision = _decision_from_identity(first_identity, "cloud-hybrid-review-2")
+
+    source.write_text(
+        "async def handler():\n"
+        "    blocking_call()\n"
+        "\n"
+        "\n"
+        "def helper():\n"
+        "    value = 1\n"
+        "    value += 3\n"
+        "    return value\n",
+        encoding="utf-8",
+    )
+    changed_findings, changed_stats, _ = _run_hybrid(repo, static_context)
+    changed_llm_finding = next(
+        item for item in changed_findings if item["_source"] == "llm"
+    )
+    assert changed_llm_finding["_llm_analysis_context_hash"] != first_llm_context
+
+    changed_result = cli._agent_findings_to_result_json(
+        changed_findings,
+        review_context=changed_stats["review_context"],
+    )
+    changed_identity = next(
+        item
+        for item in annotate_result_identities(changed_result, repo)["quality"]
+        if item["rule_id"] == "SKY-Q401"
+    )
+    assert (
+        changed_identity["stable_fingerprint"] == first_identity["stable_fingerprint"]
+    )
+    assert changed_identity["context_hash"] != first_identity["context_hash"]
+
+    projected = apply_review_decisions(
+        changed_result,
+        {
+            "schema": REVIEW_SCHEMA,
+            "version": REVIEW_SCHEMA_VERSION,
+            "decisions": [decision],
+        },
+        repo,
+        require_review_context=True,
+    )
+    assert "SKY-Q401" in [item["rule_id"] for item in projected["quality"]]
+    assert projected.get("reviewed_findings", []) == []
+
+
+def test_hybrid_prompt_revision_failure_skips_only_llm_identity(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text(
+        "async def handler():\n    blocking_call()\n\n\ndef helper():\n    return 1\n",
+        encoding="utf-8",
+    )
+    static_context = _static_review_context(repo)
+
+    with patch("skylos.llm.prompts.analysis_prompt_revision", return_value=None):
+        findings, stats, _raw_static = _run_hybrid(repo, static_context)
+
+    result = cli._agent_findings_to_result_json(
+        findings,
+        review_context=stats["review_context"],
+    )
+    annotated = annotate_result_identities(result, repo)
+    by_rule = {item["rule_id"]: item for item in annotated["quality"]}
+    assert by_rule["SKY-Q301"]["fingerprint_version"] == "skylos-finding-v2"
+    assert "fingerprint_version" not in by_rule["SKY-Q401"]
+
+
+def test_llm_only_prompt_revision_failure_does_not_mint_identity(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text("async def handler():\n    blocking_call()\n", encoding="utf-8")
+    llm = MagicMock()
+    llm.return_value.analyze_files.return_value = MagicMock(
+        findings=[_quality_finding(source)]
+    )
+    stats = {}
+
+    with (
+        patch("skylos.analyzer.analyze") as static_analyze,
+        patch("skylos.llm.analyzer.SkylosLLM", llm),
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(False, False),
+        ),
+        patch("skylos.llm.prompts.analysis_prompt_revision", return_value=None),
+    ):
+        findings = run_pipeline(
+            path=str(repo),
+            model="gpt-4.1",
+            api_key="fake-key",
+            agent_args=_agent_args(),
+            console=MagicMock(),
+            stats_out=stats,
+            provider="openai",
+            project_root=repo,
+            project_config={},
+        )
+
+    static_analyze.assert_not_called()
+    assert not review_context_is_valid(stats["review_context"])
+    result = cli._agent_findings_to_result_json(
+        findings,
+        review_context=stats["review_context"],
+    )
+    annotated = annotate_result_identities(result, repo)
+    assert "fingerprint_version" not in annotated["quality"][0]
+
+
+def test_agent_cli_passes_resolved_llm_review_inputs_to_pipeline(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    source = repo / "app.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+    template = tmp_path / "review.md"
+    template.write_text("Check tenant boundaries.\n", encoding="utf-8")
+    project_config = {"exclude": ["generated"]}
+    pipeline = MagicMock(return_value=[])
+
+    with (
+        patch.object(
+            cli.sys,
+            "argv",
+            [
+                "skylos",
+                "agent",
+                "scan",
+                str(repo),
+                "--llm-only",
+                "--provider",
+                "anthropic",
+                "--prompt-template",
+                f"review={template}",
+            ],
+        ),
+        patch("skylos.cli.Console", return_value=MagicMock()),
+        patch("skylos.cli._ensure_llm_support", return_value=True),
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=(
+                "anthropic",
+                "fake-key",
+                "https://gateway.example.test/v1",
+                False,
+            ),
+        ),
+        patch("skylos.cli.load_config", return_value=project_config),
+        patch("skylos.cli.run_pipeline", pipeline),
+        patch("skylos.cli._upload_agent_run_best_effort"),
+    ):
+        with pytest.raises(SystemExit) as error:
+            cli.main()
+
+    assert error.value.code == 0
+    kwargs = pipeline.call_args.kwargs
+    assert kwargs["provider"] == "anthropic"
+    assert kwargs["base_url"] == "https://gateway.example.test/v1"
+    assert kwargs["project_root"] == repo
+    assert kwargs["project_config"] == project_config
+    passed_args = kwargs["agent_args"]
+    assert passed_args.prompt_templates == {"review": str(template)}
+    assert passed_args.prompt_template_root == Path("/")

--- a/test/test_agent_llm_review_context.py
+++ b/test/test_agent_llm_review_context.py
@@ -20,6 +20,7 @@ from skylos.core.review_decisions import (
     annotate_result_identities,
     apply_review_decisions,
 )
+from skylos.core.safe_cache_io import write_text_no_symlink
 from skylos.llm.schemas import (
     CodeLocation,
     Confidence,
@@ -65,7 +66,10 @@ def _quality_finding(source: Path) -> Finding:
 
 def _run_llm_only(repo: Path):
     source = repo / "app.py"
-    source.write_text("async def handler():\n    blocking_call()\n", encoding="utf-8")
+    assert write_text_no_symlink(
+        source,
+        "async def handler():\n    blocking_call()\n",
+    )
     llm = MagicMock()
     llm.return_value.analyze_files.return_value = MagicMock(
         findings=[_quality_finding(source)]

--- a/test/test_agent_remediate.py
+++ b/test/test_agent_remediate.py
@@ -506,6 +506,118 @@ class TestPRDescription:
 
 
 class TestOrchestrator:
+    def test_reviewed_findings_never_reach_remediation_planner(self, tmp_path):
+        from skylos.llm.orchestrator import RemediationAgent
+
+        reviewed = {
+            "rule_id": "SKY-D215",
+            "severity": "HIGH",
+            "message": "reviewed path finding",
+            "file": str(tmp_path / "app.py"),
+            "line": 1,
+        }
+        active = {
+            "rule_id": "SKY-D324",
+            "severity": "HIGH",
+            "message": "active path finding",
+            "file": str(tmp_path / "app.py"),
+            "line": 1,
+        }
+        raw_results = {
+            "danger": [reviewed, active],
+            "quality": [],
+            "secrets": [],
+        }
+        projected_results = {
+            "danger": [active],
+            "quality": [],
+            "secrets": [],
+            "reviewed_findings": [reviewed],
+        }
+        agent = RemediationAgent()
+
+        with (
+            patch("skylos.analyzer.analyze", return_value=raw_results) as analyze,
+            patch(
+                "skylos.core.review_decisions.review_scan_requirements",
+                return_value=(True, True),
+            ),
+            patch(
+                "skylos.core.review_decisions.apply_trusted_review_decisions",
+                return_value=projected_results,
+            ) as apply_reviews,
+            patch.object(
+                agent.planner,
+                "create_plan",
+                wraps=agent.planner.create_plan,
+            ) as create_plan,
+        ):
+            summary = agent.run(tmp_path, dry_run=True, quiet=True)
+
+        assert analyze.call_args.kwargs["include_review_proofs"] is True
+        apply_reviews.assert_called_once_with(raw_results, tmp_path)
+        planned_results = create_plan.call_args.args[0]
+        assert [item["rule_id"] for item in planned_results["danger"]] == ["SKY-D324"]
+        assert summary["total_findings"] == 1
+
+    def test_remediation_scan_avoids_review_proof_without_dead_code_state(
+        self, tmp_path
+    ):
+        from skylos.llm.orchestrator import RemediationAgent
+
+        raw_results = {"danger": [], "quality": [], "secrets": []}
+        agent = RemediationAgent()
+
+        with (
+            patch("skylos.analyzer.analyze", return_value=raw_results) as analyze,
+            patch(
+                "skylos.core.review_decisions.review_scan_requirements",
+                return_value=(False, False),
+            ),
+            patch(
+                "skylos.core.review_decisions.apply_trusted_review_decisions",
+                return_value=raw_results,
+            ),
+        ):
+            result = agent._scan(tmp_path)
+
+        assert result is raw_results
+        assert "include_review_proofs" not in analyze.call_args.kwargs
+
+    def test_remediation_scan_uses_review_config_and_default_excludes(
+        self, tmp_path, monkeypatch
+    ):
+        from skylos.constants import DEFAULT_EXCLUDE_FOLDERS
+        from skylos.llm.orchestrator import RemediationAgent
+
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.skylos]\nexclude = ["generated"]\n',
+            encoding="utf-8",
+        )
+        raw_results = {"danger": [], "quality": [], "secrets": []}
+        agent = RemediationAgent()
+
+        with (
+            patch("skylos.analyzer.analyze", return_value=raw_results) as analyze,
+            patch(
+                "skylos.core.review_decisions.review_scan_requirements",
+                return_value=(False, False),
+            ),
+            patch(
+                "skylos.core.review_decisions.apply_trusted_review_decisions",
+                return_value=raw_results,
+            ),
+        ):
+            result = agent._scan(tmp_path)
+
+        assert result is raw_results
+        scan_options = analyze.call_args.kwargs
+        assert set(scan_options["exclude_folders"]) == {
+            *DEFAULT_EXCLUDE_FOLDERS,
+            "generated",
+        }
+        assert scan_options["config_file"] is None
+
     def test_dry_run_no_changes(self, tmp_path):
         test_file = tmp_path / "vuln.py"
         test_file.write_text("import hashlib\nhashlib.md5(b'data')\n")
@@ -669,7 +781,9 @@ class TestOrchestrator:
         assert "Could not verify fix" in batch.fix_description
         executor.revert_fix.assert_called_once_with(str(test_file))
 
-    def test_process_batch_writes_sqli_regression_test_after_verification(self, tmp_path):
+    def test_process_batch_writes_sqli_regression_test_after_verification(
+        self, tmp_path
+    ):
         from skylos.llm.orchestrator import RemediationAgent
 
         tests_dir = tmp_path / "tests"
@@ -677,7 +791,7 @@ class TestOrchestrator:
         test_file = tmp_path / "vuln.py"
         test_file.write_text(
             "def get_user(cursor, user_id):\n"
-            "    query = f\"SELECT * FROM users WHERE id = {user_id}\"\n"
+            '    query = f"SELECT * FROM users WHERE id = {user_id}"\n'
             "    return cursor.execute(query)\n",
             encoding="utf-8",
         )
@@ -698,7 +812,7 @@ class TestOrchestrator:
             fixed_code=(
                 "def get_user(cursor, user_id):\n"
                 "    return cursor.execute(\n"
-                "        \"SELECT * FROM users WHERE id = ?\",\n"
+                '        "SELECT * FROM users WHERE id = ?",\n'
                 "        (user_id,),\n"
                 "    )\n"
             ),

--- a/test/test_agent_review_projection.py
+++ b/test/test_agent_review_projection.py
@@ -10,6 +10,7 @@ import pytest
 import skylos.cli as cli
 from skylos.core import review_decisions
 from skylos.core.review_context import build_analysis_review_context
+from skylos.core.safe_cache_io import write_text_no_symlink
 from skylos.llm.schemas import (
     AnalysisResult,
     CodeLocation,
@@ -57,7 +58,7 @@ def _reviewed_agent_finding(tmp_path, monkeypatch):
     repo.mkdir()
     subprocess.run(["git", "init", "-q", str(repo)], check=True)
     source = repo / "app.py"
-    source.write_text("open(path).write('unsafe')\n")
+    assert write_text_no_symlink(source, "open(path).write('unsafe')\n")
     finding = {
         "rule_id": "SKY-D215",
         "file": str(source),

--- a/test/test_agent_review_projection.py
+++ b/test/test_agent_review_projection.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import skylos.cli as cli
+from skylos.core import review_decisions
+from skylos.core.review_context import build_analysis_review_context
+from skylos.llm.schemas import (
+    AnalysisResult,
+    CodeLocation,
+    Confidence,
+    Finding,
+    IssueType,
+    Severity,
+)
+
+
+_CI_KEYS = (
+    "CI",
+    "GITHUB_RUN_ID",
+    "GITHUB_RUN_ATTEMPT",
+    "GITHUB_JOB",
+    "CI_PIPELINE_ID",
+    "BUILD_BUILDID",
+    "CIRCLE_WORKFLOW_ID",
+    "BUILD_TAG",
+)
+
+
+def _reviewed_agent_finding(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    cloud_cache = home / "reviewed-findings"
+    local_cache = home / "local-review-decisions"
+    monkeypatch.setattr(
+        review_decisions,
+        "_cache_root",
+        lambda value=None: (
+            Path(value).expanduser() if value is not None else cloud_cache
+        ),
+    )
+    monkeypatch.setattr(
+        review_decisions,
+        "_local_cache_root",
+        lambda value=None: (
+            Path(value).expanduser() if value is not None else local_cache
+        ),
+    )
+    for key in _CI_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    finding = {
+        "rule_id": "SKY-D215",
+        "file": str(source),
+        "line": 1,
+        "symbol": "write_report",
+        "severity": "HIGH",
+        "message": "unsafe path",
+        "_category": "security",
+        "_source": "static+llm",
+        "_confidence": "high",
+        "model": "gpt-4.1",
+        "provider": "openai",
+    }
+    context = build_analysis_review_context(
+        repo,
+        repo,
+        config={},
+        threshold=10,
+        exclude_folders=[],
+        requested_changed_files=None,
+        effective_changed_files=None,
+        enable_secrets=True,
+        enable_danger=True,
+        enable_quality=True,
+        enable_ai_defects=True,
+        enable_sca=False,
+        enable_dependency_hallucinations=False,
+        grep_verify=True,
+        trace_file=None,
+        required_config_rules=None,
+        dependency_bump_diff_base=None,
+        custom_rules_data=None,
+        extra_visitors=None,
+        analysis_scope={"kind": "repository", "complete_repository": True},
+        environ={},
+    )
+    normalized = cli._normalize_agent_findings([finding], repo)
+    result = cli._agent_findings_to_result_json(normalized, review_context=context)
+    identity = review_decisions.annotate_result_identities(result, repo)["danger"][0]
+    review_decisions.record_local_decision(
+        repo,
+        {
+            "decision_id": "agent-review-1",
+            "fingerprint_version": identity["fingerprint_version"],
+            "stable_fingerprint": identity["stable_fingerprint"],
+            "context_hash": identity["context_hash"],
+            "rule_revision": identity["rule_revision"],
+            "rule_id": identity["rule_id"],
+            "file_path": identity["file_path"],
+            "line_number": 1,
+            "disposition": "false_positive",
+            "reason": "validated safe wrapper",
+            "created_at": "2026-09-12T00:00:00Z",
+            "language": identity["language"],
+            "symbol": identity["symbol"],
+            "section": identity["section"],
+            "category": "SECURITY",
+        },
+    )
+    return repo, finding, context
+
+
+def _run_agent_scan(repo, finding, context, *arguments, upload_response=None):
+    console = MagicMock()
+    upload = MagicMock(
+        return_value=upload_response or {"success": True, "quality_gate_passed": True}
+    )
+    printed = MagicMock()
+    argv = ["skylos", "agent", "scan", str(repo), *arguments]
+
+    def run_pipeline_with_context(**kwargs):
+        kwargs["stats_out"]["review_context"] = context
+        return [finding]
+
+    with (
+        patch.object(cli.sys, "argv", argv),
+        patch("skylos.cli.Console", return_value=console),
+        patch("skylos.cli._ensure_llm_support", return_value=True),
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.run_pipeline", side_effect=run_pipeline_with_context),
+        patch("skylos.cli.upload_report", upload),
+        patch("skylos.cli._upload_agent_run_best_effort"),
+        patch("builtins.print", printed),
+    ):
+        with pytest.raises(SystemExit) as error:
+            cli.main()
+    return error.value.code, console, printed, upload
+
+
+@pytest.mark.parametrize("output_format", ["table", "json"])
+def test_agent_scan_outputs_only_active_findings_after_review_projection(
+    tmp_path,
+    monkeypatch,
+    output_format,
+):
+    repo, finding, context = _reviewed_agent_finding(tmp_path, monkeypatch)
+
+    code, console, printed, _upload = _run_agent_scan(
+        repo,
+        finding,
+        context,
+        "--format",
+        output_format,
+    )
+
+    assert code == 0
+    if output_format == "json":
+        json_calls = [
+            call.args[0]
+            for call in printed.call_args_list
+            if call.args
+            and isinstance(call.args[0], str)
+            and call.args[0].lstrip().startswith("[")
+        ]
+        assert len(json_calls) == 1
+        assert json.loads(json_calls[0]) == []
+    else:
+        rendered = [
+            str(call.args[0]) for call in console.print.call_args_list if call.args
+        ]
+        assert any("Total findings: 0" in value for value in rendered)
+        assert any("No issues found" in value for value in rendered)
+        assert all("unsafe path" not in value for value in rendered)
+
+
+def test_agent_scan_strict_passes_when_only_finding_is_reviewed(
+    tmp_path,
+    monkeypatch,
+):
+    repo, finding, context = _reviewed_agent_finding(tmp_path, monkeypatch)
+
+    code, _console, _printed, _upload = _run_agent_scan(
+        repo,
+        finding,
+        context,
+        "--strict",
+    )
+
+    assert code == 0
+
+
+def test_agent_scan_upload_retains_locally_reviewed_raw_finding(
+    tmp_path,
+    monkeypatch,
+):
+    repo, finding, context = _reviewed_agent_finding(tmp_path, monkeypatch)
+
+    code, _console, _printed, upload = _run_agent_scan(
+        repo,
+        finding,
+        context,
+        "--upload",
+    )
+
+    assert code == 0
+    upload.assert_called_once()
+    report = upload.call_args.args[0]
+    assert report["danger"] == []
+    assert len(report["reviewed_findings"]) == 1
+    reviewed = report["reviewed_findings"][0]
+    assert reviewed["rule_id"] == "SKY-D215"
+    assert reviewed["message"] == "unsafe path"
+    assert reviewed["review_decision"]["decision_id"] == "agent-review-1"
+    assert reviewed["review_decision"]["disposition"] == "false_positive"
+
+
+def test_agent_projection_preserves_analyzer_review_context(tmp_path, monkeypatch):
+    repo, finding, context = _reviewed_agent_finding(tmp_path, monkeypatch)
+    normalized = cli._normalize_agent_findings([finding], repo)
+    result = cli._agent_findings_to_result_json(
+        normalized,
+        review_context=context,
+    )
+    identity = review_decisions.annotate_result_identities(result, repo)["danger"][0]
+    review_decisions.record_local_decision(
+        repo,
+        {
+            "decision_id": "agent-context-review",
+            "fingerprint_version": identity["fingerprint_version"],
+            "stable_fingerprint": identity["stable_fingerprint"],
+            "context_hash": identity["context_hash"],
+            "rule_revision": identity["rule_revision"],
+            "rule_id": identity["rule_id"],
+            "file_path": identity["file_path"],
+            "line_number": 1,
+            "disposition": "false_positive",
+            "reason": "reviewed with exact analyzer inputs",
+            "created_at": "2026-09-12T00:00:00Z",
+            "language": identity["language"],
+            "symbol": identity["symbol"],
+            "section": identity["section"],
+            "category": "SECURITY",
+        },
+    )
+
+    active, projected = cli._apply_agent_review_memory(
+        normalized,
+        repo,
+        review_context=context,
+    )
+
+    assert active == []
+    assert projected["reviewed_findings"][0]["review_decision"]["decision_id"] == (
+        "agent-context-review"
+    )
+
+
+def test_agent_scan_cloud_gate_rejection_exits_one_after_local_review(
+    tmp_path,
+    monkeypatch,
+):
+    repo, finding, context = _reviewed_agent_finding(tmp_path, monkeypatch)
+
+    code, _console, _printed, upload = _run_agent_scan(
+        repo,
+        finding,
+        context,
+        "--upload",
+        upload_response={"success": True, "quality_gate_passed": False},
+    )
+
+    assert code == 1
+    upload.assert_called_once()
+    report = upload.call_args.args[0]
+    assert report["danger"] == []
+    assert len(report["reviewed_findings"]) == 1
+
+
+def test_agent_security_scan_does_not_apply_inert_review_memory(
+    tmp_path,
+    monkeypatch,
+):
+    repo, raw_finding, _context = _reviewed_agent_finding(tmp_path, monkeypatch)
+    finding = Finding(
+        rule_id=raw_finding["rule_id"],
+        issue_type=IssueType.SECURITY,
+        severity=Severity.HIGH,
+        message=raw_finding["message"],
+        location=CodeLocation(file=str(repo / "app.py"), line=1),
+        confidence=Confidence.HIGH,
+        symbol=raw_finding["symbol"],
+    )
+    original_result = AnalysisResult(findings=[finding], files_analyzed=1)
+    assert original_result.has_blockers() is True
+    taskflow = MagicMock(result=original_result)
+    analyzer = MagicMock()
+    console = MagicMock()
+
+    with (
+        patch.object(
+            cli.sys,
+            "argv",
+            ["skylos", "agent", "scan", str(repo), "--security"],
+        ),
+        patch("skylos.cli.Console", return_value=console),
+        patch("skylos.cli._ensure_llm_support", return_value=True),
+        patch(
+            "skylos.cli.resolve_llm_runtime",
+            return_value=("openai", "fake-key", None, False),
+        ),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli._is_tty", return_value=False),
+        patch("skylos.cli.llm_estimate_cost", return_value=(10, 0.01)),
+        patch("skylos.cli.SkylosLLM", return_value=analyzer),
+        patch("skylos.cli.run_security_taskflow", return_value=taskflow),
+        patch("skylos.cli._apply_agent_review_memory") as apply_reviews,
+    ):
+        with pytest.raises(SystemExit) as error:
+            cli.main()
+
+    assert error.value.code == 1
+    apply_reviews.assert_not_called()
+    analyzer.print_results.assert_called_once()
+    rendered_result = analyzer.print_results.call_args.args[0]
+    assert rendered_result.findings == [finding]
+    rendered = [str(call.args[0]) for call in console.print.call_args_list if call.args]
+    assert all("previously reviewed" not in value.lower() for value in rendered)

--- a/test/test_analysis_review_context.py
+++ b/test/test_analysis_review_context.py
@@ -1,0 +1,848 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from skylos import analyze
+import skylos.cli as cli
+from skylos.commands import review_cmd
+from skylos.config import DEFAULTS
+from skylos.core.review_context import (
+    build_analysis_review_context,
+    review_context_hash_for_category,
+    review_context_is_valid,
+)
+from skylos.core.review_decisions import annotate_result_identities
+from skylos.reporting.result_builder import _attach_effective_review_config_hashes
+
+
+class _VisitorOne:
+    pass
+
+
+class _VisitorTwo:
+    marker = 2
+
+
+def _context(
+    root: Path,
+    *,
+    target: Path | None = None,
+    config: dict | None = None,
+    threshold: int = 60,
+    excluded=(),
+    requested_changed_files=None,
+    effective_changed_files=None,
+    enable_secrets=False,
+    enable_danger=False,
+    enable_quality=False,
+    enable_ai_defects=False,
+    enable_sca=False,
+    enable_dependency_hallucinations=True,
+    grep_verify=True,
+    trace_file=None,
+    required_config_rules=None,
+    dependency_bump_diff_base=None,
+    custom_rules_data=None,
+    extra_visitors=None,
+):
+    target = target or root
+    scope_kind = (
+        "repository_root" if target == root and not excluded else "subdirectory"
+    )
+    return build_analysis_review_context(
+        root,
+        target,
+        config=copy.deepcopy(DEFAULTS if config is None else config),
+        threshold=threshold,
+        exclude_folders=excluded,
+        requested_changed_files=requested_changed_files,
+        effective_changed_files=effective_changed_files,
+        enable_secrets=enable_secrets,
+        enable_danger=enable_danger,
+        enable_quality=enable_quality,
+        enable_ai_defects=enable_ai_defects,
+        enable_sca=enable_sca,
+        enable_dependency_hallucinations=enable_dependency_hallucinations,
+        grep_verify=grep_verify,
+        trace_file=trace_file,
+        required_config_rules=required_config_rules,
+        dependency_bump_diff_base=dependency_bump_diff_base,
+        custom_rules_data=custom_rules_data,
+        extra_visitors=extra_visitors,
+        analysis_scope={
+            "kind": scope_kind,
+            "complete_repository": target == root and not excluded,
+        },
+        environ={},
+    )
+
+
+def _hash(context, category):
+    value = review_context_hash_for_category(context, category)
+    assert value is not None
+    return value
+
+
+def _synthetic_result(source: Path, review_context, **finding_overrides):
+    finding = {
+        "rule_id": "SKY-D215",
+        "file": str(source),
+        "line": 2,
+        "symbol": "write_report",
+        "severity": "HIGH",
+        "message": "unsafe path",
+        "evidence_contract": {
+            "schema_version": 1,
+            "proof_state": "candidate",
+            "sources": ["path"],
+            "sinks": ["open"],
+            "symbols": ["write_report"],
+            "traces": [],
+            "limitations": [],
+        },
+    }
+    finding.update(finding_overrides)
+    return {
+        "danger": [finding],
+        "analysis_summary": {"review_context": review_context},
+    }
+
+
+def test_review_context_uses_category_specific_config_inputs(tmp_path):
+    baseline = copy.deepcopy(DEFAULTS)
+    quality_only = copy.deepcopy(DEFAULTS)
+    quality_only["complexity"] = baseline["complexity"] + 5
+    quality_only["nudges"] = not baseline["nudges"]
+
+    first = _context(tmp_path, config=baseline, enable_danger=True)
+    second = _context(tmp_path, config=quality_only, enable_danger=True)
+
+    assert _hash(first, "DEAD_CODE") == _hash(second, "DEAD_CODE")
+    assert _hash(first, "SECURITY") == _hash(second, "SECURITY")
+    assert _hash(first, "QUALITY") != _hash(second, "QUALITY")
+
+    dead_change = copy.deepcopy(DEFAULTS)
+    dead_change["dead_code"]["entrypoints"] = [{"name": "worker"}]
+    security_change = copy.deepcopy(DEFAULTS)
+    security_change["security_contracts"] = [{"rule_id": "SKY-SC001"}]
+
+    assert _hash(first, "DEAD_CODE") != _hash(
+        _context(tmp_path, config=dead_change, enable_danger=True),
+        "DEAD_CODE",
+    )
+    assert _hash(first, "SECURITY") != _hash(
+        _context(tmp_path, config=security_change, enable_danger=True),
+        "SECURITY",
+    )
+
+    source = tmp_path / "app.py"
+    source.write_text(
+        "def write_report(path):\n    open(path, 'w').write('ok')\n",
+        encoding="utf-8",
+    )
+    baseline_identity = annotate_result_identities(
+        _synthetic_result(source, first),
+        tmp_path,
+    )["danger"][0]
+    quality_only_identity = annotate_result_identities(
+        _synthetic_result(source, second),
+        tmp_path,
+    )["danger"][0]
+    security_change_identity = annotate_result_identities(
+        _synthetic_result(
+            source,
+            _context(tmp_path, config=security_change, enable_danger=True),
+        ),
+        tmp_path,
+    )["danger"][0]
+
+    assert baseline_identity["context_hash"] == quality_only_identity["context_hash"]
+    assert baseline_identity["context_hash"] != security_change_identity["context_hash"]
+
+
+def test_python_dead_finding_ignores_quality_only_config_changes(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def orphan():\n    return 1\n", encoding="utf-8")
+
+    def orphan_identity(overrides):
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                enable_quality=True,
+                grep_verify=False,
+                include_review_proofs=True,
+                project_config_overrides=overrides,
+            )
+        )
+        annotated = annotate_result_identities(result, tmp_path)
+        return next(
+            finding
+            for finding in annotated["unused_functions"]
+            if finding.get("symbol") == "orphan"
+        )
+
+    baseline = orphan_identity({"complexity": 10, "nudges": True})
+    quality_change = orphan_identity({"complexity": 25, "nudges": False})
+
+    assert baseline["stable_fingerprint"] == quality_change["stable_fingerprint"]
+    assert baseline["context_hash"] == quality_change["context_hash"]
+
+
+def test_review_context_binds_only_category_relevant_options(tmp_path):
+    app = tmp_path / "app.py"
+    other = tmp_path / "other.py"
+    app.write_text("pass\n", encoding="utf-8")
+    other.write_text("pass\n", encoding="utf-8")
+
+    baseline = _context(tmp_path, enable_danger=True)
+    review_scan = _context(
+        tmp_path,
+        enable_danger=True,
+        enable_quality=True,
+        enable_secrets=True,
+        enable_ai_defects=True,
+    )
+    assert _hash(baseline, "DEAD_CODE") == _hash(review_scan, "DEAD_CODE")
+
+    higher_threshold = _context(tmp_path, threshold=75, enable_danger=True)
+    assert _hash(baseline, "DEAD_CODE") != _hash(higher_threshold, "DEAD_CODE")
+    assert _hash(baseline, "SECURITY") == _hash(higher_threshold, "SECURITY")
+
+    selected_rule = _context(
+        tmp_path,
+        enable_danger=True,
+        required_config_rules=["sky-gpu001"],
+    )
+    assert _hash(baseline, "SECURITY") != _hash(selected_rule, "SECURITY")
+    assert _hash(baseline, "DEAD_CODE") == _hash(selected_rule, "DEAD_CODE")
+
+    auto_diff = _context(
+        tmp_path,
+        enable_danger=True,
+        effective_changed_files={app},
+    )
+    assert _hash(baseline, "DEAD_CODE") == _hash(auto_diff, "DEAD_CODE")
+    assert _hash(baseline, "SECURITY") != _hash(auto_diff, "SECURITY")
+
+    explicit_diff = _context(
+        tmp_path,
+        enable_danger=True,
+        requested_changed_files={other},
+        effective_changed_files={other},
+    )
+    assert _hash(baseline, "DEAD_CODE") != _hash(explicit_diff, "DEAD_CODE")
+
+
+def test_custom_rule_inputs_do_not_invalidate_builtin_quality(tmp_path):
+    first = _context(
+        tmp_path,
+        enable_quality=True,
+        custom_rules_data=[{"rule_id": "CUSTOM-ONE", "pattern": "first"}],
+    )
+    second = _context(
+        tmp_path,
+        enable_quality=True,
+        custom_rules_data=[{"rule_id": "CUSTOM-ONE", "pattern": "second"}],
+    )
+
+    assert _hash(first, "QUALITY") == _hash(second, "QUALITY")
+    assert _hash(first, "CUSTOM") != _hash(second, "CUSTOM")
+
+    visitor_one = _context(
+        tmp_path,
+        enable_danger=True,
+        enable_quality=True,
+        enable_ai_defects=True,
+        extra_visitors=[_VisitorOne],
+    )
+    visitor_two = _context(
+        tmp_path,
+        enable_danger=True,
+        enable_ai_defects=True,
+        extra_visitors=[_VisitorTwo],
+    )
+    same_visitor_without_quality = _context(
+        tmp_path,
+        enable_danger=True,
+        enable_ai_defects=True,
+        extra_visitors=[_VisitorOne],
+    )
+    same_visitor_without_danger = _context(
+        tmp_path,
+        enable_ai_defects=True,
+        extra_visitors=[_VisitorOne],
+    )
+
+    assert _hash(visitor_one, "CUSTOM") == _hash(visitor_two, "CUSTOM")
+    assert _hash(visitor_one, "CUSTOM") == _hash(
+        same_visitor_without_quality,
+        "CUSTOM",
+    )
+    assert _hash(visitor_one, "SECURITY") != _hash(visitor_two, "SECURITY")
+    assert _hash(visitor_one, "RELIABILITY") != _hash(visitor_two, "RELIABILITY")
+    assert _hash(visitor_one, "AI_DEFECT") != _hash(visitor_two, "AI_DEFECT")
+    assert _hash(visitor_one, "AI_DEFECT") != _hash(
+        same_visitor_without_danger,
+        "AI_DEFECT",
+    )
+
+
+def test_incomplete_extensions_only_disable_their_output_categories(tmp_path):
+    baseline = _context(
+        tmp_path,
+        enable_danger=True,
+        enable_quality=True,
+        enable_ai_defects=True,
+    )
+    malformed_rules = _context(
+        tmp_path,
+        enable_danger=True,
+        enable_quality=True,
+        enable_ai_defects=True,
+        custom_rules_data={"rule": object()},
+    )
+    uninspectable_visitor = _context(
+        tmp_path,
+        enable_danger=True,
+        enable_quality=True,
+        enable_ai_defects=True,
+        extra_visitors=[len],
+    )
+
+    assert review_context_is_valid(malformed_rules)
+    assert review_context_hash_for_category(malformed_rules, "CUSTOM") is None
+    assert _hash(malformed_rules, "DEAD_CODE") == _hash(baseline, "DEAD_CODE")
+    assert _hash(malformed_rules, "SECURITY") == _hash(baseline, "SECURITY")
+    assert _hash(malformed_rules, "QUALITY") == _hash(baseline, "QUALITY")
+
+    assert review_context_is_valid(uninspectable_visitor)
+    assert _hash(uninspectable_visitor, "CUSTOM") == _hash(baseline, "CUSTOM")
+    assert review_context_hash_for_category(uninspectable_visitor, "SECURITY") is None
+    assert (
+        review_context_hash_for_category(uninspectable_visitor, "RELIABILITY") is None
+    )
+    assert review_context_hash_for_category(uninspectable_visitor, "AI_DEFECT") is None
+    assert _hash(uninspectable_visitor, "DEAD_CODE") == _hash(
+        baseline,
+        "DEAD_CODE",
+    )
+    assert _hash(uninspectable_visitor, "QUALITY") == _hash(baseline, "QUALITY")
+
+
+def test_review_context_is_stable_when_checkout_moves(tmp_path):
+    first = tmp_path / "first" / "repo"
+    second = tmp_path / "second" / "repo"
+    for root in (first, second):
+        (root / "src").mkdir(parents=True)
+        (root / "src" / "app.py").write_text("pass\n", encoding="utf-8")
+
+    first_context = _context(
+        first,
+        target=first / "src",
+        excluded={first / "build", "node_modules"},
+        requested_changed_files={first / "src" / "app.py"},
+        effective_changed_files={first / "src" / "app.py"},
+        enable_danger=True,
+    )
+    second_context = _context(
+        second,
+        target=second / "src",
+        excluded={second / "build", "node_modules"},
+        requested_changed_files={second / "src" / "app.py"},
+        effective_changed_files={second / "src" / "app.py"},
+        enable_danger=True,
+    )
+
+    assert review_context_is_valid(first_context)
+    assert first_context == second_context
+    assert str(first) not in json.dumps(first_context)
+    assert str(second) not in json.dumps(second_context)
+
+    first_source = first / "src" / "app.py"
+    second_source = second / "src" / "app.py"
+    first_source.write_text(
+        "def write_report(path):\n    open(path, 'w').write('ok')\n",
+        encoding="utf-8",
+    )
+    second_source.write_text(first_source.read_text(encoding="utf-8"), encoding="utf-8")
+    first_identity = annotate_result_identities(
+        _synthetic_result(first_source, first_context),
+        first,
+    )["danger"][0]
+    second_identity = annotate_result_identities(
+        _synthetic_result(second_source, second_context),
+        second,
+    )["danger"][0]
+
+    assert first_identity["stable_fingerprint"] == second_identity["stable_fingerprint"]
+    assert first_identity["context_hash"] == second_identity["context_hash"]
+
+
+def test_material_scan_scope_change_resurfaces_finding(tmp_path):
+    source = tmp_path / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text(
+        "def write_report(path):\n    open(path, 'w').write('ok')\n",
+        encoding="utf-8",
+    )
+    repository_context = _context(tmp_path, enable_danger=True)
+    file_context = _context(tmp_path, target=source, enable_danger=True)
+
+    repository_identity = annotate_result_identities(
+        _synthetic_result(source, repository_context),
+        tmp_path,
+    )["danger"][0]
+    file_identity = annotate_result_identities(
+        _synthetic_result(source, file_context),
+        tmp_path,
+    )["danger"][0]
+
+    assert repository_identity["context_hash"] != file_identity["context_hash"]
+
+
+def test_nested_file_config_change_resurfaces_quality_finding(tmp_path):
+    repo = tmp_path / "repo"
+    package = repo / "package"
+    package.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    source = package / "app.py"
+    source.write_text(
+        "def branchy(value):\n"
+        "    if value == 1:\n"
+        "        return 1\n"
+        "    if value == 2:\n"
+        "        return 2\n"
+        "    if value == 3:\n"
+        "        return 3\n"
+        "    return 0\n\n"
+        "print(branchy(1))\n",
+        encoding="utf-8",
+    )
+    nested_config = package / "pyproject.toml"
+
+    def scan(complexity: int):
+        nested_config.write_text(
+            f"[tool.skylos]\ncomplexity = {complexity}\n",
+            encoding="utf-8",
+        )
+        result = json.loads(
+            analyze(
+                str(repo),
+                conf=0,
+                enable_quality=True,
+                grep_verify=False,
+                include_review_proofs=True,
+            )
+        )
+        annotated = annotate_result_identities(result, repo)
+        finding = next(
+            item for item in annotated["quality"] if item.get("rule_id") == "SKY-Q301"
+        )
+        return result["analysis_summary"]["review_context"], finding
+
+    first_context, first = scan(1)
+    second_context, second = scan(2)
+
+    assert first["message"] != second["message"]
+    assert _hash(first_context, "QUALITY") == _hash(second_context, "QUALITY")
+    assert _hash(first_context, "SECURITY") == _hash(second_context, "SECURITY")
+    assert first["stable_fingerprint"] == second["stable_fingerprint"]
+    assert first["context_hash"] != second["context_hash"]
+
+
+def test_repo_level_finding_under_nested_config_keeps_root_context(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("SKYLOS_JOBS", "1")
+    package = tmp_path / "package"
+    package.mkdir()
+    (package / "pyproject.toml").write_text(
+        "[tool.skylos]\ncomplexity = 99\n",
+        encoding="utf-8",
+    )
+    clone = (
+        "def FUNCTION(value):\n"
+        "    total = value + 1\n"
+        "    total = total * 2\n"
+        "    total = total - 3\n"
+        "    total = total / 4\n"
+        "    total = total + 5\n"
+        "    total = total * 6\n"
+        "    total = total - 7\n"
+        "    total = total / 8\n"
+        "    return total\n\n"
+        "print(FUNCTION(1))\n"
+    )
+    (package / "first.py").write_text(
+        clone.replace("FUNCTION", "first"),
+        encoding="utf-8",
+    )
+    (package / "second.py").write_text(
+        clone.replace("FUNCTION", "second"),
+        encoding="utf-8",
+    )
+
+    def scan(nudges: bool):
+        (tmp_path / "pyproject.toml").write_text(
+            f"[tool.skylos]\nnudges = {str(nudges).lower()}\n",
+            encoding="utf-8",
+        )
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                conf=0,
+                enable_quality=True,
+                grep_verify=False,
+                include_review_proofs=True,
+            )
+        )
+        raw = next(
+            item for item in result["quality"] if item.get("rule_id") == "SKY-C401"
+        )
+        assert "_analysis_config_hash" not in raw
+        annotated = annotate_result_identities(result, tmp_path)
+        return next(
+            item
+            for item in annotated["quality"]
+            if item.get("rule_id") == "SKY-C401"
+        )
+
+    first = scan(False)
+    second = scan(True)
+
+    assert first["stable_fingerprint"] == second["stable_fingerprint"]
+    assert first["context_hash"] != second["context_hash"]
+
+
+def test_large_nested_package_does_not_expand_global_review_context(tmp_path):
+    root_config = copy.deepcopy(DEFAULTS)
+    nested_config = copy.deepcopy(DEFAULTS)
+    nested_config["complexity"] += 1
+    findings = [
+        {
+            "rule_id": "SKY-Q301",
+            "file": str(tmp_path / "package" / f"module_{index}.py"),
+            "line": 1,
+            "_analysis_worker_config": nested_config,
+        }
+        for index in range(2_100)
+    ]
+    result = {"quality": findings}
+
+    _attach_effective_review_config_hashes(result, root_config)
+    context = _context(tmp_path, config=root_config, enable_quality=True)
+
+    assert review_context_is_valid(context)
+    assert len(json.dumps(context)) < 10_000
+    assert all(
+        item.get("_analysis_config_hash", "").startswith("sha256:")
+        for item in findings
+    )
+    assert all("_analysis_worker_config" not in item for item in findings)
+
+
+def test_no_source_findings_receive_the_same_effective_review_context(tmp_path):
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text("FROM ubuntu:latest\n", encoding="utf-8")
+    finding = {
+        "rule_id": "SKY-D234",
+        "file": str(dockerfile),
+        "line": 1,
+        "severity": "HIGH",
+        "message": "container runs as root",
+    }
+    options = {
+        "enable_danger": True,
+        "include_review_context": True,
+        "grep_verify": False,
+        "exclude_folders": ["node_modules"],
+        "project_config_overrides": {
+            "security_contracts": [{"rule_id": "SKY-SC001"}],
+        },
+        "required_config_rules": ["SKY-GPU001"],
+    }
+
+    with patch("skylos.rules.config.scan_config_files", return_value=[finding]):
+        no_source = json.loads(analyze(str(tmp_path), **options))
+
+    (tmp_path / "app.py").write_text("print('ok')\n", encoding="utf-8")
+    with patch("skylos.rules.config.scan_config_files", return_value=[finding]):
+        with_source = json.loads(analyze(str(tmp_path), **options))
+
+    no_source_context = no_source["analysis_summary"]["review_context"]
+    with_source_context = with_source["analysis_summary"]["review_context"]
+    assert no_source["danger"]
+    assert review_context_is_valid(no_source_context)
+    assert no_source_context == with_source_context
+
+
+def test_no_source_security_secret_sca_and_ai_findings_all_get_context(
+    tmp_path,
+):
+    manifest = tmp_path / "package.json"
+    manifest.write_text('{"dependencies": {}}\n', encoding="utf-8")
+
+    class ScaFindings(list):
+        receipt = {"status": "complete", "complete": True}
+
+    with (
+        patch(
+            "skylos.rules.config.scan_config_files",
+            return_value=[
+                {
+                    "rule_id": "SKY-D234",
+                    "file": str(manifest),
+                    "line": 1,
+                    "severity": "HIGH",
+                    "message": "unsafe deployment config",
+                }
+            ],
+        ),
+        patch(
+            "skylos.analyzer._scan_secret_config_candidates",
+            return_value=[
+                {
+                    "rule_id": "SKY-S101",
+                    "file": str(manifest),
+                    "line": 1,
+                    "severity": "HIGH",
+                    "message": "secret",
+                }
+            ],
+        ),
+        patch(
+            "skylos.rules.ai_defect.manifest_dependency_hallucination.scan_manifest_dependency_hallucinations",
+            return_value=[
+                {
+                    "rule_id": "SKY-D222",
+                    "file": str(manifest),
+                    "line": 1,
+                    "severity": "MEDIUM",
+                    "message": "unknown package",
+                }
+            ],
+        ),
+        patch(
+            "skylos.rules.sca.vulnerability_scanner.scan_dependencies",
+            return_value=ScaFindings(
+                [
+                    {
+                        "rule_id": "SKY-SCA-001",
+                        "file": str(manifest),
+                        "line": 1,
+                        "severity": "HIGH",
+                        "message": "vulnerable package",
+                    }
+                ]
+            ),
+        ),
+    ):
+        result = json.loads(
+            analyze(
+                str(tmp_path),
+                enable_danger=True,
+                enable_secrets=True,
+                enable_sca=True,
+                enable_ai_defects=True,
+                include_review_context=True,
+                grep_verify=False,
+            )
+        )
+
+    assert result["danger"]
+    assert result["secrets"]
+    assert result["dependency_vulnerabilities"]
+    assert result["ai_defects"]
+    assert review_context_is_valid(result["analysis_summary"]["review_context"])
+
+
+def test_ordinary_scan_omits_review_context_and_transient_config_fields(tmp_path):
+    package = tmp_path / "package"
+    package.mkdir()
+    (package / "pyproject.toml").write_text(
+        "[tool.skylos]\ncomplexity = 1\n",
+        encoding="utf-8",
+    )
+    (package / "app.py").write_text(
+        "def branchy(value):\n"
+        "    if value:\n"
+        "        return 1\n"
+        "    return 0\n\n"
+        "print(branchy(True))\n",
+        encoding="utf-8",
+    )
+
+    result = json.loads(
+        analyze(
+            str(tmp_path),
+            conf=0,
+            enable_quality=True,
+            grep_verify=False,
+        )
+    )
+
+    assert "review_context" not in result["analysis_summary"]
+    serialized = json.dumps(result)
+    assert "_analysis_worker_config" not in serialized
+    assert "_analysis_config_hash" not in serialized
+
+
+def test_reviewed_dead_finding_matches_an_ordinary_cli_scan(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    source = repo / "app.py"
+    source.write_text("def orphan():\n    return 1\n", encoding="utf-8")
+    notes = repo / "notes.txt"
+    notes.write_text("initial\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "app.py", "notes.txt"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Skylos Test",
+            "-c",
+            "user.email=skylos-test@example.invalid",
+            "commit",
+            "-qm",
+            "fixture",
+        ],
+        check=True,
+    )
+    # Review enables diff-aware categories, so it auto-detects this unrelated
+    # worktree change. An ordinary dead-code scan does not; the dead-code
+    # identity must ignore that category-specific internal selection.
+    notes.write_text("changed\n", encoding="utf-8")
+    cloud_cache = tmp_path / "reviewed-findings"
+    local_cache = tmp_path / "local-review-decisions"
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "_cache_root",
+        lambda value=None: (
+            Path(value).expanduser() if value is not None else cloud_cache
+        ),
+    )
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "_local_cache_root",
+        lambda value=None: (
+            Path(value).expanduser() if value is not None else local_cache
+        ),
+    )
+    for key in (
+        "CI",
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_JOB",
+        "CI_PIPELINE_ID",
+        "BUILD_BUILDID",
+        "CIRCLE_WORKFLOW_ID",
+        "BUILD_TAG",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    def choose_dead(_console, findings, _input_fn):
+        return next(
+            finding
+            for finding in findings
+            if finding.get("_review_category") == "DEAD_CODE"
+            and finding.get("symbol") == "orphan"
+        )
+
+    monkeypatch.setattr(review_cmd, "_choose_finding", choose_dead)
+    answers = iter(["1", "unused test helper"])
+    review_exit = review_cmd.run_review_command(
+        [str(repo)],
+        input_fn=lambda _prompt: next(answers),
+        environ={},
+    )
+    assert review_exit == 0
+
+    capsys.readouterr()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["skylos", str(repo), "--json", "--no-provenance"],
+    )
+    cli.main()
+    result = json.loads(capsys.readouterr().out)
+
+    assert result["unused_functions"] == []
+    assert any(
+        finding.get("symbol") == "orphan"
+        for finding in result.get("reviewed_findings", [])
+    )
+
+
+def test_invalid_or_tampered_review_context_does_not_mint_identity(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text(
+        "def write_report(path):\n    open(path, 'w').write('ok')\n",
+        encoding="utf-8",
+    )
+    context = _context(tmp_path, enable_danger=True)
+    tampered = copy.deepcopy(context)
+    tampered["scope"]["targets"] = ["other"]
+
+    annotated = annotate_result_identities(
+        _synthetic_result(source, tampered),
+        tmp_path,
+    )
+
+    assert "stable_fingerprint" not in annotated["danger"][0]
+
+
+def test_malformed_effective_file_config_hash_does_not_mint_identity(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text(
+        "def write_report(path):\n    open(path, 'w').write('ok')\n",
+        encoding="utf-8",
+    )
+    result = _synthetic_result(source, _context(tmp_path, enable_danger=True))
+    result["danger"][0]["_analysis_config_hash"] = "not-a-sha256"
+
+    annotated = annotate_result_identities(result, tmp_path)
+
+    assert "stable_fingerprint" not in annotated["danger"][0]
+    assert "_analysis_config_hash" not in annotated["danger"][0]
+
+
+def test_severity_and_evidence_changes_resurface_with_same_context(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text(
+        "def write_report(path):\n    open(path, 'w').write('ok')\n",
+        encoding="utf-8",
+    )
+    context = _context(tmp_path, enable_danger=True)
+    baseline = annotate_result_identities(
+        _synthetic_result(source, context),
+        tmp_path,
+    )["danger"][0]
+    critical = annotate_result_identities(
+        _synthetic_result(source, context, severity="CRITICAL"),
+        tmp_path,
+    )["danger"][0]
+    verified_contract = copy.deepcopy(
+        _synthetic_result(source, context)["danger"][0]["evidence_contract"]
+    )
+    verified_contract["proof_state"] = "verified"
+    verified = annotate_result_identities(
+        _synthetic_result(source, context, evidence_contract=verified_contract),
+        tmp_path,
+    )["danger"][0]
+
+    assert baseline["context_hash"] != critical["context_hash"]
+    assert baseline["context_hash"] != verified["context_hash"]

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -218,7 +218,9 @@ class TestSkylos:
         result = skylos._module(root, file_path)
         assert result == "main"
 
-    def test_module_name_generation_strips_rightmost_source_root(self, skylos, tmp_path):
+    def test_module_name_generation_strips_rightmost_source_root(
+        self, skylos, tmp_path
+    ):
         # Path contains BOTH "python" and "src" source-root names. The old
         # implementation iterated a set and stripped whichever name came first,
         # producing module names that depended on PYTHONHASHSEED. The result
@@ -239,7 +241,8 @@ class TestSkylos:
         # #773) must strip the LAST occurrence deterministically.
         root = tmp_path
         file_path = (
-            root / "mcp-servers/src/data_analysis_server/src/data_analysis_server/visualization/plots.py"
+            root
+            / "mcp-servers/src/data_analysis_server/src/data_analysis_server/visualization/plots.py"
         )
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text("x = 1\n", encoding="utf-8")
@@ -4149,10 +4152,7 @@ def fake_call():
         monkeypatch.setenv("SKYLOS_JOBS", "1")
         src = tmp_path / "app.py"
         src.write_text(
-            "def read(length: int = ...) -> int:\n"
-            "    return length + 5\n"
-            "\n"
-            "read()\n",
+            "def read(length: int = ...) -> int:\n    return length + 5\n\nread()\n",
             encoding="utf-8",
         )
 
@@ -4194,12 +4194,8 @@ class SupportsRead(Protocol):
             analyze(str(tmp_path), conf=0, enable_quality=True, grep_verify=False)
         )
         assert result.get("analysis_errors", []) == []
-        l032 = [
-            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L032"
-        ]
-        l026 = [
-            f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L026"
-        ]
+        l032 = [f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L032"]
+        l026 = [f for f in result.get("quality", []) if f.get("rule_id") == "SKY-L026"]
         assert l032 == []
         assert l026 == []
 
@@ -4530,7 +4526,9 @@ def _issue_706_cache_findings(result):
 
 def _issue_706_init_ignored_cache_repo(root):
     subprocess.run(["git", "init", "-q"], cwd=root, check=True)
-    (root / ".gitignore").write_text(  # skylos: ignore[SKY-D324] all callers pass pytest-owned temp roots
+    (
+        root / ".gitignore"
+    ).write_text(  # skylos: ignore[SKY-D324] all callers pass pytest-owned temp roots
         ".skylos/\n", encoding="utf-8"
     )
 
@@ -4540,9 +4538,7 @@ def test_recursive_secret_scan_skips_untracked_generated_grep_cache(tmp_path):
     _issue_706_init_ignored_cache_repo(tmp_path)
     _issue_706_cache_file(tmp_path)
 
-    result = json.loads(
-        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
-    )
+    result = json.loads(analyze(str(tmp_path), enable_secrets=True, grep_verify=False))
 
     assert _issue_706_cache_findings(result) == []
 
@@ -4551,9 +4547,7 @@ def test_non_git_project_skips_its_generated_grep_cache(tmp_path):
     (tmp_path / "app.py").write_text("print('clean')\n", encoding="utf-8")
     _issue_706_cache_file(tmp_path)
 
-    result = json.loads(
-        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
-    )
+    result = json.loads(analyze(str(tmp_path), enable_secrets=True, grep_verify=False))
 
     assert _issue_706_cache_findings(result) == []
 
@@ -4583,8 +4577,7 @@ def test_grep_evidence_with_secret_is_not_persisted_in_project(tmp_path):
 
     assert list(cache_file.parent.glob(cache_file.name)) == []
     assert any(
-        finding.get("file") == "evidence.yaml"
-        and finding.get("provider") == "github"
+        finding.get("file") == "evidence.yaml" and finding.get("provider") == "github"
         for finding in first.get("secrets", [])
     )
     assert not any(
@@ -4621,9 +4614,7 @@ def test_recursive_secret_scan_keeps_tracked_grep_cache_visible(tmp_path):
         check=True,
     )
 
-    result = json.loads(
-        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
-    )
+    result = json.loads(analyze(str(tmp_path), enable_secrets=True, grep_verify=False))
 
     cache_findings = _issue_706_cache_findings(result)
     assert cache_findings
@@ -4644,9 +4635,7 @@ def test_nested_git_repo_uses_its_own_tracked_cache_state(tmp_path):
         check=True,
     )
 
-    result = json.loads(
-        analyze(str(nested), enable_secrets=True, grep_verify=False)
-    )
+    result = json.loads(analyze(str(nested), enable_secrets=True, grep_verify=False))
 
     assert _issue_706_cache_findings(result)
 
@@ -4658,9 +4647,7 @@ def test_generated_grep_cache_git_probe_failure_scans_fail_closed(
     _issue_706_cache_file(tmp_path)
     monkeypatch.setattr("skylos.analyzer._git_tracking_status", lambda _path: None)
 
-    result = json.loads(
-        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
-    )
+    result = json.loads(analyze(str(tmp_path), enable_secrets=True, grep_verify=False))
 
     assert _issue_706_cache_findings(result)
 
@@ -4681,8 +4668,7 @@ def test_explicit_generated_grep_cache_scan_is_not_suppressed(tmp_path, target_k
     )
 
     assert any(
-        finding.get("provider") == "github"
-        for finding in result.get("secrets", [])
+        finding.get("provider") == "github" for finding in result.get("secrets", [])
     )
 
 
@@ -4719,13 +4705,10 @@ def test_grep_cache_lookalike_paths_remain_scannable(tmp_path, relative_path):
         json.dumps({"token": github_token}), encoding="utf-8"
     )
 
-    result = json.loads(
-        analyze(str(tmp_path), enable_secrets=True, grep_verify=False)
-    )
+    result = json.loads(analyze(str(tmp_path), enable_secrets=True, grep_verify=False))
 
     assert any(
-        finding.get("file") == relative_path
-        and finding.get("provider") == "github"
+        finding.get("file") == relative_path and finding.get("provider") == "github"
         for finding in result.get("secrets", [])
     )
 
@@ -4748,13 +4731,15 @@ def test_generated_grep_cache_tracking_status_is_fail_closed(
         actual = _git_tracking_status(candidate)
 
     assert actual is expected
-    assert git_run.call_args.args[0] == [
-        "git",
+    command = git_run.call_args.args[0]
+    assert command[-4:] == [
         "ls-files",
         "--error-unmatch",
         "--",
         ".skylos/cache/grep_results.json",
     ]
+    assert "core.fsmonitor=false" in command
+    assert git_run.call_args.kwargs["env"]["GIT_CONFIG_NOSYSTEM"] == "1"
 
 
 def test_generated_grep_cache_tracking_timeout_is_unknown(tmp_path):
@@ -4767,6 +4752,30 @@ def test_generated_grep_cache_tracking_timeout_is_unknown(tmp_path):
         side_effect=subprocess.TimeoutExpired("git", 5),
     ):
         assert _git_tracking_status(candidate) is None
+
+
+def test_generated_grep_cache_tracking_probe_disables_fsmonitor(tmp_path):
+    from skylos.analyzer import _git_tracking_status
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    candidate = tmp_path / ".skylos" / "cache" / "grep_results.json"
+    candidate.parent.mkdir(parents=True)
+    candidate.write_text("{}", encoding="utf-8")
+    sentinel = tmp_path / "fsmonitor-ran"
+    helper = tmp_path / "fsmonitor-hook"
+    helper.write_text(
+        f"#!/bin/sh\ntouch '{sentinel}'\nexit 1\n",
+        encoding="utf-8",
+    )
+    helper.chmod(0o755)
+    subprocess.run(
+        ["git", "config", "core.fsmonitor", str(helper)],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    assert _git_tracking_status(candidate) is False
+    assert not sentinel.exists()
 
 
 _ISSUE_693_UV_LOCK = """\

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -13,6 +13,7 @@ from skylos.visitors.framework_aware import FrameworkAwareVisitor
 from skylos.analysis.penalties import _check_abstract_overrides, apply_penalties
 from skylos.deadcode.config_entrypoints import configured_entrypoint_reason
 from skylos.engines.go_runner import GoEngineError
+from skylos.core.safe_cache_io import write_text_no_symlink
 
 from skylos.analyzer import (
     Skylos,
@@ -4498,7 +4499,8 @@ def _issue_706_cache_file(root):
     github_token = "ghp_" + "1234567890abcdef" * 2 + "1234"
     cache_file = root / ".skylos" / "cache" / "grep_results.json"
     cache_file.parent.mkdir(parents=True)
-    cache_file.write_text(  # skylos: ignore[SKY-D324] all callers pass pytest-owned temp roots
+    assert write_text_no_symlink(
+        cache_file,
         json.dumps(
             {
                 "version": 1,
@@ -4511,7 +4513,6 @@ def _issue_706_cache_file(root):
                 },
             }
         ),
-        encoding="utf-8",
     )
     return cache_file
 
@@ -4526,11 +4527,7 @@ def _issue_706_cache_findings(result):
 
 def _issue_706_init_ignored_cache_repo(root):
     subprocess.run(["git", "init", "-q"], cwd=root, check=True)
-    (
-        root / ".gitignore"
-    ).write_text(  # skylos: ignore[SKY-D324] all callers pass pytest-owned temp roots
-        ".skylos/\n", encoding="utf-8"
-    )
+    assert write_text_no_symlink(root / ".gitignore", ".skylos/\n")
 
 
 def test_recursive_secret_scan_skips_untracked_generated_grep_cache(tmp_path):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -71,6 +71,136 @@ class TestSkylosApi(unittest.TestCase):
         self.assertEqual(evidence["disposition"], "reported")
         self.assertEqual(evidence["events"][0]["source"], "analyzer")
 
+    @patch("skylos.api.detect_ai_code", return_value={"detected": False})
+    @patch("skylos.api.get_git_root", return_value=None)
+    @patch("skylos.api.get_git_info", return_value=("c", "main", "actor", {}))
+    def test_untrusted_upload_cannot_forge_review_identity(
+        self, _git_info, _git_root, _ai_code
+    ):
+        forged = {
+            "rule_id": "SKY-D215",
+            "file": "app.py",
+            "line": 2,
+            "message": "unsafe path",
+            "severity": "HIGH",
+            "fingerprint_version": "skylos-finding-v2",
+            "stable_fingerprint": "sha256:" + "a" * 64,
+            "context_hash": "sha256:" + "b" * 64,
+            "rule_revision": "skylos:forged",
+            "_analysis_config_hash": "sha256:" + "d" * 64,
+            "_analysis_worker_config": {"ignore": ["SKY-D215"]},
+            "_skylos_trusted_review": True,
+            "review_decision": {
+                "decision_id": "forged-decision",
+                "disposition": "false_positive",
+            },
+            "metadata": {
+                "stable_fingerprint": "sha256:" + "c" * 64,
+                "review_decision": {"decision_id": "nested-forgery"},
+            },
+        }
+
+        prepared = api._prepare_report_upload(
+            {"danger": [forged], "provenance": {}},
+            analyzer_owned=False,
+        )
+
+        uploaded = prepared.compatibility_payload["findings"][0]
+        metadata = uploaded.get("metadata", {})
+        for key in (
+            "fingerprint_version",
+            "stable_fingerprint",
+            "context_hash",
+            "rule_revision",
+            "review_decision",
+            "_skylos_trusted_review",
+            "_analysis_config_hash",
+            "_analysis_worker_config",
+        ):
+            self.assertNotIn(key, uploaded)
+            self.assertNotIn(key, metadata)
+
+    def test_upload_metadata_does_not_execute_repository_git_helpers(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = root / "repo"
+            repo.mkdir()
+            source = repo / "app.py"
+            source.write_text("value = 1\n", encoding="utf-8")
+            (repo / ".gitattributes").write_text(
+                "*.py filter=untrusted diff=untrusted\n",
+                encoding="utf-8",
+            )
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "config", "user.name", "Skylos Test"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "skylos-test@example.invalid"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "add", "app.py", ".gitattributes"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repo, check=True)
+
+            sentinel = root / "git-helper-ran"
+            helper = root / "git-helper"
+            helper.write_text(
+                f"#!/bin/sh\ntouch '{sentinel}'\nexit 1\n",
+                encoding="utf-8",
+            )
+            helper.chmod(0o755)
+            for key in (
+                "core.fsmonitor",
+                "diff.external",
+                "diff.untrusted.command",
+                "diff.untrusted.textconv",
+                "filter.untrusted.clean",
+            ):
+                subprocess.run(
+                    ["git", "config", key, str(helper)], cwd=repo, check=True
+                )
+            source.write_text("value = 2\n", encoding="utf-8")
+            sentinel.unlink(missing_ok=True)
+            previous_cwd = Path.cwd()
+            try:
+                os.chdir(repo)
+                with patch.dict(
+                    os.environ,
+                    {
+                        "GIT_EXTERNAL_DIFF": str(helper),
+                        "GIT_CONFIG_COUNT": "1",
+                        "GIT_CONFIG_KEY_0": "diff.external",
+                        "GIT_CONFIG_VALUE_0": str(helper),
+                    },
+                ):
+                    prepared = api._prepare_report_upload(
+                        {
+                            "danger": [
+                                {
+                                    "rule_id": "SKY-D215",
+                                    "file": str(source),
+                                    "line": 1,
+                                    "message": "unsafe path",
+                                    "severity": "HIGH",
+                                }
+                            ],
+                            "provenance": {},
+                        },
+                        analyzer_owned=True,
+                    )
+            finally:
+                os.chdir(previous_cwd)
+
+            self.assertEqual(len(prepared.compatibility_payload["findings"]), 1)
+            self.assertFalse(sentinel.exists())
+
     def test_compact_upload_finding_preserves_npm_dependency_context(self):
         compact = api._compact_upload_finding(
             {
@@ -746,6 +876,51 @@ class TestSkylosApi(unittest.TestCase):
         f = all_findings[0]
         self.assertEqual(f["file_path"], "app.py")
         self.assertEqual(f["line_number"], 5)
+
+    @patch("skylos.api.SarifExporter")
+    @patch("skylos.api.get_project_token")
+    @patch("skylos.api.get_git_info", return_value=("c", "b", "actor", {}))
+    @patch("skylos.api.get_git_root", return_value="/mock/git/root")
+    @patch("requests.post")
+    def test_upload_keeps_locally_reviewed_security_findings(
+        self, mock_post, _root, _git, mock_token, mock_exporter
+    ):
+        mock_token.return_value = "token"
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"scanId": "scan_reviewed"}
+        mock_post.return_value = response
+        mock_exporter.return_value.generate.return_value = {"version": "2.1.0"}
+        decision = {
+            "decision_id": "decision-1",
+            "disposition": "false_positive",
+            "match_mode": "v2_exact_context",
+        }
+
+        result = upload_report(
+            {
+                "danger": [],
+                "reviewed_findings": [
+                    {
+                        "rule_id": "SKY-D215",
+                        "file": "/mock/git/root/app.py",
+                        "line": 5,
+                        "message": "unsafe path",
+                        "severity": "HIGH",
+                        "category": "SECURITY",
+                        "review_decision": decision,
+                        "_skylos_trusted_review": True,
+                    }
+                ],
+            },
+            quiet=True,
+            analyzer_owned=True,
+        )
+
+        self.assertTrue(result["success"])
+        all_findings = mock_exporter.call_args[0][0]
+        self.assertEqual(len(all_findings), 1)
+        self.assertEqual(all_findings[0]["rule_id"], "SKY-D215")
+        self.assertEqual(all_findings[0]["metadata"]["review_decision"], decision)
 
     @patch("skylos.api.SarifExporter")
     @patch("skylos.api.get_project_token")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -731,7 +731,14 @@ def test_precommit_snapshot_remaps_related_location_files(tmp_path):
                     }
                 ],
             }
-        ]
+        ],
+        "reviewed_findings": [
+            {
+                "file": str(source_root / "app" / "reviewed.py"),
+                "line": 7,
+                "category": "SECURITY",
+            }
+        ],
     }
 
     remapped = cli._remap_precommit_result_files(result, source_root, target_root)
@@ -740,6 +747,9 @@ def test_precommit_snapshot_remaps_related_location_files(tmp_path):
     assert finding["file"] == str((target_root / "app" / "main.py").resolve())
     assert finding["related_locations"][0]["file"] == str(
         (target_root / "deploy" / "rendered.yaml").resolve()
+    )
+    assert remapped["reviewed_findings"][0]["file"] == str(
+        (target_root / "app" / "reviewed.py").resolve()
     )
 
 

--- a/test/test_cli_precommit.py
+++ b/test/test_cli_precommit.py
@@ -1,10 +1,131 @@
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
 import skylos.cli as cli
+
+
+def test_agent_pre_commit_does_not_block_an_exact_reviewed_finding(
+    tmp_path, monkeypatch
+):
+    from skylos.analyzer import analyze
+    from skylos.constants import parse_exclude_folders
+    from skylos.core import review_decisions
+
+    cloud_cache = tmp_path / "cloud-review-cache"
+    local_cache = tmp_path / "local-review-cache"
+    monkeypatch.setattr(
+        review_decisions,
+        "_cache_root",
+        lambda value=None: Path(value) if value is not None else cloud_cache,
+    )
+    monkeypatch.setattr(
+        review_decisions,
+        "_local_cache_root",
+        lambda value=None: Path(value) if value is not None else local_cache,
+    )
+    for key in (
+        "CI",
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_JOB",
+        "CI_PIPELINE_ID",
+        "BUILD_BUILDID",
+        "CIRCLE_WORKFLOW_ID",
+        "BUILD_TAG",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    source = repo / "app.py"
+    source.write_text(
+        "def save_report():\n"
+        "    path = input('path: ')\n"
+        "    open(path, 'w').write('data')\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "-C", str(repo), "add", "app.py"], check=True)
+
+    excludes = list(parse_exclude_folders(use_defaults=True))
+    raw = analyze(
+        [str(source.resolve())],
+        conf=80,
+        enable_secrets=True,
+        enable_danger=True,
+        enable_quality=True,
+        enable_ai_defects=True,
+        exclude_folders=excludes,
+        changed_files={str(source.resolve())},
+        grep_verify=False,
+        include_review_context=True,
+    )
+    result = json.loads(raw) if isinstance(raw, str) else raw
+    findings = review_decisions.annotate_result_identities(result, repo)["danger"]
+    assert {finding["rule_id"] for finding in findings} == {"SKY-D215", "SKY-D324"}
+    for index, finding in enumerate(findings, 1):
+        review_decisions.record_local_decision(
+            repo,
+            {
+                "decision_id": f"precommit-reviewed-{index}",
+                "fingerprint_version": finding["fingerprint_version"],
+                "stable_fingerprint": finding["stable_fingerprint"],
+                "context_hash": finding["context_hash"],
+                "rule_revision": finding["rule_revision"],
+                "rule_id": finding["rule_id"],
+                "file_path": finding["file_path"],
+                "line_number": finding["line"],
+                "disposition": "false_positive",
+                "reason": "validated path handling is intentional",
+                "created_at": "2026-09-12T00:00:00Z",
+                "language": finding["language"],
+                "symbol": finding["symbol"],
+                "section": finding["section"],
+                "category": "SECURITY",
+            },
+        )
+
+    # Leave the reviewed unsafe bytes in the index, then diverge the worktree.
+    # The command must build identities from its checkout-index snapshot rather
+    # than the safe worktree file.
+    source.write_text(
+        "def save_report():\n"
+        "    path = 'report.txt'\n"
+        "    open(path, 'w').write('data')\n",
+        encoding="utf-8",
+    )
+
+    real_run_analyze = cli.run_analyze
+    analyze_calls = []
+
+    def capture_analyze(*args, **kwargs):
+        analyze_calls.append(dict(kwargs))
+        return real_run_analyze(*args, **kwargs)
+
+    console = Mock()
+    monkeypatch.setattr(cli, "run_analyze", capture_analyze)
+    with (
+        patch("sys.argv", ["skylos", "agent", "pre-commit", str(repo)]),
+        patch("skylos.cli.Console", return_value=console),
+        patch("skylos.cli.setup_logger"),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 0
+    assert len(analyze_calls) == 1
+    assert "include_review_proofs" not in analyze_calls[0]
+    rendered = " ".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "SKY-D215" not in rendered
+    assert "SKY-D324" not in rendered
+    assert "No staged security" in rendered
+    assert "Using staged git snapshot for exact commit results" in rendered
 
 
 def test_agent_pre_commit_scans_only_staged_source_files(tmp_path):
@@ -173,6 +294,8 @@ def test_agent_pre_commit_reports_ai_defects(tmp_path):
 
 
 def test_agent_pre_commit_includes_staged_config_files(tmp_path):
+    from skylos.core.review_context import review_context_is_valid
+
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / ".env").write_text("SAFE_VALUE=1\n", encoding="utf-8")
@@ -185,6 +308,7 @@ def test_agent_pre_commit_includes_staged_config_files(tmp_path):
     )
     staged_blob = Mock(stdout="API_KEY=test\n", returncode=0)
     seen_ctx = {}
+    seen_review_context = {}
 
     def fake_scan_ctx(ctx, **kwargs):
         seen_ctx["lines"] = list(ctx["lines"])
@@ -195,9 +319,15 @@ def test_agent_pre_commit_includes_staged_config_files(tmp_path):
             return staged
         if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
             return cached_diff
+        if cmd == ["git", "status", "--porcelain", "--untracked-files=all"]:
+            return Mock(stdout="", returncode=0)
         if cmd == ["git", "show", ":.env"]:
             return staged_blob
         raise AssertionError(f"Unexpected command: {cmd}")
+
+    def capture_review_decisions(result, *args, **kwargs):
+        seen_review_context.update(result["analysis_summary"]["review_context"])
+        return result
 
     with (
         patch("sys.argv", ["skylos", "agent", "pre-commit", str(repo)]),
@@ -210,6 +340,14 @@ def test_agent_pre_commit_includes_staged_config_files(tmp_path):
         patch("skylos.cli.run_analyze") as mock_analyze,
         patch("skylos.rules.secrets.scan_ctx", side_effect=fake_scan_ctx),
         patch("skylos.core.baseline.load_baseline", return_value=None),
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(True, False),
+        ),
+        patch(
+            "skylos.core.review_decisions.apply_trusted_review_decisions",
+            side_effect=capture_review_decisions,
+        ),
     ):
         with pytest.raises(SystemExit) as exc_info:
             cli.main()
@@ -217,6 +355,9 @@ def test_agent_pre_commit_includes_staged_config_files(tmp_path):
     assert exc_info.value.code == 0
     mock_analyze.assert_not_called()
     assert "".join(seen_ctx["lines"]) == "API_KEY=test\n"
+    assert review_context_is_valid(seen_review_context)
+    assert seen_review_context["scope"]["kind"] == "precommit_staged_manual"
+    assert seen_review_context["options"]["enabled_categories"] == ["secrets"]
 
     printed = " ".join(
         str(call.args[0]) for call in console.print.call_args_list if call.args
@@ -228,6 +369,169 @@ def test_agent_pre_commit_includes_staged_config_files(tmp_path):
         "No staged security, reliability, secrets, quality, or AI-defect issues"
         in printed
     )
+
+
+@pytest.mark.parametrize(
+    ("status_stdout", "status_returncode"),
+    [(" M .env\n", 0), ("", 1)],
+)
+def test_agent_pre_commit_manual_review_context_fails_open_without_staged_snapshot(
+    tmp_path, status_stdout, status_returncode
+):
+    from skylos.core.review_context import review_context_is_valid
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".env").write_text("WORKTREE_VALUE=1\n", encoding="utf-8")
+
+    console = Mock()
+    staged = Mock(stdout=".env\n", returncode=0)
+    cached_diff = Mock(
+        stdout="diff --git a/.env b/.env\n--- a/.env\n+++ b/.env\n@@ -1 +1 @@\n",
+        returncode=0,
+    )
+    dirty_status = Mock(stdout=status_stdout, returncode=status_returncode)
+    staged_blob = Mock(stdout="API_KEY=staged\n", returncode=0)
+    failed_checkout = Mock(stdout="", stderr="checkout failed", returncode=1)
+    seen_review_context = {}
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "diff", "--cached", "--name-only"]:
+            return staged
+        if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
+            return cached_diff
+        if cmd == ["git", "status", "--porcelain", "--untracked-files=all"]:
+            return dirty_status
+        if cmd[:4] == ["git", "checkout-index", "--all", "--force"]:
+            return failed_checkout
+        if cmd == ["git", "show", ":.env"]:
+            return staged_blob
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    def capture_review_decisions(result, *args, **kwargs):
+        seen_review_context.update(result["analysis_summary"]["review_context"])
+        return result
+
+    with (
+        patch("sys.argv", ["skylos", "agent", "pre-commit", str(repo)]),
+        patch("skylos.cli.Console", return_value=console),
+        patch("skylos.cli.setup_logger"),
+        patch("skylos.cli.find_project_root", return_value=repo),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.parse_exclude_folders", return_value=set()),
+        patch("skylos.cli.subprocess.run", side_effect=fake_run),
+        patch("skylos.rules.secrets.scan_ctx", return_value=[]),
+        patch("skylos.core.baseline.load_baseline", return_value=None),
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(True, False),
+        ),
+        patch(
+            "skylos.core.review_decisions.apply_trusted_review_decisions",
+            side_effect=capture_review_decisions,
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 0
+    assert not review_context_is_valid(seen_review_context)
+    assert seen_review_context["complete"] is False
+    printed = " ".join(
+        str(call.args[0]) for call in console.print.call_args_list if call.args
+    )
+    assert "Exact staged snapshot unavailable" in printed
+
+
+def test_agent_pre_commit_static_review_context_fails_open_without_staged_snapshot(
+    tmp_path,
+):
+    from skylos.core.review_context import (
+        REVIEW_CONTEXT_SCHEMA,
+        review_context_is_valid,
+    )
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text("print('worktree')\n", encoding="utf-8")
+
+    console = Mock()
+    staged = Mock(stdout="app.py\n", returncode=0)
+    cached_diff = Mock(
+        stdout=(
+            "diff --git a/app.py b/app.py\n--- a/app.py\n+++ b/app.py\n@@ -1 +1 @@\n"
+        ),
+        returncode=0,
+    )
+    dirty_status = Mock(stdout=" M app.py\n", returncode=0)
+    failed_checkout = Mock(stdout="", stderr="checkout failed", returncode=1)
+    result = {
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_classes": [],
+        "unused_variables": [],
+        "unused_parameters": [],
+        "unused_files": [],
+        "danger": [],
+        "quality": [],
+        "ai_defects": [],
+        "secrets": [],
+        "custom_rules": [],
+        "analysis_summary": {
+            "review_context": {
+                "schema": "skylos.analysis-review-context.v1",
+                "complete": True,
+                "context_hash": "worktree-context-that-must-not-be-trusted",
+            }
+        },
+    }
+    seen_review_context = {}
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "diff", "--cached", "--name-only"]:
+            return staged
+        if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
+            return cached_diff
+        if cmd == ["git", "status", "--porcelain", "--untracked-files=all"]:
+            return dirty_status
+        if cmd[:4] == ["git", "checkout-index", "--all", "--force"]:
+            return failed_checkout
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    def capture_review_decisions(scan_result, *args, **kwargs):
+        seen_review_context.update(scan_result["analysis_summary"]["review_context"])
+        return scan_result
+
+    with (
+        patch("sys.argv", ["skylos", "agent", "pre-commit", str(repo)]),
+        patch("skylos.cli.Console", return_value=console),
+        patch("skylos.cli.setup_logger"),
+        patch("skylos.cli.find_project_root", return_value=repo),
+        patch("skylos.cli.load_config", return_value={}),
+        patch("skylos.cli.parse_exclude_folders", return_value=set()),
+        patch("skylos.cli.subprocess.run", side_effect=fake_run),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)) as scan,
+        patch("skylos.core.baseline.load_baseline", return_value=None),
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(True, False),
+        ),
+        patch(
+            "skylos.core.review_decisions.apply_trusted_review_decisions",
+            side_effect=capture_review_decisions,
+        ),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+
+    assert exc_info.value.code == 0
+    scan.assert_called_once()
+    assert not review_context_is_valid(seen_review_context)
+    assert seen_review_context == {
+        "schema": REVIEW_CONTEXT_SCHEMA,
+        "complete": False,
+    }
 
 
 def test_agent_pre_commit_scans_staged_cross_layer_manifest(tmp_path):
@@ -515,6 +819,8 @@ def test_agent_pre_commit_scans_staged_test_files_for_secrets_only(tmp_path):
             return staged
         if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
             return cached_diff
+        if cmd == ["git", "status", "--porcelain", "--untracked-files=all"]:
+            return Mock(stdout="", returncode=0)
         if cmd == ["git", "show", ":test/test_rules.py"]:
             return staged_blob
         raise AssertionError(f"Unexpected command: {cmd}")
@@ -581,6 +887,8 @@ def test_agent_pre_commit_scans_staged_benchmark_files_for_secrets_only(tmp_path
             return staged
         if cmd[:4] == ["git", "diff", "--cached", "--unified=0"]:
             return cached_diff
+        if cmd == ["git", "status", "--porcelain", "--untracked-files=all"]:
+            return Mock(stdout="", returncode=0)
         if cmd == ["git", "show", ":benchmarks/agent_review/fixtures/demo/app.py"]:
             return staged_blob
         raise AssertionError(f"Unexpected command: {cmd}")

--- a/test/test_cli_refactor_guardrails.py
+++ b/test/test_cli_refactor_guardrails.py
@@ -608,6 +608,10 @@ def test_cli_guardrail_baseline_subcommand_writes_baseline(tmp_path, monkeypatch
             "skylos.commands.baseline_cmd.save_baseline",
             return_value=baseline_path,
         ) as mock_save,
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(False, False),
+        ),
         patch("skylos.commands.baseline_cmd.Console", return_value=console),
         pytest.raises(SystemExit) as exc,
     ):
@@ -620,6 +624,7 @@ def test_cli_guardrail_baseline_subcommand_writes_baseline(tmp_path, monkeypatch
         enable_quality=True,
         enable_secrets=True,
         enable_ai_defects=True,
+        exclude_folders=sorted(cli.DEFAULT_EXCLUDE_FOLDERS),
     )
     mock_save.assert_called_once()
 
@@ -644,6 +649,15 @@ def test_baseline_command_defaults_to_current_directory():
             "skylos.commands.baseline_cmd.save_baseline",
             return_value=Path(".skylos/baseline.json"),
         ),
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(False, False),
+        ),
+        patch("skylos.commands.baseline_cmd.load_config", return_value={}),
+        patch(
+            "skylos.commands.baseline_cmd.resolve_config_file_path",
+            return_value=None,
+        ),
         patch("skylos.commands.baseline_cmd.Console", return_value=Mock()),
     ):
         from skylos.commands.baseline_cmd import run_baseline_command
@@ -657,6 +671,7 @@ def test_baseline_command_defaults_to_current_directory():
         enable_quality=True,
         enable_secrets=True,
         enable_ai_defects=True,
+        exclude_folders=sorted(cli.DEFAULT_EXCLUDE_FOLDERS),
     )
 
 

--- a/test/test_cli_uncovered_paths.py
+++ b/test/test_cli_uncovered_paths.py
@@ -897,6 +897,86 @@ def test_main_gate_uploads_when_upload_flag_is_set(monkeypatch):
     gate.assert_called_once()
 
 
+def test_main_gate_honors_cloud_rejection_before_local_projection(monkeypatch):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "quality": [],
+        "secrets": [],
+    }
+    monkeypatch.setattr(cli.sys, "argv", ["skylos", ".", "--gate", "--upload"])
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={"gate": {}}),
+        patch(
+            "skylos.cli.upload_report",
+            return_value={"success": True, "quality_gate_passed": False},
+        ),
+        patch("skylos.cli.run_gate_interaction", return_value=0) as local_gate,
+        patch("builtins.print"),
+    ):
+        with pytest.raises(SystemExit) as error:
+            cli.main()
+
+    assert error.value.code == 1
+    local_gate.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "output_args",
+    (["--format", "concise"], ["--llm"], ["--github"]),
+    ids=("concise", "llm", "github"),
+)
+def test_formatted_upload_modes_honor_cloud_gate_rejection(monkeypatch, output_args):
+    result = {
+        "analysis_summary": {"total_files": 1},
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_variables": [],
+        "unused_classes": [],
+        "unused_parameters": [],
+        "danger": [],
+        "quality": [],
+        "secrets": [],
+    }
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        ["skylos", ".", *output_args, "--gate", "--upload", "--no-provenance"],
+    )
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+
+    with (
+        patch("skylos.cli.setup_logger", return_value=fake_logger),
+        patch("skylos.cli.Progress", return_value=_progress_ctx()),
+        patch("skylos.cli.run_analyze", return_value=json.dumps(result)),
+        patch("skylos.cli.load_config", return_value={"gate": {}}),
+        patch(
+            "skylos.cli.upload_report",
+            return_value={"success": True, "quality_gate_passed": False},
+        ) as upload,
+        patch("skylos.cli.run_gate_interaction", return_value=0) as local_gate,
+        patch("builtins.print"),
+    ):
+        with pytest.raises(SystemExit) as error:
+            cli.main()
+
+    assert error.value.code == 1
+    upload.assert_called_once()
+    local_gate.assert_not_called()
+
+
 def test_main_interactive_dry_run_does_not_modify(monkeypatch):
     result = {
         "analysis_summary": {"total_files": 1},

--- a/test/test_command_review_memory.py
+++ b/test/test_command_review_memory.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import skylos
+import skylos.cli as cli
+from skylos.commands import baseline_cmd, cicd_cmd, scan_cmd
+from skylos.constants import DEFAULT_EXCLUDE_FOLDERS
+from skylos.core import baseline as baseline_store
+from skylos.core import review_decisions
+
+
+def _scan_result(project_root: Path) -> dict:
+    return {
+        "project_root": str(project_root),
+        "analysis_summary": {"total_files": 1, "danger_count": 2},
+        "danger": [
+            {
+                "rule_id": "SKY-D201",
+                "file": str(project_root / "reviewed.py"),
+                "line": 4,
+                "severity": "HIGH",
+            },
+            {
+                "rule_id": "SKY-D211",
+                "file": str(project_root / "baseline.py"),
+                "line": 8,
+                "severity": "HIGH",
+            },
+        ],
+        "reliability": [],
+        "ai_defects": [],
+        "quality": [],
+        "secrets": [],
+        "unused_functions": [],
+        "unused_imports": [],
+        "unused_classes": [],
+        "unused_variables": [],
+        "unused_parameters": [],
+    }
+
+
+def _project_first_finding(result: dict) -> dict:
+    projected = deepcopy(result)
+    reviewed = dict(projected["danger"].pop(0))
+    reviewed["category"] = "SECURITY"
+    reviewed["review_decision"] = {"decision_id": "decision-1"}
+    reviewed["_skylos_trusted_review"] = True
+    projected["reviewed_findings"] = [reviewed]
+    projected["reviewed_findings_summary"] = {
+        "suppressed_count": 1,
+        "active_decision_count": 1,
+        "ambiguous_match_count": 0,
+    }
+    projected["analysis_summary"]["danger_count"] = 1
+    projected["analysis_summary"]["reviewed_findings"] = dict(
+        projected["reviewed_findings_summary"]
+    )
+    return projected
+
+
+def test_baseline_projects_reviews_before_save_with_effective_scan_context(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "repo"
+    project.mkdir()
+    raw = _scan_result(project)
+    projected = _project_first_finding(raw)
+    events: list[str] = []
+    analyze_call = {}
+    saved = {}
+
+    def fake_analyze(path, **kwargs):
+        events.append("analyze")
+        analyze_call.update({"path": path, "kwargs": kwargs})
+        return json.dumps(raw)
+
+    def fake_apply(result, project_root, **kwargs):
+        events.append("project")
+        assert result == raw
+        assert project_root == project.resolve()
+        assert kwargs == {}
+        return projected
+
+    def fake_save(path, result):
+        events.append("save")
+        saved.update({"path": path, "result": result})
+        return project / ".skylos" / "baseline.json"
+
+    monkeypatch.setattr(baseline_cmd, "run_analyze", fake_analyze)
+    monkeypatch.setattr(baseline_cmd, "save_baseline", fake_save)
+    monkeypatch.setattr(baseline_cmd, "Console", Mock)
+    monkeypatch.setattr(
+        baseline_cmd,
+        "load_config",
+        lambda root, config_file=None: {"exclude": ["generated"]},
+    )
+    monkeypatch.setattr(baseline_cmd, "resolve_config_file_path", lambda: None)
+    monkeypatch.setattr(
+        review_decisions, "review_scan_requirements", lambda root: (True, True)
+    )
+    monkeypatch.setattr(review_decisions, "apply_trusted_review_decisions", fake_apply)
+
+    assert baseline_cmd.run_baseline_command([str(project)]) == 0
+
+    assert events == ["analyze", "project", "save"]
+    assert analyze_call["path"] == str(project)
+    kwargs = analyze_call["kwargs"]
+    assert kwargs["include_review_context"] is True
+    assert kwargs["include_review_proofs"] is True
+    assert kwargs["enable_danger"] is True
+    assert kwargs["enable_quality"] is True
+    assert kwargs["enable_secrets"] is True
+    assert kwargs["enable_ai_defects"] is True
+    assert set(kwargs["exclude_folders"]) == DEFAULT_EXCLUDE_FOLDERS | {"generated"}
+    assert saved == {"path": str(project), "result": projected}
+    assert saved["result"]["danger"] == [raw["danger"][1]]
+
+
+def test_baseline_avoids_review_analysis_overhead_without_active_v2_state(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "repo"
+    project.mkdir()
+    captured = {}
+
+    def fake_analyze(path, **kwargs):
+        captured.update(kwargs)
+        return json.dumps(_scan_result(project))
+
+    monkeypatch.setattr(baseline_cmd, "run_analyze", fake_analyze)
+    monkeypatch.setattr(baseline_cmd, "save_baseline", lambda path, result: project)
+    monkeypatch.setattr(baseline_cmd, "Console", Mock)
+    monkeypatch.setattr(baseline_cmd, "load_config", lambda root, config_file=None: {})
+    monkeypatch.setattr(baseline_cmd, "resolve_config_file_path", lambda: None)
+    monkeypatch.setattr(
+        review_decisions, "review_scan_requirements", lambda root: (False, False)
+    )
+    monkeypatch.setattr(
+        review_decisions,
+        "apply_trusted_review_decisions",
+        lambda result, root: result,
+    )
+
+    assert baseline_cmd.run_baseline_command([str(project)]) == 0
+    assert "include_review_context" not in captured
+    assert "include_review_proofs" not in captured
+
+
+def test_cicd_direct_scan_projects_reviews_before_gate(tmp_path, monkeypatch):
+    project = tmp_path / "repo"
+    project.mkdir()
+    raw = _scan_result(project)
+    projected = _project_first_finding(raw)
+    events: list[str] = []
+    analyze_call = {}
+
+    def fake_analyze(path, **kwargs):
+        events.append("analyze")
+        analyze_call.update({"path": path, "kwargs": kwargs})
+        return json.dumps(raw)
+
+    def fake_apply(result, project_root, **kwargs):
+        events.append("project")
+        assert result == raw
+        assert project_root == project.resolve()
+        assert kwargs == {}
+        return projected
+
+    def fake_gate(**kwargs):
+        events.append("gate")
+        assert kwargs["result"] == projected
+        return 0
+
+    monkeypatch.setattr(skylos, "analyze", fake_analyze)
+    monkeypatch.setattr(
+        review_decisions, "review_scan_requirements", lambda root: (True, True)
+    )
+    monkeypatch.setattr(review_decisions, "apply_trusted_review_decisions", fake_apply)
+    monkeypatch.setattr(
+        cicd_cmd, "resolve_config_file_path", lambda: None, raising=False
+    )
+
+    def load_config(_root):
+        return {"exclude": ["generated"], "gate": {}}
+
+    exit_code = cicd_cmd.run_cicd_command(
+        ["gate", str(project)],
+        console_factory=Mock,
+        load_config_func=load_config,
+        run_gate_interaction_func=fake_gate,
+        emit_github_annotations_func=Mock(),
+    )
+
+    assert exit_code == 0
+    assert events == ["analyze", "project", "gate"]
+    kwargs = analyze_call["kwargs"]
+    assert kwargs["include_review_context"] is True
+    assert kwargs["include_review_proofs"] is True
+    assert set(kwargs["exclude_folders"]) == DEFAULT_EXCLUDE_FOLDERS | {"generated"}
+
+
+def test_cicd_direct_scan_is_lazy_and_input_reports_remain_raw(tmp_path, monkeypatch):
+    project = tmp_path / "repo"
+    project.mkdir()
+    raw = _scan_result(project)
+    projected = _project_first_finding(raw)
+    analyze_kwargs = {}
+    apply_mock = Mock(side_effect=lambda result, root: result)
+    requirement_mock = Mock(return_value=(False, False))
+
+    def fake_analyze(path, **kwargs):
+        analyze_kwargs.update(kwargs)
+        return json.dumps(raw)
+
+    monkeypatch.setattr(skylos, "analyze", fake_analyze)
+    monkeypatch.setattr(review_decisions, "review_scan_requirements", requirement_mock)
+    monkeypatch.setattr(review_decisions, "apply_trusted_review_decisions", apply_mock)
+
+    args = SimpleNamespace(input_file=None, path=str(project), diff_base=None)
+    direct, exit_code = cicd_cmd._cicd_load_results(
+        args,
+        console_factory=Mock,
+        load_config_func=lambda root: {},
+    )
+
+    assert exit_code == 0
+    assert direct == raw
+    assert "include_review_context" not in analyze_kwargs
+    assert "include_review_proofs" not in analyze_kwargs
+    requirement_mock.assert_called_once_with(project.resolve())
+    apply_mock.assert_called_once()
+
+    report = project / "results.json"
+    report.write_text(json.dumps(projected), encoding="utf-8")
+    apply_mock.reset_mock()
+    requirement_mock.reset_mock()
+
+    imported, exit_code = cicd_cmd._cicd_load_results(
+        SimpleNamespace(input_file=str(report)),
+        console_factory=Mock,
+        load_config_func=lambda root: {},
+    )
+
+    assert exit_code == 0
+    assert imported == projected
+    requirement_mock.assert_not_called()
+    apply_mock.assert_not_called()
+
+
+def test_main_scan_projects_before_baseline_and_keeps_review_audit_for_upload(
+    tmp_path, monkeypatch
+):
+    project = tmp_path / "repo"
+    project.mkdir()
+    raw = _scan_result(project)
+    projected = _project_first_finding(raw)
+    baseline = {
+        "fingerprints": [
+            f"SKY-D211:{raw['danger'][1]['file']}:{raw['danger'][1]['line']}"
+        ]
+    }
+    events: list[str] = []
+    uploaded = {}
+    filter_new_findings = baseline_store.filter_new_findings
+
+    def fake_apply(result, project_root, **kwargs):
+        events.append("project")
+        assert result == {**raw, "provenance": None}
+        assert project_root == project.resolve()
+        assert kwargs == {"include_identities": True}
+        return projected
+
+    def filter_after_projection(result, saved_baseline):
+        events.append("baseline")
+        assert result["reviewed_findings"] == projected["reviewed_findings"]
+        assert saved_baseline == baseline
+        return filter_new_findings(result, saved_baseline)
+
+    def fake_upload(result, **kwargs):
+        events.append("upload")
+        uploaded.update(deepcopy(result))
+        return {"success": True, "quality_gate_passed": True}
+
+    fake_logger = Mock()
+    fake_logger.console = Mock()
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(cli, "setup_logger", lambda: fake_logger)
+    monkeypatch.setattr(cli, "run_analyze", lambda *args, **kwargs: json.dumps(raw))
+    monkeypatch.setattr(cli, "load_config", lambda *args, **kwargs: {})
+    monkeypatch.setattr(cli, "upload_report", fake_upload)
+    monkeypatch.setattr(
+        review_decisions, "review_scan_requirements", lambda root: (False, False)
+    )
+    monkeypatch.setattr(review_decisions, "apply_trusted_review_decisions", fake_apply)
+    monkeypatch.setattr(baseline_store, "load_baseline", lambda root: baseline)
+    monkeypatch.setattr(baseline_store, "filter_new_findings", filter_after_projection)
+    monkeypatch.setattr("builtins.print", Mock())
+
+    scan_cmd.run_scan_command(
+        [
+            str(project),
+            "--format",
+            "json",
+            "--baseline",
+            "--upload",
+            "--no-provenance",
+        ],
+        cli_module=cli,
+    )
+
+    assert events == ["project", "baseline", "upload"]
+    assert uploaded["danger"] == []
+    assert uploaded["reviewed_findings"] == projected["reviewed_findings"]
+    assert uploaded["reviewed_findings_summary"]["suppressed_count"] == 1

--- a/test/test_debt.py
+++ b/test/test_debt.py
@@ -1,11 +1,15 @@
 import json
 import os
+import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
 import skylos.cli as cli
+import skylos.core.review_decisions as review_decisions
+import skylos.debt.engine as debt_engine
 from skylos.debt.advisor import (
     DebtAdvisor,
     _parse_json_object,
@@ -264,6 +268,150 @@ def test_run_debt_analysis_builds_snapshot():
         "quality",
         "dead_code",
     ]
+
+
+@pytest.mark.parametrize(
+    ("requirements", "expected_context", "expected_proofs"),
+    [
+        ((False, False), False, False),
+        ((True, False), True, False),
+        ((True, True), True, True),
+    ],
+)
+def test_run_debt_analysis_requests_review_evidence_only_when_needed(
+    tmp_path,
+    monkeypatch,
+    requirements,
+    expected_context,
+    expected_proofs,
+):
+    captured = []
+
+    def fake_analyze(*args, **kwargs):
+        captured.append((args, kwargs))
+        return json.dumps(SAMPLE_RESULT)
+
+    monkeypatch.setattr(debt_engine, "run_analyze", fake_analyze)
+    monkeypatch.setattr(
+        review_decisions,
+        "review_scan_requirements",
+        lambda project_root: requirements,
+    )
+    monkeypatch.setattr(
+        review_decisions,
+        "apply_trusted_review_decisions",
+        lambda result, project_root: result,
+    )
+
+    run_debt_analysis(tmp_path)
+
+    assert len(captured) == 1
+    options = captured[0][1]
+    assert ("include_review_context" in options) is expected_context
+    assert ("include_review_proofs" in options) is expected_proofs
+
+
+def test_run_debt_analysis_excludes_a_reviewed_quality_finding(tmp_path, monkeypatch):
+    from skylos.analyzer import analyze as real_analyze
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    (repo / "pyproject.toml").write_text(
+        "[tool.skylos]\ncomplexity = 1\n",
+        encoding="utf-8",
+    )
+    source = repo / "app.py"
+    source.write_text(
+        "def choose(value):\n"
+        "    if value == 1:\n"
+        "        return 'one'\n"
+        "    if value == 2:\n"
+        "        return 'two'\n"
+        "    return 'other'\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+
+    cloud_cache = tmp_path / "cloud-review-cache"
+    local_cache = tmp_path / "local-review-cache"
+    local_cache.mkdir()
+    local_cache = local_cache.resolve()
+    monkeypatch.setattr(
+        review_decisions,
+        "_cache_root",
+        lambda value=None: Path(value) if value is not None else cloud_cache,
+    )
+    monkeypatch.setattr(
+        review_decisions,
+        "_local_cache_root",
+        lambda value=None: Path(value) if value is not None else local_cache,
+    )
+    for key in (
+        "CI",
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_JOB",
+        "CI_PIPELINE_ID",
+        "BUILD_BUILDID",
+        "CIRCLE_WORKFLOW_ID",
+        "BUILD_TAG",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    authored = json.loads(
+        real_analyze(
+            str(repo),
+            conf=80,
+            enable_quality=True,
+            enable_danger=False,
+            enable_secrets=False,
+            exclude_folders=[],
+            include_review_context=True,
+        )
+    )
+    annotated = review_decisions.annotate_result_identities(authored, repo)
+    finding = next(
+        item for item in annotated["quality"] if item["rule_id"] == "SKY-Q301"
+    )
+    review_decisions.record_local_decision(
+        repo,
+        {
+            "decision_id": "reviewed-quality-debt",
+            "fingerprint_version": finding["fingerprint_version"],
+            "stable_fingerprint": finding["stable_fingerprint"],
+            "context_hash": finding["context_hash"],
+            "rule_revision": finding["rule_revision"],
+            "rule_id": finding["rule_id"],
+            "file_path": finding["file_path"],
+            "line_number": finding["line"],
+            "disposition": "false_positive",
+            "reason": "known generated branch table",
+            "created_at": "2026-01-01T00:00:00Z",
+            "language": finding["language"],
+            "symbol": finding["symbol"],
+            "section": finding["section"],
+            "category": "QUALITY",
+        },
+    )
+
+    analyze_calls = []
+
+    def capture_analyze(*args, **kwargs):
+        analyze_calls.append(dict(kwargs))
+        return real_analyze(*args, **kwargs)
+
+    monkeypatch.setattr(debt_engine, "run_analyze", capture_analyze)
+    snapshot = run_debt_analysis(repo, exclude_folders=[])
+
+    rule_ids = {
+        signal.rule_id
+        for hotspot in snapshot.all_hotspots
+        for signal in hotspot.signals
+    }
+    assert "SKY-Q301" not in rule_ids
+    assert analyze_calls[0]["include_review_context"] is True
+    assert "include_review_proofs" not in analyze_calls[0]
 
 
 def test_run_debt_analysis_changed_mode_keeps_project_score_and_filters_hotspots():
@@ -1552,9 +1700,7 @@ def test_cli_debt_show_history_json_outputs_saved_entries(tmp_path, monkeypatch)
     assert payload["history"][0]["score"]["score_pct"] == 93
 
 
-def test_cli_debt_show_history_json_rejects_symlink_history(
-    tmp_path, monkeypatch
-):
+def test_cli_debt_show_history_json_rejects_symlink_history(tmp_path, monkeypatch):
     history_dir = tmp_path / ".skylos"
     history_dir.mkdir()
     outside = tmp_path / "outside.jsonl"

--- a/test/test_file_discovery.py
+++ b/test/test_file_discovery.py
@@ -67,3 +67,27 @@ def test_discover_source_files_skips_git_visible_symlinked_target_outside_root(
     files = discover_source_files(repo, [".py"])
 
     assert files == []
+
+
+def test_git_inventory_disables_repository_fsmonitor_hook(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text("print('safe')\n", encoding="utf-8")
+    sentinel = tmp_path / "fsmonitor-ran"
+    hook = tmp_path / "fsmonitor-hook"
+    hook.write_text(
+        f"#!/bin/sh\ntouch '{sentinel}'\nprintf '0\\n'\n",
+        encoding="utf-8",
+    )
+    hook.chmod(0o755)
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "core.fsmonitor", str(hook)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    assert list_git_visible_files(repo) == [source]
+    assert not sentinel.exists()

--- a/test/test_git_context.py
+++ b/test/test_git_context.py
@@ -170,3 +170,39 @@ def test_relative_paths_preserve_names_and_reject_outside_files(repo):
     )
     assert context.relative_path(repo.parent / "outside.py") is None
     assert context.relative_path(Path("package") / "tracked.py") == "package/tracked.py"
+
+
+def test_diff_does_not_execute_repository_or_environment_helpers(
+    repo, tmp_path, monkeypatch
+):
+    sentinel = tmp_path / "git-helper-ran"
+    helper = tmp_path / "git-helper"
+    helper.write_text(
+        f"#!/bin/sh\ntouch '{sentinel}'\nexit 1\n",
+        encoding="utf-8",
+    )
+    helper.chmod(0o755)
+    info_attributes = repo / ".git" / "info" / "attributes"
+    info_attributes.write_text(
+        "*.py filter=untrusted diff=untrusted\n",
+        encoding="utf-8",
+    )
+    _git(repo, "config", "core.fsmonitor", str(helper))
+    _git(repo, "config", "diff.external", str(helper))
+    _git(repo, "config", "diff.untrusted.command", str(helper))
+    _git(repo, "config", "diff.untrusted.textconv", str(helper))
+    _git(repo, "config", "extensions.worktreeConfig", "true")
+    _git(repo, "config", "--worktree", "filter.untrusted.clean", str(helper))
+    monkeypatch.setenv("GIT_EXTERNAL_DIFF", str(helper))
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "diff.external")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", str(helper))
+    source = repo / "package" / "tracked.py"
+    assert write_text_no_symlink(source, "value = 2\n")
+    sentinel.unlink(missing_ok=True)
+
+    result = GitContext.from_path(source).run("diff", "--name-only", "HEAD")
+
+    assert result.returncode == 0
+    assert result.stdout == "package/tracked.py\n"
+    assert not sentinel.exists()

--- a/test/test_git_context.py
+++ b/test/test_git_context.py
@@ -183,9 +183,9 @@ def test_diff_does_not_execute_repository_or_environment_helpers(
     )
     helper.chmod(0o755)
     info_attributes = repo / ".git" / "info" / "attributes"
-    info_attributes.write_text(
+    assert write_text_no_symlink(
+        info_attributes,
         "*.py filter=untrusted diff=untrusted\n",
-        encoding="utf-8",
     )
     _git(repo, "config", "core.fsmonitor", str(helper))
     _git(repo, "config", "diff.external", str(helper))

--- a/test/test_llm_review_context.py
+++ b/test/test_llm_review_context.py
@@ -9,15 +9,16 @@ from skylos.core.review_context import (
     review_context_hash_for_category,
     review_context_is_valid,
 )
+from skylos.core.safe_cache_io import write_text_no_symlink
 from skylos.llm.prompts import analysis_prompt_revision
 
 
 def _build_context(root, **overrides):
     source = root / "src" / "app.py"
     source.parent.mkdir(parents=True, exist_ok=True)
-    source.write_text(
+    assert write_text_no_symlink(
+        source,
         overrides.pop("source_text", "def handler():\n    return 1\n"),
-        encoding="utf-8",
     )
     prompt_revision = analysis_prompt_revision("review")
     values = {

--- a/test/test_llm_review_context.py
+++ b/test/test_llm_review_context.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import copy
+import json
+
+from skylos.core.review_context import (
+    LLM_REVIEW_CONTEXT_SCHEMA,
+    build_llm_review_context,
+    review_context_hash_for_category,
+    review_context_is_valid,
+)
+from skylos.llm.prompts import analysis_prompt_revision
+
+
+def _build_context(root, **overrides):
+    source = root / "src" / "app.py"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(
+        overrides.pop("source_text", "def handler():\n    return 1\n"),
+        encoding="utf-8",
+    )
+    prompt_revision = analysis_prompt_revision("review")
+    values = {
+        "mode": "agent_llm_only",
+        "config": {"exclude": ["vendor"], "complexity": 10},
+        "exclude_folders": [".git", "vendor"],
+        "requested_changed_files": None,
+        "effective_files": [source],
+        "repo_context_map": {source: "- review_score=30"},
+        "force_full_file_paths": {source},
+        "definitions": {},
+        "scan_kind": "directory",
+        "complete_target": True,
+        "model": "gpt-4.1",
+        "provider": "openai",
+        "base_url": "https://llm.example.test/v1",
+        "min_confidence": "low",
+        "prompt_revision": prompt_revision,
+        "enable_security": True,
+        "enable_quality": True,
+        "temperature": 0.0,
+        "max_tokens": 4_096,
+        "strict_validation": False,
+        "stream": True,
+        "smart_filter": True,
+        "full_file_review": False,
+        "parallel": True,
+        "max_workers": 4,
+        "max_chunk_tokens": 1_000,
+        "batch_functions": True,
+        "batch_size": 10,
+        "complexity_threshold": 5,
+        "agent_route": "full",
+    }
+    values.update(overrides)
+    return build_llm_review_context(root, root, **values)
+
+
+def test_llm_review_context_is_valid_and_category_scoped(tmp_path):
+    context = _build_context(tmp_path)
+
+    assert context["schema"] == LLM_REVIEW_CONTEXT_SCHEMA
+    assert review_context_is_valid(context)
+    assert review_context_hash_for_category(context, "QUALITY")
+    assert review_context_hash_for_category(context, "SECURITY")
+    assert review_context_hash_for_category(context, "DEAD_CODE") is None
+    assert "llm.example.test" not in json.dumps(context)
+
+
+def test_llm_review_context_binds_runtime_config_and_selection(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    base = _build_context(root)
+    source = root / "src" / "app.py"
+    changed = root / "src" / "changed.py"
+    changed.write_text("value = 1\n", encoding="utf-8")
+
+    variants = [
+        _build_context(root, model="gpt-4.2"),
+        _build_context(root, provider="anthropic"),
+        _build_context(root, min_confidence="high"),
+        _build_context(root, temperature=0.2),
+        _build_context(root, max_tokens=8_192),
+        _build_context(root, strict_validation=True),
+        _build_context(root, stream=False),
+        _build_context(root, config={"exclude": ["vendor"], "complexity": 11}),
+        _build_context(root, exclude_folders=[".git", "generated"]),
+        _build_context(root, requested_changed_files=[changed]),
+        _build_context(root, effective_files=[source, changed]),
+        _build_context(
+            root,
+            repo_context_map={source: "- review_score=90"},
+        ),
+        _build_context(root, force_full_file_paths=set()),
+        _build_context(root, smart_filter=False),
+        _build_context(root, max_chunk_tokens=2_000),
+        _build_context(
+            root,
+            definitions={
+                "shared.helper": {
+                    "name": "helper",
+                    "file": root / "src" / "app.py",
+                    "type": "function",
+                }
+            },
+        ),
+        _build_context(root, source_text="def handler():\n    return 2\n"),
+    ]
+
+    assert all(review_context_is_valid(item) for item in variants)
+    assert all(item["context_hash"] != base["context_hash"] for item in variants)
+
+
+def test_llm_review_context_distinguishes_llm_only_and_hybrid_modes(tmp_path):
+    llm_only = _build_context(tmp_path, mode="agent_llm_only")
+    hybrid = _build_context(tmp_path, mode="agent_hybrid_llm")
+
+    assert review_context_is_valid(llm_only)
+    assert review_context_is_valid(hybrid)
+    assert hybrid["context_hash"] != llm_only["context_hash"]
+    assert review_context_hash_for_category(hybrid, "QUALITY")
+
+
+def test_llm_review_context_is_checkout_independent(tmp_path):
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first_root.mkdir()
+    second_root.mkdir()
+
+    first = _build_context(
+        first_root,
+        definitions={
+            "app.handler": {
+                "name": "handler",
+                "file": first_root / "src" / "app.py",
+                "type": "function",
+            }
+        },
+    )
+    second = _build_context(
+        second_root,
+        definitions={
+            "app.handler": {
+                "name": "handler",
+                "file": second_root / "src" / "app.py",
+                "type": "function",
+            }
+        },
+    )
+
+    assert first == second
+
+
+def test_llm_review_context_fails_open_for_incomplete_or_tampered_inputs(tmp_path):
+    context = _build_context(tmp_path, provider=None)
+    assert context == {"schema": LLM_REVIEW_CONTEXT_SCHEMA, "complete": False}
+    assert not review_context_is_valid(context)
+    assert review_context_hash_for_category(context, "QUALITY") is None
+
+    valid = _build_context(tmp_path)
+    tampered = copy.deepcopy(valid)
+    tampered["analyzer"]["model"] = "different-model"
+    assert not review_context_is_valid(tampered)
+    assert review_context_hash_for_category(tampered, "QUALITY") is None
+
+
+def test_analysis_prompt_revision_tracks_effective_template_content(tmp_path):
+    template = tmp_path / "review.md"
+    template.write_text("Check tenant isolation.\n", encoding="utf-8")
+    first = analysis_prompt_revision(
+        "review",
+        templates={"review": str(template)},
+        template_root=tmp_path,
+    )
+    template.write_text("Check authorization boundaries.\n", encoding="utf-8")
+    second = analysis_prompt_revision(
+        "review",
+        templates={"review": str(template)},
+        template_root=tmp_path,
+    )
+
+    assert first and first.startswith("sha256:")
+    assert second and second.startswith("sha256:")
+    assert first != second
+    assert analysis_prompt_revision("unknown") is None

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -396,11 +396,13 @@ class TestRunStaticOnFiles:
         run_static_on_files(
             ["/proj/a.py", "/proj/b.py"],
             project_root=pathlib.Path("/proj"),
+            include_review_proofs=True,
         )
 
         kwargs = mock_analyze.call_args.kwargs
         assert sorted(kwargs["changed_files"]) == ["/proj/a.py", "/proj/b.py"]
         assert kwargs["enable_ai_defects"] is True
+        assert kwargs["include_review_proofs"] is True
 
 
 class TestPipelinePhase1:
@@ -1878,6 +1880,32 @@ class TestPipelineIntegration:
             mock_static.assert_called_once()
             assert mock_static.call_args[0][0] == changed
 
+    def test_review_mode_requests_dead_code_proofs_for_upload(self, tmp_path):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "a.py").write_text("x = 1")
+
+        with (
+            patch(P_STATIC_FN, return_value=_empty_result()) as mock_static,
+            patch(P_PROGRESS),
+            patch(P_LLM) as mock_llm,
+            patch(
+                "skylos.core.review_decisions.review_scan_requirements",
+                return_value=(False, False),
+            ),
+        ):
+            mock_llm.return_value.analyze_files.return_value = MagicMock(findings=[])
+            run_pipeline(
+                path=str(proj),
+                model="t",
+                api_key="k",
+                agent_args=_agent_args(upload=True),
+                console=_console(),
+                changed_files=[str(proj / "a.py")],
+            )
+
+        assert mock_static.call_args.kwargs["include_review_proofs"] is True
+
     def test_analyze_mode_calls_run_analyze_directly(self, tmp_path):
         proj = tmp_path / "proj"
         proj.mkdir()
@@ -1902,3 +1930,58 @@ class TestPipelineIntegration:
 
             mock_analyze.assert_called_once()
             assert mock_analyze.call_args[0][0] == str(proj)
+
+    def test_analyze_mode_returns_review_context_in_pipeline_stats(self, tmp_path):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "a.py").write_text("x = 1")
+        static_result = _empty_result()
+        static_result["analysis_summary"] = {
+            "review_context": {"schema": "test-review-context"}
+        }
+        stats = {}
+
+        with (
+            patch(P_ANALYZE, return_value=json.dumps(static_result)),
+            patch(P_EXCLUDE, return_value=set()),
+            patch(P_PROGRESS),
+            patch(P_LLM) as mock_llm,
+        ):
+            mock_llm.return_value.analyze_files.return_value = MagicMock(findings=[])
+            run_pipeline(
+                path=str(proj),
+                model="t",
+                api_key="k",
+                agent_args=_agent_args(static_only=True, skip_verification=True),
+                console=_console(),
+                stats_out=stats,
+            )
+
+        assert stats["review_context"] == {"schema": "test-review-context"}
+
+    def test_analyze_mode_requests_proofs_when_review_state_needs_them(self, tmp_path):
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "a.py").write_text("x = 1")
+
+        with (
+            patch(P_ANALYZE) as mock_analyze,
+            patch(P_EXCLUDE, return_value=set()),
+            patch(P_PROGRESS),
+            patch(P_LLM) as mock_llm,
+            patch(
+                "skylos.core.review_decisions.review_scan_requirements",
+                return_value=(True, True),
+            ),
+        ):
+            mock_analyze.return_value = json.dumps(_empty_result())
+            mock_llm.return_value.analyze_files.return_value = MagicMock(findings=[])
+            run_pipeline(
+                path=str(proj),
+                model="t",
+                api_key="k",
+                agent_args=_agent_args(static_only=True, skip_verification=True),
+                console=_console(),
+            )
+
+        assert mock_analyze.call_args.kwargs["include_review_proofs"] is True

--- a/test/test_provenance.py
+++ b/test/test_provenance.py
@@ -260,7 +260,7 @@ def _mock_check_output(cmd, **kwargs):
     cmd_str = " ".join(cmd)
     if "merge-base" in cmd_str:
         return MERGE_BASE.encode()
-    if "git log" in cmd_str:
+    if " log " in cmd_str:
         return GIT_LOG_OUTPUT.encode()
     if "diff-tree" in cmd_str:
         return DIFF_TREE_OUTPUT.encode()
@@ -290,7 +290,7 @@ def test_analyze_provenance_no_ai_commits():
         cmd_str = " ".join(cmd)
         if "merge-base" in cmd_str:
             return MERGE_BASE.encode()
-        if "git log" in cmd_str:
+        if " log " in cmd_str:
             return log_no_ai.encode()
         if "diff" in cmd_str and "--name-only" in cmd_str:
             return diff_names.encode()
@@ -319,7 +319,7 @@ diff --git a/fix.py b/fix.py
         cmd_str = " ".join(cmd)
         if "merge-base" in cmd_str:
             return MERGE_BASE.encode()
-        if "git log" in cmd_str:
+        if " log " in cmd_str:
             return log.encode()
         if "diff-tree" in cmd_str:
             return diff_tree.encode()
@@ -349,7 +349,7 @@ diff --git a/gen.py b/gen.py
         cmd_str = " ".join(cmd)
         if "merge-base" in cmd_str:
             return MERGE_BASE.encode()
-        if "git log" in cmd_str:
+        if " log " in cmd_str:
             return log.encode()
         if "diff-tree" in cmd_str:
             return diff_tree.encode()
@@ -373,7 +373,7 @@ def test_analyze_provenance_merge_base_fallback():
         call_log.append(cmd_str)
         if "merge-base" in cmd_str:
             raise subprocess.CalledProcessError(1, cmd)
-        if "git log" in cmd_str:
+        if " log " in cmd_str:
             assert "HEAD~10..HEAD" in cmd_str
             return b""
         if "diff" in cmd_str and "--name-only" in cmd_str:
@@ -391,7 +391,7 @@ def test_analyze_provenance_git_log_failure():
         cmd_str = " ".join(cmd)
         if "merge-base" in cmd_str:
             return MERGE_BASE.encode()
-        if "git log" in cmd_str:
+        if " log " in cmd_str:
             raise subprocess.CalledProcessError(1, cmd)
         return b""
 
@@ -427,7 +427,7 @@ diff --git a/b.py b/b.py
         cmd_str = " ".join(cmd)
         if "merge-base" in cmd_str:
             return MERGE_BASE.encode()
-        if "git log" in cmd_str:
+        if " log " in cmd_str:
             return log.encode()
         if "diff-tree" in cmd_str:
             if "abc1234full" in cmd_str:
@@ -470,7 +470,7 @@ diff --git a/f{i}.py b/f{i}.py
         cmd_str = " ".join(cmd)
         if "merge-base" in cmd_str:
             return MERGE_BASE.encode()
-        if "git log" in cmd_str:
+        if " log " in cmd_str:
             return log.encode()
         if "diff-tree" in cmd_str:
             for i in range(10):

--- a/test/test_review_cmd.py
+++ b/test/test_review_cmd.py
@@ -1,0 +1,660 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from io import StringIO
+
+import pytest
+from rich.console import Console
+
+import skylos.cli as cli
+from skylos.commands import review_cmd
+from skylos.config import DEFAULTS
+from skylos.core.review_context import build_analysis_review_context
+from skylos.core.review_decisions import FINGERPRINT_VERSION
+
+
+NOW = datetime(2026, 9, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def _console_capture():
+    stream = StringIO()
+
+    def factory():
+        return Console(
+            file=stream,
+            force_terminal=False,
+            color_system=None,
+            width=180,
+        )
+
+    return stream, factory
+
+
+def _scan_result(source):
+    review_context = build_analysis_review_context(
+        source.parent,
+        source,
+        config=DEFAULTS,
+        threshold=60,
+        exclude_folders=(),
+        requested_changed_files=None,
+        effective_changed_files=None,
+        enable_secrets=True,
+        enable_danger=True,
+        enable_quality=True,
+        enable_ai_defects=True,
+        enable_sca=False,
+        enable_dependency_hallucinations=True,
+        grep_verify=True,
+        trace_file=None,
+        required_config_rules=None,
+        dependency_bump_diff_base=None,
+        custom_rules_data=None,
+        extra_visitors=None,
+        analysis_scope={"kind": "file", "complete_repository": False},
+        environ={},
+    )
+    return {
+        "analysis_summary": {
+            "total_files": 1,
+            "danger_count": 1,
+            "review_context": review_context,
+        },
+        "danger": [
+            {
+                "rule_id": "SKY-D215",
+                "file": str(source),
+                "line": 2,
+                "symbol": "write_report",
+                "severity": "HIGH",
+                "message": "User-controlled output path",
+            }
+        ],
+    }
+
+
+def _answers(*values):
+    iterator = iter(values)
+    return lambda _prompt: next(iterator)
+
+
+def test_interactive_review_records_v2_false_positive(tmp_path, monkeypatch):
+    source = tmp_path / "app.py"
+    source.write_text("def write_report(path):\n    open(path, 'w').write('ok')\n")
+    monkeypatch.setattr(
+        review_cmd,
+        "run_analyze",
+        lambda *_args, **_kwargs: json.dumps(_scan_result(source)),
+    )
+    recorded = []
+
+    def record(_project_root, decision, *, environ, cache_root, now):
+        assert cache_root is None
+        assert now == NOW
+        recorded.append((decision, environ))
+        return dict(decision)
+
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "record_local_decision",
+        record,
+        raising=False,
+    )
+    stream, console_factory = _console_capture()
+
+    exit_code = review_cmd.run_review_command(
+        [str(tmp_path)],
+        console_factory=console_factory,
+        input_fn=_answers("1", "1", "The wrapper constrains the path"),
+        environ={},
+        now=NOW,
+    )
+
+    assert exit_code == 0
+    assert len(recorded) == 1
+    decision, passed_env = recorded[0]
+    assert passed_env == {}
+    assert decision["fingerprint_version"] == FINGERPRINT_VERSION
+    assert decision["stable_fingerprint"].startswith("sha256:")
+    assert decision["context_hash"].startswith("sha256:")
+    assert decision["rule_revision"]
+    assert decision["rule_id"] == "SKY-D215"
+    assert decision["file_path"] == "app.py"
+    assert decision["line_number"] == 2
+    assert decision["disposition"] == "false_positive"
+    assert decision["reason"] == "The wrapper constrains the path"
+    assert decision["created_at"] == "2026-09-12T12:00:00Z"
+    assert "expires_at" not in decision
+    assert "Recorded false positive" in stream.getvalue()
+    assert "relevant code and evidence still match" in stream.getvalue()
+    assert decision["decision_id"] in stream.getvalue()
+
+
+def test_interactive_review_requires_time_bound_for_accepted_risk(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "app.py"
+    source.write_text("def write_report(path):\n    open(path, 'w').write('ok')\n")
+    monkeypatch.setattr(
+        review_cmd,
+        "run_analyze",
+        lambda *_args, **_kwargs: json.dumps(_scan_result(source)),
+    )
+    recorded = []
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "record_local_decision",
+        lambda _root, decision, *, environ, cache_root, now: (
+            recorded.append(decision) or decision
+        ),
+        raising=False,
+    )
+    _stream, console_factory = _console_capture()
+
+    exit_code = review_cmd.run_review_command(
+        [str(tmp_path)],
+        console_factory=console_factory,
+        input_fn=_answers("1", "2", "Vendor fix is scheduled", "14"),
+        environ={},
+        now=NOW,
+    )
+
+    assert exit_code == 0
+    assert recorded[0]["disposition"] == "risk_accepted"
+    assert recorded[0]["expires_at"] == "2026-09-26T12:00:00Z"
+
+
+def test_interactive_review_rejects_unbounded_risk_acceptance(tmp_path, monkeypatch):
+    source = tmp_path / "app.py"
+    source.write_text("def write_report(path):\n    open(path, 'w').write('ok')\n")
+    monkeypatch.setattr(
+        review_cmd,
+        "run_analyze",
+        lambda *_args, **_kwargs: json.dumps(_scan_result(source)),
+    )
+
+    def record(*_args, **_kwargs):
+        pytest.fail("decision must not be written")
+
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "record_local_decision",
+        record,
+        raising=False,
+    )
+    stream, console_factory = _console_capture()
+
+    exit_code = review_cmd.run_review_command(
+        [str(tmp_path)],
+        console_factory=console_factory,
+        input_fn=_answers("1", "2", "Temporary exception", "0"),
+        environ={},
+        now=NOW,
+    )
+
+    assert exit_code == 2
+    assert "Expiry must be between 1 and 365 days" in stream.getvalue()
+
+
+def test_review_scan_runtime_failure_is_rendered_cleanly(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        review_cmd,
+        "run_analyze",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("analyzer worker failed")
+        ),
+    )
+    stream, console_factory = _console_capture()
+
+    exit_code = review_cmd.run_review_command(
+        [str(tmp_path)],
+        console_factory=console_factory,
+        environ={},
+        now=NOW,
+    )
+
+    assert exit_code == 2
+    assert "Review scan failed: analyzer worker failed" in stream.getvalue()
+
+
+def test_review_table_strips_terminal_controls_from_finding_text(tmp_path, monkeypatch):
+    source = tmp_path / "app.py"
+    source.write_text("open(path, 'w').write('ok')\n")
+    result = _scan_result(source)
+    result["danger"][0]["message"] = "unsafe\x1b]8;;https://evil.invalid\x07link"
+    monkeypatch.setattr(
+        review_cmd,
+        "run_analyze",
+        lambda *_args, **_kwargs: json.dumps(result),
+    )
+    stream, console_factory = _console_capture()
+
+    exit_code = review_cmd.run_review_command(
+        [str(tmp_path)],
+        console_factory=console_factory,
+        input_fn=_answers("q"),
+        environ={},
+        now=NOW,
+    )
+
+    assert exit_code == 0
+    assert "\x1b" not in stream.getvalue()
+    assert "\x07" not in stream.getvalue()
+
+
+def test_review_list_renders_active_and_revoked_decisions(tmp_path, monkeypatch):
+    decisions = [
+        {
+            "decision_id": "active-1",
+            "disposition": "false_positive",
+            "rule_id": "SKY-D215",
+            "file_path": "app.py",
+            "line_number": 2,
+            "reason": "Safe wrapper",
+        },
+        {
+            "decision_id": "revoked-1",
+            "disposition": "risk_accepted",
+            "rule_id": "SKY-D212",
+            "file_path": "worker.py",
+            "line_number": 8,
+            "reason": "Old exception",
+            "revoked_at": "2026-09-12T12:00:00Z",
+        },
+    ]
+    calls = []
+
+    def list_decisions(root, *, include_revoked, environ, cache_root):
+        assert cache_root is None
+        calls.append((root, include_revoked, environ))
+        return decisions
+
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "list_local_decisions",
+        list_decisions,
+        raising=False,
+    )
+    stream, console_factory = _console_capture()
+
+    exit_code = review_cmd.run_review_command(
+        ["list", str(tmp_path)],
+        console_factory=console_factory,
+        environ={},
+    )
+
+    assert exit_code == 0
+    assert calls == [(tmp_path.resolve(), True, {})]
+    output = stream.getvalue()
+    assert "active-1" in output
+    assert "revoked-1" in output
+    assert "false_positive" in output
+    assert "revoked" in output
+
+
+@pytest.mark.parametrize("verb", ["restore", "revoke"])
+def test_review_restore_revokes_local_decision(tmp_path, monkeypatch, verb):
+    calls = []
+
+    def revoke(root, decision_id, *, environ, cache_root, now):
+        assert cache_root is None
+        calls.append((root, decision_id, environ))
+        return True
+
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "revoke_local_decision",
+        revoke,
+        raising=False,
+    )
+    stream, console_factory = _console_capture()
+
+    exit_code = review_cmd.run_review_command(
+        [verb, "decision-7", str(tmp_path)],
+        console_factory=console_factory,
+        environ={},
+    )
+
+    assert exit_code == 0
+    assert calls == [(tmp_path.resolve(), "decision-7", {})]
+    assert "Restored finding" in stream.getvalue()
+
+
+def test_review_authoring_and_revocation_are_rejected_in_ci(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        review_cmd,
+        "run_analyze",
+        lambda *_args, **_kwargs: pytest.fail("CI must not start an authoring scan"),
+    )
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "revoke_local_decision",
+        lambda *_args, **_kwargs: pytest.fail("CI must not change local decisions"),
+        raising=False,
+    )
+    stream, console_factory = _console_capture()
+    env = {"CI": "true", "GITHUB_RUN_ID": "123"}
+
+    add_exit = review_cmd.run_review_command(
+        [str(tmp_path)], console_factory=console_factory, environ=env
+    )
+    restore_exit = review_cmd.run_review_command(
+        ["restore", "decision-1", str(tmp_path)],
+        console_factory=console_factory,
+        environ=env,
+    )
+
+    assert add_exit == 2
+    assert restore_exit == 2
+    assert "cannot be created in CI" in stream.getvalue()
+    assert "cannot be changed in CI" in stream.getvalue()
+
+
+def test_review_list_is_empty_in_ci_without_reading_local_state(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "list_local_decisions",
+        lambda *_args, **_kwargs: pytest.fail("CI must ignore local decisions"),
+        raising=False,
+    )
+    stream, console_factory = _console_capture()
+
+    exit_code = review_cmd.run_review_command(
+        ["list", str(tmp_path)],
+        console_factory=console_factory,
+        environ={"CI": "true", "GITHUB_RUN_ID": "123"},
+    )
+
+    assert exit_code == 0
+    assert "ignored in CI" in stream.getvalue()
+
+
+def test_review_is_registered_as_top_level_command(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        review_cmd,
+        "run_review_command",
+        lambda argv, *, console_factory: calls.append(argv) or 0,
+    )
+    monkeypatch.setattr(cli.sys, "argv", ["skylos", "review", "list", "."])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    assert calls == [["list", "."]]
+
+
+def test_review_command_local_decision_round_trip_and_ci_isolation(
+    tmp_path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/acme/review-demo.git",
+        ],
+        check=True,
+    )
+    source = repo / "app.py"
+    source.write_text("def write_report(path):\n    open(path, 'w').write('ok')\n")
+    result = _scan_result(source)
+    monkeypatch.setattr(
+        review_cmd,
+        "run_analyze",
+        lambda *_args, **_kwargs: json.dumps(result),
+    )
+    local_cache = tmp_path / "operator-local-decisions"
+    trusted_cache = tmp_path / "empty-trusted-decisions"
+    assert not local_cache.exists()
+    assert not trusted_cache.exists()
+    stream, console_factory = _console_capture()
+
+    add_exit = review_cmd.run_review_command(
+        [str(source)],
+        console_factory=console_factory,
+        input_fn=_answers("1", "1", "Reviewed safe wrapper"),
+        environ={},
+        now=NOW,
+        trusted_cache_root=trusted_cache,
+        local_cache_root=local_cache,
+    )
+    repeat_exit = review_cmd.run_review_command(
+        [str(source)],
+        console_factory=console_factory,
+        input_fn=lambda _prompt: pytest.fail(
+            "an active decision must not be offered for review again"
+        ),
+        environ={},
+        now=NOW,
+        trusted_cache_root=trusted_cache,
+        local_cache_root=local_cache,
+    )
+    listed = review_cmd.review_decisions.list_local_decisions(
+        repo,
+        environ={},
+        cache_root=local_cache,
+    )
+    local_projection = review_cmd.review_decisions.apply_trusted_review_decisions(
+        result,
+        repo,
+        cache_root=tmp_path / "empty-cloud-cache",
+        local_cache_root=local_cache,
+        environ={},
+        now=NOW,
+    )
+    ci_projection = review_cmd.review_decisions.apply_trusted_review_decisions(
+        result,
+        repo,
+        cache_root=tmp_path / "empty-cloud-cache",
+        local_cache_root=local_cache,
+        environ={"CI": "true", "GITHUB_RUN_ID": "42"},
+        now=NOW,
+    )
+
+    assert add_exit == 0
+    assert repeat_exit == 0
+    assert "No findings with stable review identity were found" in stream.getvalue()
+    assert len(listed) == 1
+    assert listed[0]["language"] == "python"
+    assert listed[0]["symbol"] == "write_report"
+    assert listed[0]["section"] == "danger"
+    assert listed[0]["category"] == "SECURITY"
+    assert local_projection["danger"] == []
+    assert len(local_projection["reviewed_findings"]) == 1
+    assert len(ci_projection["danger"]) == 1
+    assert ci_projection.get("reviewed_findings", []) == []
+
+    restore_exit = review_cmd.run_review_command(
+        ["restore", listed[0]["decision_id"], str(repo)],
+        console_factory=console_factory,
+        environ={},
+        now=NOW,
+        local_cache_root=local_cache,
+    )
+    restored_projection = review_cmd.review_decisions.apply_trusted_review_decisions(
+        result,
+        repo,
+        cache_root=tmp_path / "empty-cloud-cache",
+        local_cache_root=local_cache,
+        environ={},
+        now=NOW,
+    )
+
+    assert restore_exit == 0
+    assert len(restored_projection["danger"]) == 1
+    assert restored_projection.get("reviewed_findings", []) == []
+
+
+def test_cloud_reviewed_finding_cannot_be_selected_for_duplicate_local_decision(
+    tmp_path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/acme/cloud-reviewed-demo.git",
+        ],
+        check=True,
+    )
+    source = repo / "app.py"
+    source.write_text("def write_report(path):\n    open(path, 'w').write('ok')\n")
+    skylos_dir = repo / ".skylos"
+    skylos_dir.mkdir()
+    (skylos_dir / "link.json").write_text(
+        json.dumps({"project_id": "project-cloud-reviewed-demo", "projects": {}})
+    )
+    result = _scan_result(source)
+    annotated = review_cmd.review_decisions.annotate_result_identities(result, repo)
+    identity = annotated["danger"][0]
+    decision = {
+        key: identity[key]
+        for key in (
+            "fingerprint_version",
+            "stable_fingerprint",
+            "context_hash",
+            "rule_revision",
+            "rule_id",
+            "file_path",
+        )
+    }
+    decision.update(
+        {
+            "decision_id": "cloud-decision-1",
+            "line_number": 2,
+            "disposition": "false_positive",
+            "reason": "Reviewed in Cloud",
+            "created_at": "2026-09-12T11:00:00Z",
+        }
+    )
+    cloud_cache = tmp_path / "cloud-cache"
+    local_cache = tmp_path / "local-cache"
+    stored = review_cmd.review_decisions.write_trusted_bundle(
+        repo,
+        {
+            "schema": review_cmd.review_decisions.REVIEW_SCHEMA,
+            "version": review_cmd.review_decisions.REVIEW_SCHEMA_VERSION,
+            "project_id": "project-cloud-reviewed-demo",
+            "decisions": [decision],
+        },
+        cache_root=cloud_cache,
+        fetched_at=NOW,
+        environ={},
+    )
+    assert stored is not None
+    monkeypatch.setattr(
+        review_cmd,
+        "run_analyze",
+        lambda *_args, **_kwargs: json.dumps(result),
+    )
+    stream, console_factory = _console_capture()
+
+    exit_code = review_cmd.run_review_command(
+        [str(source)],
+        console_factory=console_factory,
+        input_fn=lambda _prompt: pytest.fail(
+            "a Cloud-reviewed finding must not be offered for local review"
+        ),
+        environ={},
+        now=NOW,
+        trusted_cache_root=cloud_cache,
+        local_cache_root=local_cache,
+    )
+
+    assert exit_code == 0
+    assert "No findings with stable review identity were found" in stream.getvalue()
+    assert (
+        review_cmd.review_decisions.list_local_decisions(
+            repo,
+            environ={},
+            cache_root=local_cache,
+        )
+        == []
+    )
+
+
+def test_review_scan_does_not_execute_repository_git_helpers(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "app.py"
+    source.write_text(
+        "def write_report(path):\n    open(path, 'w').write('ok')\n",
+        encoding="utf-8",
+    )
+    (repo / ".gitattributes").write_text(
+        "*.py filter=untrusted diff=untrusted\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Skylos Test"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "skylos-test@example.invalid"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "add", "app.py", ".gitattributes"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/acme/untrusted-review.git",
+        ],
+        cwd=repo,
+        check=True,
+    )
+
+    sentinel = tmp_path / "git-helper-ran"
+    helper = tmp_path / "git-helper"
+    helper.write_text(
+        f"#!/bin/sh\ntouch '{sentinel}'\nexit 1\n",
+        encoding="utf-8",
+    )
+    helper.chmod(0o755)
+    for key in (
+        "core.fsmonitor",
+        "diff.external",
+        "diff.untrusted.command",
+        "diff.untrusted.textconv",
+        "filter.untrusted.clean",
+    ):
+        subprocess.run(["git", "config", key, str(helper)], cwd=repo, check=True)
+    monkeypatch.setenv("GIT_EXTERNAL_DIFF", str(helper))
+    monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0", "diff.external")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0", str(helper))
+    source.write_text(
+        "# changed locally\ndef write_report(path):\n    open(path, 'w').write('ok')\n",
+        encoding="utf-8",
+    )
+    sentinel.unlink(missing_ok=True)
+
+    findings = review_cmd._scan_reviewable_findings(
+        repo,
+        repo,
+        environ={},
+        now=NOW,
+        trusted_cache_root=tmp_path / "trusted-cache",
+        local_cache_root=tmp_path / "local-cache",
+    )
+
+    assert findings
+    assert not sentinel.exists()

--- a/test/test_review_decisions.py
+++ b/test/test_review_decisions.py
@@ -1,0 +1,1602 @@
+from datetime import datetime, timedelta, timezone
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+import skylos.core.review_decisions as review_decisions
+from skylos.config import DEFAULTS
+from skylos.core.review_context import build_analysis_review_context
+from skylos.core.review_decisions import (
+    FINGERPRINT_VERSION,
+    REVIEW_SCHEMA,
+    active_decisions,
+    annotate_result_identities,
+    apply_review_decisions,
+    apply_trusted_review_decisions,
+    invalidate_trusted_bundle,
+    load_trusted_bundle,
+    list_local_decisions,
+    record_local_decision,
+    repository_scope,
+    review_context_required,
+    review_proofs_required,
+    review_state_revision,
+    revoke_local_decision,
+    write_trusted_bundle,
+)
+
+
+NOW = datetime(2026, 9, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def _result(path, *, line=2, message="unsafe call"):
+    review_context = build_analysis_review_context(
+        path.parent,
+        path,
+        config=DEFAULTS,
+        threshold=60,
+        exclude_folders=(),
+        requested_changed_files=None,
+        effective_changed_files=None,
+        enable_secrets=False,
+        enable_danger=True,
+        enable_quality=False,
+        enable_ai_defects=False,
+        enable_sca=False,
+        enable_dependency_hallucinations=True,
+        grep_verify=True,
+        trace_file=None,
+        required_config_rules=None,
+        dependency_bump_diff_base=None,
+        custom_rules_data=None,
+        extra_visitors=None,
+        analysis_scope={"kind": "file", "complete_repository": False},
+        environ={},
+    )
+    return {
+        "danger": [
+            {
+                "rule_id": "SKY-D215",
+                "file": str(path),
+                "line": line,
+                "symbol": "write_report",
+                "severity": "HIGH",
+                "message": message,
+            }
+        ],
+        "analysis_summary": {
+            "danger_count": 1,
+            "review_context": review_context,
+        },
+    }
+
+
+def _v2_decision(identity, **overrides):
+    decision = {
+        "decision_id": "decision-1",
+        "fingerprint_version": identity["fingerprint_version"],
+        "stable_fingerprint": identity["stable_fingerprint"],
+        "context_hash": identity["context_hash"],
+        "rule_revision": identity["rule_revision"],
+        "rule_id": identity["rule_id"],
+        "file_path": identity["file_path"],
+        "line_number": 2,
+        "disposition": "false_positive",
+        "reason": "reviewed safe wrapper",
+        "created_at": "2026-09-12T10:00:00Z",
+    }
+    decision.update(overrides)
+    return decision
+
+
+def _git_repo(path, remote="git@github.com:Example/Project.git"):
+    path.mkdir()
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(path), "remote", "add", "origin", remote],
+        check=True,
+    )
+    return path
+
+
+def _proof_requirement_decision(**overrides):
+    decision = {
+        "decision_id": "proof-decision",
+        "fingerprint_version": FINGERPRINT_VERSION,
+        "stable_fingerprint": "sha256:" + "a" * 64,
+        "context_hash": "sha256:" + "b" * 64,
+        "rule_revision": "skylos:1",
+        "rule_id": "SKY-Q001",
+        "file_path": "app.py",
+        "line_number": 1,
+        "disposition": "false_positive",
+    }
+    decision.update(overrides)
+    return decision
+
+
+def test_review_proofs_required_only_for_active_dead_code_v2(monkeypatch, tmp_path):
+    selected_bundle = {"value": None}
+    monkeypatch.setattr(
+        review_decisions, "_identity_project_root", lambda _project_root: tmp_path
+    )
+    monkeypatch.setattr(
+        review_decisions, "_git_remote_identity", lambda _identity_root: None
+    )
+    monkeypatch.setattr(
+        review_decisions,
+        "_load_local_bundle",
+        lambda *_args, **_kwargs: selected_bundle["value"],
+    )
+
+    def required(decision):
+        selected_bundle["value"] = {"version": 2, "decisions": [decision]}
+        return (
+            review_context_required(tmp_path, environ={}, now=NOW),
+            review_proofs_required(tmp_path, environ={}, now=NOW),
+        )
+
+    assert required(_proof_requirement_decision(category="QUALITY")) == (True, False)
+    assert (
+        required(_proof_requirement_decision(rule_id="SKY-D215", category="SECURITY"))
+        == (True, False)
+    )
+    assert (
+        required(_proof_requirement_decision(rule_id="SKY-U001", category="DEAD_CODE"))
+        == (True, True)
+    )
+    assert required(_proof_requirement_decision(rule_id="SKY-U001")) == (True, True)
+    assert required(_proof_requirement_decision(rule_id="SKY-U005")) == (True, False)
+    assert (
+        required(
+            _proof_requirement_decision(
+                rule_id="SKY-U001", expires_at="2026-09-12T11:59:59Z"
+            )
+        )
+        == (False, False)
+    )
+
+
+def test_review_state_revision_tracks_projection_changes_only(monkeypatch, tmp_path):
+    selected_bundle = {"value": None}
+    monkeypatch.setattr(
+        review_decisions, "_identity_project_root", lambda _project_root: tmp_path
+    )
+    monkeypatch.setattr(
+        review_decisions, "_git_remote_identity", lambda _identity_root: None
+    )
+    monkeypatch.setattr(
+        review_decisions, "_linked_project_id", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        review_decisions,
+        "_load_local_bundle",
+        lambda *_args, **_kwargs: selected_bundle["value"],
+    )
+
+    decision = _proof_requirement_decision(category="QUALITY")
+    selected_bundle["value"] = {"version": 2, "decisions": [decision]}
+    original = review_state_revision(tmp_path, environ={}, now=NOW)
+
+    assert original is not None
+    decision["reason"] = "a different audit explanation"
+    assert review_state_revision(tmp_path, environ={}, now=NOW) == original
+
+    decision["expires_at"] = "2026-09-13T12:00:00Z"
+    expiring = review_state_revision(tmp_path, environ={}, now=NOW)
+    assert expiring is not None
+    assert expiring != original
+    assert (
+        review_state_revision(
+            tmp_path,
+            environ={},
+            now=NOW + timedelta(days=2),
+        )
+        is None
+    )
+
+
+def test_review_state_revision_tracks_ambiguity_and_ignores_ci(monkeypatch, tmp_path):
+    selected_bundle = {"value": None}
+    monkeypatch.setattr(
+        review_decisions, "_identity_project_root", lambda _project_root: tmp_path
+    )
+    monkeypatch.setattr(
+        review_decisions, "_git_remote_identity", lambda _identity_root: None
+    )
+    monkeypatch.setattr(
+        review_decisions, "_linked_project_id", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        review_decisions,
+        "_load_local_bundle",
+        lambda *_args, **_kwargs: selected_bundle["value"],
+    )
+
+    first = _proof_requirement_decision(category="QUALITY")
+    selected_bundle["value"] = {"version": 2, "decisions": [first]}
+    one_revision = review_state_revision(tmp_path, environ={}, now=NOW)
+    duplicate = dict(first, decision_id="proof-decision-2")
+    selected_bundle["value"] = {"version": 2, "decisions": [first, duplicate]}
+
+    assert review_state_revision(tmp_path, environ={}, now=NOW) != one_revision
+    assert (
+        review_state_revision(
+            tmp_path,
+            environ={"CI": "true", "GITHUB_RUN_ID": "123"},
+            now=NOW,
+        )
+        is None
+    )
+
+
+def test_v2_suppression_survives_line_shift_and_keeps_audit_record(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text(
+        "import os\nENABLED = True\ndef write_report(path):\n"
+        "    open(path).write('ok')\n"
+    )
+    original = annotate_result_identities(_result(source, line=4), tmp_path)
+    identity = original["danger"][0]
+    bundle = {
+        "schema": "skylos.reviewed-findings",
+        "version": 2,
+        "decisions": [_v2_decision(identity, line_number=4)],
+    }
+
+    source.write_text(
+        "# unrelated heading\nimport os\nENABLED = True\ndef write_report(path):\n"
+        "    open(path).write('ok')\n"
+    )
+    shifted = _result(source, line=5)
+    projected = apply_review_decisions(shifted, bundle, tmp_path, now=NOW)
+
+    assert projected["danger"] == []
+    assert projected["analysis_summary"]["danger_count"] == 0
+    assert projected["reviewed_findings_summary"]["suppressed_count"] == 1
+    assert projected["reviewed_findings"][0]["review_decision"] == {
+        "decision_id": "decision-1",
+        "disposition": "false_positive",
+        "reason": "reviewed safe wrapper",
+        "created_at": "2026-09-12T10:00:00Z",
+        "match_mode": "v2_exact_context",
+    }
+
+
+def test_security_review_survives_nearby_comment_only_line_shift(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def write_report(path):\n    open(path).write('ok')\n")
+    result = _result(source, line=2)
+    identity = annotate_result_identities(result, tmp_path)["danger"][0]
+    bundle = {"version": 2, "decisions": [_v2_decision(identity)]}
+
+    source.write_text(
+        "def write_report(path):\n"
+        "    # explain why this wrapper is safe\n"
+        "    open(path).write('ok')\n"
+    )
+    shifted = _result(source, line=3)
+    projected = apply_review_decisions(shifted, bundle, tmp_path, now=NOW)
+
+    assert projected["danger"] == []
+
+
+def test_changed_security_context_resurfaces_finding(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def write_report(path):\n    open(path).write('ok')\n")
+    identity = annotate_result_identities(_result(source), tmp_path)["danger"][0]
+    bundle = {"version": 2, "decisions": [_v2_decision(identity)]}
+
+    source.write_text("def write_report(path):\n    open('/tmp/' + path).write('ok')\n")
+    projected = apply_review_decisions(_result(source), bundle, tmp_path, now=NOW)
+
+    assert len(projected["danger"]) == 1
+    assert projected["reviewed_findings"] == []
+
+
+def test_static_agent_label_keeps_native_analyzer_identity(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def write_report(path):\n    open(path).write('ok')\n")
+    native = annotate_result_identities(_result(source), tmp_path)["danger"][0]
+    agent_result = _result(source)
+    agent_result["danger"][0]["_source"] = "static"
+    agent = annotate_result_identities(agent_result, tmp_path)["danger"][0]
+
+    assert agent["stable_fingerprint"] == native["stable_fingerprint"]
+    assert agent["context_hash"] == native["context_hash"]
+
+
+def test_incomplete_v2_record_does_not_fall_back_to_location(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def write_report(path):\n    open(path).write('ok')\n")
+    identity = annotate_result_identities(_result(source), tmp_path)["danger"][0]
+    decision = _v2_decision(identity)
+    decision.pop("context_hash")
+
+    projected = apply_review_decisions(_result(source), [decision], tmp_path, now=NOW)
+
+    assert len(projected["danger"]) == 1
+    assert projected["reviewed_findings"] == []
+
+
+def test_v2_duplicate_current_identity_is_ambiguous(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def write_report(path):\n    open(path).write('ok')\n")
+    result = _result(source)
+    result["danger"].append(dict(result["danger"][0]))
+    identity = annotate_result_identities(result, tmp_path)["danger"][0]
+
+    projected = apply_review_decisions(
+        result, [_v2_decision(identity)], tmp_path, now=NOW
+    )
+
+    assert len(projected["danger"]) == 2
+    assert projected["reviewed_findings"] == []
+    assert projected["reviewed_findings_summary"]["ambiguous_match_count"] == 2
+
+
+def test_legacy_low_risk_decision_requires_exact_rule_path_and_line(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def helper():\n    return 1\n")
+    result = {
+        "quality": [
+            {
+                "rule_id": "SKY-Q999",
+                "file": str(source),
+                "line": 2,
+                "severity": "LOW",
+                "message": "review this helper",
+            }
+        ]
+    }
+    decision = {
+        "rule_id": "SKY-Q999",
+        "file_path": "app.py",
+        "line_number": 2,
+        "type": "false_positive",
+    }
+
+    matched = apply_review_decisions(result, [decision], tmp_path, now=NOW)
+    shifted_result = {"quality": [{**result["quality"][0], "line": 1}]}
+    shifted = apply_review_decisions(shifted_result, [decision], tmp_path, now=NOW)
+
+    assert matched["quality"] == []
+    assert len(shifted["quality"]) == 1
+
+
+def test_cloud_wire_null_v2_fields_keep_low_risk_legacy_compatibility(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def helper():\n    return 1\n")
+    result = {
+        "quality": [
+            {
+                "rule_id": "SKY-Q999",
+                "file": str(source),
+                "line": 2,
+                "severity": "LOW",
+                "message": "review this helper",
+            }
+        ]
+    }
+    cloud_wire_decision = {
+        "rule_id": "SKY-Q999",
+        "file_path": "app.py",
+        "line_number": 2,
+        "type": "false_positive",
+        "fingerprint_version": None,
+        "stable_fingerprint": None,
+        "context_hash": None,
+        "rule_revision": None,
+    }
+
+    projected = apply_review_decisions(result, [cloud_wire_decision], tmp_path, now=NOW)
+
+    assert projected["quality"] == []
+
+
+def test_partial_non_null_v2_claim_never_falls_back_to_legacy(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def helper():\n    return 1\n")
+    result = {
+        "quality": [
+            {
+                "rule_id": "SKY-Q999",
+                "file": str(source),
+                "line": 2,
+                "severity": "LOW",
+                "message": "review this helper",
+            }
+        ]
+    }
+    partial = {
+        "rule_id": "SKY-Q999",
+        "file_path": "app.py",
+        "line_number": 2,
+        "type": "false_positive",
+        "fingerprint_version": FINGERPRINT_VERSION,
+        "stable_fingerprint": None,
+        "context_hash": None,
+        "rule_revision": None,
+    }
+
+    projected = apply_review_decisions(result, [partial], tmp_path, now=NOW)
+
+    assert len(projected["quality"]) == 1
+
+
+def test_legacy_decision_never_suppresses_high_risk_finding(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("open(input()).write('unsafe')\n")
+    decision = {
+        "rule_id": "SKY-D215",
+        "file_path": "app.py",
+        "line_number": 1,
+        "type": "false_positive",
+    }
+
+    projected = apply_review_decisions(
+        _result(source, line=1), [decision], tmp_path, now=NOW
+    )
+
+    assert len(projected["danger"]) == 1
+    assert projected["reviewed_findings"] == []
+
+
+def test_legacy_decision_treats_padded_high_severity_as_high_risk(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("value = 1\n")
+    result = {
+        "quality": [
+            {
+                "rule_id": "SKY-Q999",
+                "file": str(source),
+                "line": 1,
+                "severity": " HIGH ",
+                "message": "high risk quality finding",
+            }
+        ]
+    }
+    decision = {
+        "rule_id": "SKY-Q999",
+        "file_path": "app.py",
+        "line_number": 1,
+        "type": "false_positive",
+    }
+
+    projected = apply_review_decisions(result, [decision], tmp_path, now=NOW)
+
+    assert len(projected["quality"]) == 1
+    assert projected["reviewed_findings"] == []
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"file_path": "app.py\n"},
+        {"file_path": "app.py\x1f"},
+        {"file_path": "app.py\x7f"},
+        {"rule_id": "SKY-Q999\n"},
+        {"rule_revision": ".skylos:1"},
+        {"rule_revision": " skylos:1"},
+    ],
+)
+def test_stored_v2_identity_rejects_noncanonical_contract_fields(tmp_path, overrides):
+    source = tmp_path / "app.py"
+    source.write_text("value = 1\n")
+    result = {
+        "quality": [
+            {
+                "rule_id": "SKY-Q999",
+                "file": str(source),
+                "line": 1,
+                "severity": "LOW",
+                "message": "quality finding",
+            }
+        ]
+    }
+    identity = annotate_result_identities(result, tmp_path)["quality"][0]
+    decision = _v2_decision(identity, **overrides)
+
+    assert active_decisions([decision], tmp_path, now=NOW) == []
+
+
+def test_risk_acceptance_requires_future_expiry(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def write_report(path):\n    open(path).write('ok')\n")
+    identity = annotate_result_identities(_result(source), tmp_path)["danger"][0]
+
+    permanent = _v2_decision(identity, disposition="risk_accepted", expires_at=None)
+    expired = _v2_decision(
+        identity, disposition="risk_accepted", expires_at="2026-09-12T11:00:00Z"
+    )
+    active = _v2_decision(
+        identity, disposition="risk_accepted", expires_at="2026-09-13T11:00:00Z"
+    )
+
+    assert active_decisions([permanent], tmp_path, now=NOW) == []
+    assert active_decisions([expired], tmp_path, now=NOW) == []
+    assert len(active_decisions([active], tmp_path, now=NOW)) == 1
+
+
+def test_fixed_revoked_invalid_and_traversal_decisions_are_inactive(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("def write_report(path):\n    open(path).write('ok')\n")
+    identity = annotate_result_identities(_result(source), tmp_path)["danger"][0]
+    records = [
+        _v2_decision(identity, disposition="fixed"),
+        _v2_decision(identity, revoked_at="2026-09-12T11:00:00Z"),
+        _v2_decision(identity, expires_at="not-a-time"),
+        {
+            "rule_id": "SKY-D215",
+            "file_path": "../app.py",
+            "line_number": 2,
+            "type": "false_positive",
+        },
+    ]
+
+    assert active_decisions(records, tmp_path, now=NOW) == []
+
+
+def test_symlinked_source_cannot_mint_v2_identity(tmp_path):
+    outside = tmp_path / "outside.py"
+    outside.write_text("open(user_path).write('x')\n")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    link = repo / "app.py"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        return
+
+    annotated = annotate_result_identities(_result(link, line=1), repo)
+
+    assert "stable_fingerprint" not in annotated["danger"][0]
+    assert annotated["danger"][0].get("fingerprint_version") != FINGERPRINT_VERSION
+
+
+def test_trusted_cloud_cache_is_local_only_even_with_matching_ci_run(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    cache = tmp_path / "operator-cache"
+    bundle = {"schema": "skylos.reviewed-findings", "version": 2, "decisions": []}
+    env = {"CI": "true", "GITHUB_RUN_ID": "101"}
+
+    path = write_trusted_bundle(
+        repo,
+        bundle,
+        cache_root=cache,
+        fetched_at=NOW,
+        environ=env,
+    )
+
+    assert path is not None
+    assert load_trusted_bundle(repo, cache_root=cache, environ={}, now=NOW) == bundle
+    assert (
+        load_trusted_bundle(
+            repo,
+            cache_root=cache,
+            environ=env,
+            now=NOW,
+        )
+        is None
+    )
+
+
+def test_forged_same_user_cloud_cache_cannot_suppress_in_ci(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    skylos_dir = repo / ".skylos"
+    skylos_dir.mkdir()
+    (skylos_dir / "link.json").write_text(
+        json.dumps({"project_id": "project-a", "projects": {}})
+    )
+    identity = annotate_result_identities(_result(source, line=1), repo)["danger"][0]
+    cache = tmp_path / "cloud-cache"
+    env = {
+        "CI": "true",
+        "GITHUB_RUN_ID": "101",
+        "GITHUB_RUN_ATTEMPT": "1",
+        "GITHUB_JOB": "security",
+    }
+    assert (
+        write_trusted_bundle(
+            repo,
+            {
+                "schema": "skylos.reviewed-findings",
+                "version": 2,
+                "project_id": "project-a",
+                "decisions": [_v2_decision(identity, line_number=1)],
+            },
+            cache_root=cache,
+            fetched_at=NOW,
+            environ=env,
+        )
+        is not None
+    )
+
+    projected = apply_trusted_review_decisions(
+        _result(source, line=1),
+        repo,
+        cache_root=cache,
+        local_cache_root=tmp_path / "local-cache",
+        environ=env,
+        now=NOW,
+    )
+
+    assert len(projected["danger"]) == 1
+    assert projected.get("reviewed_findings", []) == []
+
+
+def test_stale_cloud_cache_fails_open_for_local_scan(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    skylos_dir = repo / ".skylos"
+    skylos_dir.mkdir()
+    (skylos_dir / "link.json").write_text(
+        json.dumps({"project_id": "project-a", "projects": {}})
+    )
+    identity = annotate_result_identities(_result(source, line=1), repo)["danger"][0]
+    cache = tmp_path / "cloud-cache"
+    assert (
+        write_trusted_bundle(
+            repo,
+            {
+                "schema": "skylos.reviewed-findings",
+                "version": 2,
+                "project_id": "project-a",
+                "decisions": [_v2_decision(identity, line_number=1)],
+            },
+            cache_root=cache,
+            fetched_at=NOW - timedelta(hours=25),
+            environ={},
+        )
+        is not None
+    )
+
+    projected = apply_trusted_review_decisions(
+        _result(source, line=1),
+        repo,
+        cache_root=cache,
+        local_cache_root=tmp_path / "local-cache",
+        environ={},
+        now=NOW,
+    )
+
+    assert len(projected["danger"]) == 1
+    assert projected.get("reviewed_findings", []) == []
+
+
+def test_cloud_cache_rejects_malformed_and_future_fetched_at(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    cache = tmp_path / "cloud-cache"
+    bundle = {"schema": REVIEW_SCHEMA, "version": 2, "decisions": []}
+    path = write_trusted_bundle(
+        repo,
+        bundle,
+        cache_root=cache,
+        fetched_at=NOW,
+        environ={},
+    )
+    assert path is not None
+    original = json.loads(path.read_text())
+
+    for invalid in (None, "", "not-a-timestamp", "2026-09-12T12:00:01Z"):
+        payload = json.loads(json.dumps(original))
+        payload["_local_trust"]["fetched_at"] = invalid
+        path.write_text(json.dumps(payload))
+        assert (
+            load_trusted_bundle(
+                repo,
+                cache_root=cache,
+                environ={},
+                now=NOW,
+            )
+            is None
+        )
+
+
+def test_repo_local_forgery_is_not_a_trusted_cache(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    forged_dir = repo / ".skylos"
+    forged_dir.mkdir()
+    forged = {
+        "version": 1,
+        "suppressions": [
+            {"rule_id": "SKY-D215", "file_path": "app.py", "line_number": 1}
+        ],
+    }
+    (forged_dir / "suppressions.json").write_text(json.dumps(forged))
+
+    assert load_trusted_bundle(repo, cache_root=tmp_path / "operator-cache") is None
+
+
+def test_trusted_cache_rejects_cross_repo_copy_and_symlink(tmp_path):
+    first = _git_repo(tmp_path / "first", "https://github.com/acme/one.git")
+    second = _git_repo(tmp_path / "second", "https://github.com/acme/two.git")
+    cache = tmp_path / "operator-cache"
+    bundle = {"version": 2, "decisions": []}
+    first_path = write_trusted_bundle(first, bundle, cache_root=cache, fetched_at=NOW)
+    assert first_path is not None
+
+    second_scope = repository_scope(second)
+    assert second_scope is not None
+    second_path = (
+        cache
+        / __import__("hashlib")
+        .sha256(
+            json.dumps(second_scope, sort_keys=True, separators=(",", ":")).encode()
+        )
+        .hexdigest()
+    )
+    second_path = second_path.with_suffix(".json")
+    second_path.write_bytes(first_path.read_bytes())
+    assert load_trusted_bundle(second, cache_root=cache, now=NOW) is None
+
+    first_path.unlink()
+    try:
+        first_path.symlink_to(second_path)
+    except OSError:
+        return
+    assert load_trusted_bundle(first, cache_root=cache, now=NOW) is None
+
+
+def test_invalidate_trusted_cache_removes_only_regular_bound_file(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    cache = tmp_path / "operator-cache"
+    path = write_trusted_bundle(
+        repo,
+        {"version": 2, "decisions": []},
+        cache_root=cache,
+        fetched_at=NOW,
+    )
+    assert path is not None and path.exists()
+    assert invalidate_trusted_bundle(repo, cache_root=cache) is True
+    assert not path.exists()
+    assert invalidate_trusted_bundle(repo, cache_root=cache) is False
+
+
+def test_force_tracked_repo_suppression_cannot_bypass_strict_gate(tmp_path):
+    from skylos.cli import _strict_scan_exit_code
+
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(user_path).write('unsafe')\n")
+    skylos_dir = repo / ".skylos"
+    skylos_dir.mkdir()
+    (skylos_dir / "suppressions.json").write_text(
+        json.dumps(
+            [
+                {
+                    "rule_id": "SKY-D215",
+                    "file_path": "app.py",
+                    "line_number": 1,
+                    "type": "false_positive",
+                }
+            ]
+        )
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "-f", ".skylos/suppressions.json"],
+        check=True,
+    )
+    result = {
+        "danger": [
+            {
+                "rule_id": "SKY-D215",
+                "file": str(source),
+                "line": 1,
+                "severity": "HIGH",
+                "message": "unsafe path",
+            }
+        ]
+    }
+
+    projected = apply_trusted_review_decisions(
+        result,
+        repo,
+        cache_root=tmp_path / "operator-cache",
+        environ={"CI": "true", "GITHUB_RUN_ID": "44"},
+    )
+
+    assert len(projected["danger"]) == 1
+    assert projected.get("reviewed_findings", []) == []
+    assert (
+        _strict_scan_exit_code(
+            projected,
+            SimpleNamespace(strict=True, gate=False, force=False),
+        )
+        == 1
+    )
+
+
+def test_security_identity_preserves_semantic_whitespace(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("if allowed:\n    open(path).write('a b')\n")
+    identity = annotate_result_identities(_result(source, line=2), tmp_path)["danger"][
+        0
+    ]
+    bundle = {"version": 2, "decisions": [_v2_decision(identity)]}
+
+    source.write_text("if allowed:\nopen(path).write('a b')\n")
+    dedented = apply_review_decisions(
+        _result(source, line=2), bundle, tmp_path, now=NOW
+    )
+    assert len(dedented["danger"]) == 1
+
+    source.write_text("if allowed:\n    open(path).write('a  b')\n")
+    literal_changed = apply_review_decisions(
+        _result(source, line=2), bundle, tmp_path, now=NOW
+    )
+    assert len(literal_changed["danger"]) == 1
+
+
+def test_rule_revision_change_resurfaces_finding(tmp_path, monkeypatch):
+    import skylos.core.review_decisions as review_decisions
+
+    source = tmp_path / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    original = _result(source, line=1)
+    monkeypatch.setattr(review_decisions, "DEFAULT_RULE_REVISION", "rule:7")
+    identity = annotate_result_identities(original, tmp_path)["danger"][0]
+    bundle = {"version": 2, "decisions": [_v2_decision(identity, line_number=1)]}
+    changed = _result(source, line=1)
+    monkeypatch.setattr(review_decisions, "DEFAULT_RULE_REVISION", "rule:8")
+
+    projected = apply_review_decisions(changed, bundle, tmp_path, now=NOW)
+
+    assert len(projected["danger"]) == 1
+
+
+def test_unknown_bundle_schema_cannot_be_laundered_during_merge(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    identity = annotate_result_identities(_result(source, line=1), repo)["danger"][0]
+    cache = tmp_path / "cloud-cache"
+    cache_path = write_trusted_bundle(
+        repo,
+        {
+            "schema": "skylos.reviewed-findings",
+            "version": 2,
+            "project_id": "project-1",
+            "decisions": [_v2_decision(identity, line_number=1)],
+        },
+        cache_root=cache,
+        fetched_at=NOW,
+        environ={},
+    )
+    assert cache_path is not None
+    forged_bundle = json.loads(cache_path.read_text())
+    forged_bundle["schema"] = "future.untrusted-schema"
+    forged_bundle["version"] = 999
+    cache_path.write_text(json.dumps(forged_bundle))
+
+    projected = apply_trusted_review_decisions(
+        _result(source, line=1),
+        repo,
+        cache_root=cache,
+        local_cache_root=tmp_path / "local-cache",
+        environ={},
+        now=NOW,
+    )
+
+    assert len(projected["danger"]) == 1
+
+
+def test_root_synced_decision_applies_when_scanning_subdirectory(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    (repo / ".skylos").mkdir()
+    (repo / ".skylos" / "link.json").write_text(
+        json.dumps({"project_id": "project-1", "projects": {}})
+    )
+    source = repo / "src" / "app.py"
+    source.parent.mkdir()
+    source.write_text("open(path).write('unsafe')\n")
+    identity = annotate_result_identities(_result(source, line=1), repo)["danger"][0]
+    cache = tmp_path / "cloud-cache"
+    assert (
+        write_trusted_bundle(
+            repo,
+            {
+                "schema": "skylos.reviewed-findings",
+                "version": 2,
+                "project_id": "project-1",
+                "decisions": [_v2_decision(identity, line_number=1)],
+            },
+            cache_root=cache,
+            fetched_at=NOW,
+            environ={},
+        )
+        is not None
+    )
+
+    projected = apply_trusted_review_decisions(
+        _result(source, line=1),
+        source.parent,
+        cache_root=cache,
+        local_cache_root=tmp_path / "local-cache",
+        environ={},
+        now=NOW,
+    )
+
+    assert projected["danger"] == []
+
+
+def test_local_decision_round_trip_is_repo_bound_and_ignored_in_ci(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    identity = annotate_result_identities(_result(source, line=1), repo)["danger"][0]
+    decision = _v2_decision(identity, line_number=1)
+    local_cache = tmp_path / "local-cache"
+
+    saved = record_local_decision(
+        repo, decision, cache_root=local_cache, environ={}, now=NOW
+    )
+    assert saved["decision_id"] == "decision-1"
+    assert len(list_local_decisions(repo, cache_root=local_cache, environ={})) == 1
+    projected = apply_trusted_review_decisions(
+        _result(source, line=1),
+        repo,
+        cache_root=tmp_path / "cloud-cache",
+        local_cache_root=local_cache,
+        environ={},
+        now=NOW,
+    )
+    assert projected["danger"] == []
+
+    ci_projected = apply_trusted_review_decisions(
+        _result(source, line=1),
+        repo,
+        cache_root=tmp_path / "cloud-cache",
+        local_cache_root=local_cache,
+        environ={"CI": "true", "GITHUB_RUN_ID": "9", "GITHUB_RUN_ATTEMPT": "1"},
+        now=NOW,
+    )
+    assert len(ci_projected["danger"]) == 1
+    assert (
+        revoke_local_decision(
+            repo, "decision-1", cache_root=local_cache, environ={}, now=NOW
+        )
+        is True
+    )
+    assert list_local_decisions(repo, cache_root=local_cache, environ={}) == []
+
+
+def test_v2_requires_explicit_disposition_strict_line_and_audit_id(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    identity = annotate_result_identities(_result(source, line=1), tmp_path)["danger"][
+        0
+    ]
+    base = _v2_decision(identity, line_number=1)
+    malformed = []
+    for changes in (
+        {"disposition": None, "type": "false_positive"},
+        {"line_number": "1"},
+        {"decision_id": ""},
+        {"revoked_at": ""},
+        {"expires_at": ""},
+        {"status": "disabled"},
+    ):
+        record = dict(base)
+        record.update(changes)
+        malformed.append(record)
+
+    for record in malformed:
+        projected = apply_review_decisions(
+            _result(source, line=1),
+            {"version": 2, "decisions": [record]},
+            tmp_path,
+            now=NOW,
+        )
+        assert len(projected["danger"]) == 1
+
+
+def test_v2_collision_does_not_fall_back_to_legacy(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    identity = annotate_result_identities(_result(source, line=1), tmp_path)["danger"][
+        0
+    ]
+    bundle = {
+        "version": 2,
+        "decisions": [
+            _v2_decision(identity, line_number=1, decision_id="v2-a"),
+            _v2_decision(identity, line_number=1, decision_id="v2-b"),
+            {
+                "rule_id": "SKY-D215",
+                "file_path": "app.py",
+                "line_number": 1,
+                "type": "false_positive",
+            },
+        ],
+    }
+
+    projected = apply_review_decisions(
+        _result(source, line=1), bundle, tmp_path, now=NOW
+    )
+
+    assert len(projected["danger"]) == 1
+
+
+def test_review_projection_drops_stale_aggregates(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    result = _result(source, line=1)
+    result.update(
+        {
+            "grade": {"overall": {"letter": "F"}},
+            "ai_security_stats": {"total_findings": 1},
+            "provenance_summary": {"findings": 1},
+        }
+    )
+    result["analysis_summary"]["by_directory"] = [{"path": ".", "total": 1}]
+    identity = annotate_result_identities(result, tmp_path)["danger"][0]
+
+    projected = apply_review_decisions(
+        result,
+        {"version": 2, "decisions": [_v2_decision(identity, line_number=1)]},
+        tmp_path,
+        now=NOW,
+    )
+
+    assert projected["danger"] == []
+    assert "grade" not in projected
+    assert "ai_security_stats" not in projected
+    assert "provenance_summary" not in projected
+    assert "by_directory" not in projected["analysis_summary"]
+
+
+def test_distant_security_semantic_change_resurfaces_finding(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text(
+        "def write_report(path):\n"
+        "    path = validate_path(path)\n"
+        "    marker = 1\n"
+        "    marker += 1\n"
+        "    marker += 1\n"
+        "    open(path).write('unsafe')\n"
+    )
+    identity = annotate_result_identities(_result(source, line=6), tmp_path)["danger"][
+        0
+    ]
+    bundle = {
+        "version": 2,
+        "decisions": [_v2_decision(identity, line_number=6)],
+    }
+    source.write_text(
+        "def write_report(path):\n"
+        "    path = input()\n"
+        "    marker = 1\n"
+        "    marker += 1\n"
+        "    marker += 1\n"
+        "    open(path).write('unsafe')\n"
+    )
+
+    projected = apply_review_decisions(
+        _result(source, line=6), bundle, tmp_path, now=NOW
+    )
+
+    assert len(projected["danger"]) == 1
+
+
+def test_imported_security_dependency_change_resurfaces_finding(tmp_path):
+    source = tmp_path / "app.py"
+    validator = tmp_path / "validator.py"
+    source.write_text(
+        "from validator import safe_path\n"
+        "def write_report():\n"
+        "    open(safe_path(input())).write('unsafe')\n"
+    )
+    validator.write_text("def safe_path(value):\n    return '/tmp/report'\n")
+    result = _result(source, line=3)
+    identity = annotate_result_identities(result, tmp_path)["danger"][0]
+    bundle = {
+        "version": 2,
+        "decisions": [_v2_decision(identity, line_number=3)],
+    }
+
+    validator.write_text("def safe_path(value):\n    return value\n")
+    projected = apply_review_decisions(result, bundle, tmp_path, now=NOW)
+
+    assert len(projected["danger"]) == 1
+
+
+def test_unimported_python_change_conservatively_invalidates_security_review(tmp_path):
+    source = tmp_path / "app.py"
+    validator = tmp_path / "validator.py"
+    unrelated = tmp_path / "unrelated.py"
+    source.write_text(
+        "from validator import safe_path\n"
+        "def write_report():\n"
+        "    open(safe_path(input())).write('unsafe')\n"
+    )
+    validator.write_text("def safe_path(value):\n    return '/tmp/report'\n")
+    unrelated.write_text("VALUE = 'old'\n")
+    result = _result(source, line=3)
+    identity = annotate_result_identities(result, tmp_path)["danger"][0]
+    bundle = {
+        "version": 2,
+        "decisions": [_v2_decision(identity, line_number=3)],
+    }
+
+    unrelated.write_text("VALUE = 'new'\n")
+    projected = apply_review_decisions(result, bundle, tmp_path, now=NOW)
+
+    assert len(projected["danger"]) == 1
+    assert projected["reviewed_findings"] == []
+
+
+def test_imported_typescript_dependency_change_resurfaces_finding(tmp_path):
+    source = tmp_path / "app.ts"
+    validator = tmp_path / "validator.ts"
+    source.write_text(
+        "import { safePath } from './validator';\n"
+        "export function writeReport(value: string) {\n"
+        "  writeFileSync(safePath(value), 'unsafe');\n"
+        "}\n"
+    )
+    validator.write_text(
+        "export function safePath(value: string) { return '/tmp/report'; }\n"
+    )
+    result = _result(source, line=3)
+    identity = annotate_result_identities(result, tmp_path)["danger"][0]
+    assert identity["fingerprint_version"] == FINGERPRINT_VERSION
+    bundle = {
+        "version": 2,
+        "decisions": [_v2_decision(identity, line_number=3)],
+    }
+
+    validator.write_text("export function safePath(value: string) { return value; }\n")
+    projected = apply_review_decisions(result, bundle, tmp_path, now=NOW)
+
+    assert len(projected["danger"]) == 1
+
+
+def test_typescript_dependency_comment_change_keeps_review_identity(tmp_path):
+    source = tmp_path / "app.ts"
+    validator = tmp_path / "validator.ts"
+    source.write_text(
+        "import { safePath } from './validator';\n"
+        "writeFileSync(safePath(value), 'unsafe');\n"
+    )
+    validator.write_text(
+        "export function safePath(value: string) { return '/tmp/report'; }\n"
+    )
+    result = _result(source, line=2)
+    identity = annotate_result_identities(result, tmp_path)["danger"][0]
+    bundle = {
+        "version": 2,
+        "decisions": [_v2_decision(identity, line_number=2)],
+    }
+
+    validator.write_text(
+        "// documentation only\n"
+        "export function safePath(value: string) { return '/tmp/report'; }\n"
+    )
+    projected = apply_review_decisions(result, bundle, tmp_path, now=NOW)
+
+    assert projected["danger"] == []
+
+
+def test_unresolved_relative_typescript_dependency_abstains_from_identity(tmp_path):
+    source = tmp_path / "app.ts"
+    source.write_text(
+        "import { safePath } from './missing';\n"
+        "writeFileSync(safePath(value), 'unsafe');\n"
+    )
+
+    annotated = annotate_result_identities(_result(source, line=2), tmp_path)
+
+    assert "stable_fingerprint" not in annotated["danger"][0]
+
+
+def test_dynamic_typescript_dependency_abstains_from_identity(tmp_path):
+    source = tmp_path / "app.ts"
+    source.write_text(
+        "const validator = require(process.env.VALIDATOR);\n"
+        "writeFileSync(validator.safePath(value), 'unsafe');\n"
+    )
+
+    annotated = annotate_result_identities(_result(source, line=2), tmp_path)
+
+    assert "stable_fingerprint" not in annotated["danger"][0]
+
+
+def test_go_high_risk_identity_is_bound_to_repository_semantics(tmp_path):
+    source = tmp_path / "main.go"
+    source.write_text("package main\nfunc main() { writeFile(path) }\n")
+
+    annotated = annotate_result_identities(_result(source, line=2), tmp_path)
+    identity = annotated["danger"][0]
+    assert identity["fingerprint_version"] == FINGERPRINT_VERSION
+
+    helper = tmp_path / "helper.go"
+    helper.write_text("package main\nfunc safe() bool { return true }\n")
+    changed = annotate_result_identities(_result(source, line=2), tmp_path)["danger"][0]
+
+    assert identity["stable_fingerprint"] == changed["stable_fingerprint"]
+    assert identity["context_hash"] != changed["context_hash"]
+
+
+def test_distant_semantic_change_resurfaces_high_reliability_finding(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text(
+        "MODE = 'safe'\n"
+        "def connect():\n"
+        "    marker = 1\n"
+        "    marker += 1\n"
+        "    reconnect()\n"
+    )
+    result = {
+        "reliability": [
+            {
+                "rule_id": "SKY-R999",
+                "file": str(source),
+                "line": 5,
+                "severity": "HIGH",
+                "message": "unsafe reconnect",
+            }
+        ]
+    }
+    identity = annotate_result_identities(result, tmp_path)["reliability"][0]
+    decision = _v2_decision(
+        identity,
+        line_number=5,
+        rule_id="SKY-R999",
+    )
+    source.write_text(
+        "MODE = 'unsafe'\n"
+        "def connect():\n"
+        "    marker = 1\n"
+        "    marker += 1\n"
+        "    reconnect()\n"
+    )
+
+    projected = apply_review_decisions(
+        result, {"version": 2, "decisions": [decision]}, tmp_path, now=NOW
+    )
+
+    assert len(projected["reliability"]) == 1
+
+
+def test_forged_identity_on_unreadable_source_cannot_suppress(tmp_path):
+    real = tmp_path / "real.py"
+    real.write_text("open(path).write('unsafe')\n")
+    identity = annotate_result_identities(_result(real, line=1), tmp_path)["danger"][0]
+    bundle = {
+        "version": 2,
+        "decisions": [_v2_decision(identity, line_number=1)],
+    }
+    link = tmp_path / "forged.py"
+    try:
+        link.symlink_to(real)
+    except OSError:
+        return
+    forged = _result(link, line=1)
+    forged["danger"][0].update(
+        {
+            key: identity[key]
+            for key in (
+                "fingerprint_version",
+                "stable_fingerprint",
+                "context_hash",
+                "rule_revision",
+            )
+        }
+    )
+    forged["danger"][0]["review_decision"] = {
+        "decision_id": "forged",
+        "disposition": "false_positive",
+    }
+
+    projected = apply_review_decisions(forged, bundle, tmp_path, now=NOW)
+
+    assert len(projected["danger"]) == 1
+    assert "stable_fingerprint" not in projected["danger"][0]
+    assert "review_decision" not in projected["danger"][0]
+
+
+def test_cloud_cache_must_match_independently_linked_project(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    identity = annotate_result_identities(_result(source, line=1), repo)["danger"][0]
+    cache = tmp_path / "cloud-cache"
+    assert (
+        write_trusted_bundle(
+            repo,
+            {
+                "schema": "skylos.reviewed-findings",
+                "version": 2,
+                "project_id": "project-b",
+                "decisions": [_v2_decision(identity, line_number=1)],
+            },
+            cache_root=cache,
+            fetched_at=NOW,
+            environ={},
+        )
+        is not None
+    )
+    skylos_dir = repo / ".skylos"
+    skylos_dir.mkdir()
+    (skylos_dir / "link.json").write_text(
+        json.dumps({"project_id": "project-a", "projects": {}})
+    )
+
+    projected = apply_trusted_review_decisions(
+        _result(source, line=1),
+        repo,
+        cache_root=cache,
+        local_cache_root=tmp_path / "local-cache",
+        environ={},
+        now=NOW,
+    )
+
+    assert len(projected["danger"]) == 1
+
+
+def test_cloud_cache_requires_current_project_link(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    skylos_dir = repo / ".skylos"
+    skylos_dir.mkdir()
+    link = skylos_dir / "link.json"
+    link_payload = json.dumps({"project_id": "project-a", "projects": {}})
+    link.write_text(link_payload)
+    identity = annotate_result_identities(_result(source, line=1), repo)["danger"][0]
+    cache = tmp_path / "cloud-cache"
+    assert (
+        write_trusted_bundle(
+            repo,
+            {
+                "schema": "skylos.reviewed-findings",
+                "version": 2,
+                "project_id": "project-a",
+                "decisions": [_v2_decision(identity, line_number=1)],
+            },
+            cache_root=cache,
+            fetched_at=NOW,
+            environ={},
+        )
+        is not None
+    )
+
+    link.unlink()
+    without_link = apply_trusted_review_decisions(
+        _result(source, line=1),
+        repo,
+        cache_root=cache,
+        local_cache_root=tmp_path / "local-cache",
+        environ={},
+        now=NOW,
+    )
+    assert len(without_link["danger"]) == 1
+
+    link.write_text(link_payload)
+    linked = apply_trusted_review_decisions(
+        _result(source, line=1),
+        repo,
+        cache_root=cache,
+        local_cache_root=tmp_path / "local-cache",
+        environ={},
+        now=NOW,
+    )
+    assert linked["danger"] == []
+
+    link.unlink()
+    unlinked = apply_trusted_review_decisions(
+        _result(source, line=1),
+        repo,
+        cache_root=cache,
+        local_cache_root=tmp_path / "local-cache",
+        environ={},
+        now=NOW,
+    )
+    assert len(unlinked["danger"]) == 1
+
+
+def test_nested_cloud_project_prefixes_legacy_project_relative_paths(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    project = repo / "packages" / "a"
+    project.mkdir(parents=True)
+    source = project / "app.py"
+    source.write_text("def helper():\n    return 1\n")
+    skylos_dir = repo / ".skylos"
+    skylos_dir.mkdir()
+    (skylos_dir / "link.json").write_text(
+        json.dumps(
+            {
+                "project_id": "project-a",
+                "projects": {
+                    "packages/a": {
+                        "project_id": "project-a",
+                        "repo_subpath": "packages/a",
+                    }
+                },
+            }
+        )
+    )
+    cache = tmp_path / "cloud-cache"
+    assert (
+        write_trusted_bundle(
+            project,
+            {
+                "schema": "skylos.reviewed-findings",
+                "version": 2,
+                "project_id": "project-a",
+                "decisions": [
+                    {
+                        "decision_id": "legacy-1",
+                        "rule_id": "SKY-Q999",
+                        "file_path": "app.py",
+                        "line_number": 2,
+                        "disposition": "false_positive",
+                    }
+                ],
+            },
+            cache_root=cache,
+            fetched_at=NOW,
+            environ={},
+        )
+        is not None
+    )
+    result = {
+        "quality": [
+            {
+                "rule_id": "SKY-Q999",
+                "file": str(source),
+                "line": 2,
+                "severity": "LOW",
+                "message": "review helper",
+            }
+        ]
+    }
+
+    projected = apply_trusted_review_decisions(
+        result,
+        project,
+        cache_root=cache,
+        local_cache_root=tmp_path / "local-cache",
+        environ={},
+        now=NOW,
+    )
+
+    assert projected["quality"] == []
+    assert projected["reviewed_findings"][0]["review_decision"]["decision_id"] == (
+        "legacy-1"
+    )
+
+
+def test_tree_sitter_semantic_hash_distinguishes_javascript_asi():
+    from skylos.core.review_decisions import _semantic_source_hash
+
+    with_newline = "function value() { return\nuserInput() }\n"
+    same_line = "function value() { return userInput() }\n"
+
+    assert _semantic_source_hash(with_newline, "javascript", ".js") != (
+        _semantic_source_hash(same_line, "javascript", ".js")
+    )
+
+
+def test_projection_only_fingerprints_findings_targeted_by_active_decisions(
+    tmp_path, monkeypatch
+):
+    target = tmp_path / "app.py"
+    target.write_text("def write_report(path):\n    open(path, 'w').write('ok')\n")
+    result = _result(target)
+    for index in range(50):
+        source = tmp_path / f"helper_{index}.py"
+        source.write_text(f"value_{index} = {index}\n")
+        result.setdefault("quality", []).append(
+            {
+                "rule_id": "SKY-Q999",
+                "file": str(source),
+                "line": 1,
+                "severity": "LOW",
+                "message": "unrelated quality finding",
+            }
+        )
+    identity = annotate_result_identities(_result(target), tmp_path)["danger"][0]
+    calls = []
+    real_finding_identity = review_decisions.finding_identity
+
+    def counted_identity(*args, **kwargs):
+        calls.append((kwargs["section"], kwargs["default_rule_id"]))
+        return real_finding_identity(*args, **kwargs)
+
+    monkeypatch.setattr(review_decisions, "finding_identity", counted_identity)
+    projected = apply_review_decisions(
+        result,
+        [_v2_decision(identity)],
+        tmp_path,
+        now=NOW,
+        include_identities=False,
+    )
+
+    assert projected["danger"] == []
+    assert len(projected["quality"]) == 50
+    assert all("stable_fingerprint" not in item for item in projected["quality"])
+    assert calls == [("danger", "SKY-D000")]
+
+
+def test_trusted_projection_reads_staged_snapshot_instead_of_worktree(tmp_path):
+    project = _git_repo(tmp_path / "repo")
+    worktree_source = project / "app.py"
+    worktree_source.write_text(
+        "def write_report(path):\n    safe_wrapper(path)\n",
+        encoding="utf-8",
+    )
+    staged_root = tmp_path / "staged-snapshot"
+    staged_root.mkdir()
+    staged_source = staged_root / "app.py"
+    staged_source.write_text(
+        "def write_report(path):\n    open(path, 'w').write('unsafe')\n",
+        encoding="utf-8",
+    )
+    staged_result = _result(staged_source)
+    staged_identity = annotate_result_identities(staged_result, staged_root)["danger"][
+        0
+    ]
+    local_cache = tmp_path / "local-review-cache"
+    record_local_decision(
+        project,
+        _v2_decision(staged_identity),
+        cache_root=local_cache,
+        environ={},
+        now=NOW,
+    )
+
+    projected_staged = apply_trusted_review_decisions(
+        staged_result,
+        project,
+        analysis_root=staged_root,
+        cache_root=tmp_path / "cloud-review-cache",
+        local_cache_root=local_cache,
+        environ={},
+        now=NOW,
+    )
+    projected_worktree = apply_trusted_review_decisions(
+        _result(worktree_source),
+        project,
+        cache_root=tmp_path / "cloud-review-cache",
+        local_cache_root=local_cache,
+        environ={},
+        now=NOW,
+    )
+
+    assert projected_staged["danger"] == []
+    assert len(projected_staged["reviewed_findings"]) == 1
+    assert len(projected_worktree["danger"]) == 1
+    assert projected_worktree["reviewed_findings"] == []
+
+
+def test_trusted_projection_rejects_symlink_analysis_root(tmp_path):
+    project = _git_repo(tmp_path / "repo")
+    source = project / "app.py"
+    source.write_text("def write_report(path):\n    open(path, 'w')\n", encoding="utf-8")
+    linked_root = tmp_path / "linked-analysis-root"
+    try:
+        linked_root.symlink_to(project, target_is_directory=True)
+    except OSError:
+        pytest.skip("filesystem does not allow symlink creation")
+    result = _result(source)
+
+    projected = apply_trusted_review_decisions(
+        result,
+        project,
+        analysis_root=linked_root,
+        include_identities=True,
+        cache_root=tmp_path / "cloud-review-cache",
+        local_cache_root=tmp_path / "local-review-cache",
+        environ={},
+        now=NOW,
+    )
+
+    assert projected["danger"] == result["danger"]
+    assert "stable_fingerprint" not in projected["danger"][0]

--- a/test/test_review_memory_adversarial.py
+++ b/test/test_review_memory_adversarial.py
@@ -10,6 +10,7 @@ import skylos.core.review_decisions as review_decisions
 from skylos.api._findings import _normalize_findings
 from skylos.api._payloads import _compact_upload_finding
 from skylos.cli import _apply_display_filters
+from skylos.core.safe_cache_io import read_text_no_symlink, write_text_no_symlink
 
 
 NOW = datetime(2026, 9, 12, 12, 0, tzinfo=timezone.utc)
@@ -78,9 +79,11 @@ def _record_then_corrupt_with_deep_extra(repo, source, cache):
         now=NOW,
     )
     path = next(cache.glob("*.json"))
-    payload = json.loads(path.read_text())
+    serialized = read_text_no_symlink(path, max_bytes=1_000_000)
+    assert serialized is not None
+    payload = json.loads(serialized)
     payload["decisions"][0]["unexpected"] = _nested_list(500)
-    path.write_text(json.dumps(payload))
+    assert write_text_no_symlink(path, json.dumps(payload))
 
 
 def test_deep_local_record_is_inactive_instead_of_suppressing(tmp_path):
@@ -127,7 +130,9 @@ def test_deep_untrusted_finding_metadata_cannot_crash_projection(tmp_path):
     source = tmp_path / "app.py"
     source.write_text("open(path).write('unsafe')\n")
     result = _result(source)
-    identity = review_decisions.annotate_result_identities(result, tmp_path)["danger"][0]
+    identity = review_decisions.annotate_result_identities(result, tmp_path)["danger"][
+        0
+    ]
     result["danger"][0]["metadata"] = {"unexpected": _nested_list(500)}
 
     projected = review_decisions.apply_review_decisions(
@@ -137,9 +142,10 @@ def test_deep_untrusted_finding_metadata_cannot_crash_projection(tmp_path):
         now=NOW,
     )
 
-    assert len(projected.get("danger", [])) + len(
-        projected.get("reviewed_findings", [])
-    ) == 1
+    assert (
+        len(projected.get("danger", [])) + len(projected.get("reviewed_findings", []))
+        == 1
+    )
 
 
 def test_deep_cloud_json_fails_open_without_crashing(tmp_path):
@@ -180,13 +186,16 @@ def test_ci_rejects_cloud_cache_even_when_attempt_and_job_match(tmp_path):
         "GITHUB_RUN_ATTEMPT": "2",
         "GITHUB_JOB": "security-scan",
     }
-    assert review_decisions.write_trusted_bundle(
-        repo,
-        bundle,
-        cache_root=cache,
-        fetched_at=NOW,
-        environ=env,
-    ) is not None
+    assert (
+        review_decisions.write_trusted_bundle(
+            repo,
+            bundle,
+            cache_root=cache,
+            fetched_at=NOW,
+            environ=env,
+        )
+        is not None
+    )
 
     for candidate_env in (
         env,
@@ -404,10 +413,10 @@ def _assert_python_dependency_change_resurfaces(
     assert before["fingerprint_version"] == review_decisions.FINGERPRINT_VERSION
     decision = _decision(before, line_number=line)
 
-    dependency.write_text(replacement)
-    after = review_decisions.annotate_result_identities(result, project_root)[
-        "danger"
-    ][0]
+    assert write_text_no_symlink(dependency, replacement)
+    after = review_decisions.annotate_result_identities(result, project_root)["danger"][
+        0
+    ]
 
     assert before["stable_fingerprint"] == after["stable_fingerprint"]
     assert before["context_hash"] != after["context_hash"]

--- a/test/test_review_memory_adversarial.py
+++ b/test/test_review_memory_adversarial.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+
+import pytest
+
+import skylos.core.review_decisions as review_decisions
+from skylos.api._findings import _normalize_findings
+from skylos.api._payloads import _compact_upload_finding
+from skylos.cli import _apply_display_filters
+
+
+NOW = datetime(2026, 9, 12, 12, 0, tzinfo=timezone.utc)
+
+
+def _git_repo(path, remote="https://github.com/acme/review-qa.git"):
+    path.mkdir()
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(path), "remote", "add", "origin", remote],
+        check=True,
+    )
+    return path.resolve()
+
+
+def _result(source, *, line=1):
+    return {
+        "danger": [
+            {
+                "rule_id": "SKY-D215",
+                "file": str(source),
+                "line": line,
+                "symbol": "write_report",
+                "severity": "HIGH",
+                "message": "unsafe path",
+            }
+        ],
+        "analysis_summary": {"danger_count": 1},
+    }
+
+
+def _decision(identity, **overrides):
+    decision = {
+        "decision_id": "decision-qa-1",
+        "fingerprint_version": identity["fingerprint_version"],
+        "stable_fingerprint": identity["stable_fingerprint"],
+        "context_hash": identity["context_hash"],
+        "rule_revision": identity["rule_revision"],
+        "rule_id": identity["rule_id"],
+        "file_path": identity["file_path"],
+        "line_number": 1,
+        "disposition": "false_positive",
+        "reason": "reviewed safe wrapper",
+        "created_at": "2026-09-12T10:00:00Z",
+    }
+    decision.update(overrides)
+    return decision
+
+
+def _nested_list(depth):
+    value = "leaf"
+    for _ in range(depth):
+        value = [value]
+    return value
+
+
+def _record_then_corrupt_with_deep_extra(repo, source, cache):
+    identity = review_decisions.annotate_result_identities(_result(source), repo)[
+        "danger"
+    ][0]
+    review_decisions.record_local_decision(
+        repo,
+        _decision(identity),
+        cache_root=cache,
+        environ={},
+        now=NOW,
+    )
+    path = next(cache.glob("*.json"))
+    payload = json.loads(path.read_text())
+    payload["decisions"][0]["unexpected"] = _nested_list(500)
+    path.write_text(json.dumps(payload))
+
+
+def test_deep_local_record_is_inactive_instead_of_suppressing(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    cache = tmp_path / "local-cache"
+    _record_then_corrupt_with_deep_extra(repo, source, cache)
+
+    projected = review_decisions.apply_trusted_review_decisions(
+        _result(source),
+        repo,
+        cache_root=tmp_path / "cloud-cache",
+        local_cache_root=cache,
+        environ={},
+        now=NOW,
+    )
+
+    assert len(projected["danger"]) == 1
+    assert projected.get("reviewed_findings", []) == []
+
+
+def test_deep_local_record_listing_fails_cleanly(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    cache = tmp_path / "local-cache"
+    _record_then_corrupt_with_deep_extra(repo, source, cache)
+
+    try:
+        listed = review_decisions.list_local_decisions(
+            repo,
+            include_revoked=True,
+            cache_root=cache,
+            environ={},
+        )
+    except ValueError:
+        listed = []
+
+    assert listed == []
+
+
+def test_deep_untrusted_finding_metadata_cannot_crash_projection(tmp_path):
+    source = tmp_path / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    result = _result(source)
+    identity = review_decisions.annotate_result_identities(result, tmp_path)["danger"][0]
+    result["danger"][0]["metadata"] = {"unexpected": _nested_list(500)}
+
+    projected = review_decisions.apply_review_decisions(
+        result,
+        [_decision(identity)],
+        tmp_path,
+        now=NOW,
+    )
+
+    assert len(projected.get("danger", [])) + len(
+        projected.get("reviewed_findings", [])
+    ) == 1
+
+
+def test_deep_cloud_json_fails_open_without_crashing(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    cache = tmp_path / "cloud-cache"
+    path = review_decisions.write_trusted_bundle(
+        repo,
+        {"version": 2, "decisions": []},
+        cache_root=cache,
+        fetched_at=NOW,
+        environ={},
+    )
+    assert path is not None
+    deep_json = "[" * 2_000 + "0" + "]" * 2_000
+    path.write_text('{"unexpected":' + deep_json + "}")
+
+    projected = review_decisions.apply_trusted_review_decisions(
+        _result(source),
+        repo,
+        cache_root=cache,
+        local_cache_root=tmp_path / "local-cache",
+        environ={},
+        now=NOW,
+    )
+
+    assert len(projected["danger"]) == 1
+
+
+def test_ci_rejects_cloud_cache_even_when_attempt_and_job_match(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    cache = tmp_path / "cloud-cache"
+    bundle = {"version": 2, "decisions": []}
+    env = {
+        "CI": "true",
+        "GITHUB_RUN_ID": "101",
+        "GITHUB_RUN_ATTEMPT": "2",
+        "GITHUB_JOB": "security-scan",
+    }
+    assert review_decisions.write_trusted_bundle(
+        repo,
+        bundle,
+        cache_root=cache,
+        fetched_at=NOW,
+        environ=env,
+    ) is not None
+
+    for candidate_env in (
+        env,
+        {**env, "GITHUB_RUN_ATTEMPT": "3"},
+        {**env, "GITHUB_JOB": "different-job"},
+    ):
+        assert (
+            review_decisions.load_trusted_bundle(
+                repo,
+                cache_root=cache,
+                environ=candidate_env,
+                now=NOW,
+            )
+            is None
+        )
+
+
+def test_compact_upload_preserves_v2_identity_and_trusted_review_audit():
+    finding = {
+        "rule_id": "SKY-D215",
+        "file_path": "app.py",
+        "line_number": 2,
+        "message": "unsafe path",
+        "severity": "HIGH",
+        "fingerprint_version": "skylos-finding-v2",
+        "stable_fingerprint": "sha256:" + "a" * 64,
+        "context_hash": "sha256:" + "b" * 64,
+        "rule_revision": "skylos:4.36.1",
+        "language": "python",
+        "symbol": "write_report",
+        "_skylos_trusted_review": True,
+        "review_decision": {
+            "decision_id": "decision-1",
+            "disposition": "false_positive",
+            "match_mode": "v2_exact_context",
+        },
+    }
+
+    normalized = _normalize_findings(
+        [finding],
+        "SECURITY",
+        None,
+        extract_metadata=True,
+        analyzer_owned=True,
+    )[0]
+    compact = _compact_upload_finding(normalized, include_snippet=False)
+
+    assert compact["metadata"] == {
+        "fingerprint_version": "skylos-finding-v2",
+        "stable_fingerprint": "sha256:" + "a" * 64,
+        "context_hash": "sha256:" + "b" * 64,
+        "rule_revision": "skylos:4.36.1",
+        "language": "python",
+        "symbol": "write_report",
+        "review_decision": {
+            "decision_id": "decision-1",
+            "disposition": "false_positive",
+            "match_mode": "v2_exact_context",
+        },
+    }
+
+
+def test_display_filters_keep_review_summary_counts_consistent():
+    result = {
+        "danger": [],
+        "quality": [],
+        "reviewed_findings": [
+            {
+                "section": "danger",
+                "category": "SECURITY",
+                "severity": "HIGH",
+                "file": "src/keep.py",
+            },
+            {
+                "section": "quality",
+                "category": "QUALITY",
+                "severity": "LOW",
+                "file": "src/drop.py",
+            },
+        ],
+        "reviewed_findings_summary": {
+            "suppressed_count": 2,
+            "active_decision_count": 2,
+        },
+        "analysis_summary": {
+            "reviewed_findings": {
+                "suppressed_count": 2,
+                "active_decision_count": 2,
+            }
+        },
+    }
+
+    filtered = _apply_display_filters(
+        result,
+        severity="high",
+        category="security",
+        file_filter="keep.py",
+    )
+
+    assert len(filtered["reviewed_findings"]) == 1
+    assert filtered["reviewed_findings_summary"]["suppressed_count"] == 1
+    assert filtered["analysis_summary"]["reviewed_findings"]["suppressed_count"] == 1
+
+
+@pytest.mark.parametrize("state", ["empty", "expired"])
+def test_inactive_cache_does_not_compute_finding_identities(
+    tmp_path, monkeypatch, state
+):
+    repo = _git_repo(tmp_path / "repo")
+    source = repo / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    cloud_cache = tmp_path / "cloud-cache"
+    local_cache = tmp_path / "local-cache"
+    cloud_cache.mkdir()
+    local_cache.mkdir()
+    if state == "expired":
+        identity = review_decisions.annotate_result_identities(_result(source), repo)[
+            "danger"
+        ][0]
+        review_decisions.write_trusted_bundle(
+            repo,
+            {
+                "version": 2,
+                "project_id": "project-1",
+                "decisions": [
+                    _decision(
+                        identity,
+                        disposition="risk_accepted",
+                        expires_at="2026-09-12T11:00:00Z",
+                    )
+                ],
+            },
+            cache_root=cloud_cache,
+            fetched_at=NOW,
+            environ={},
+        )
+    monkeypatch.setattr(
+        review_decisions,
+        "annotate_result_identities",
+        lambda *_args, **_kwargs: pytest.fail(
+            "inactive decision state must not read sources or compute identities"
+        ),
+    )
+
+    projected = review_decisions.apply_trusted_review_decisions(
+        _result(source),
+        repo,
+        cache_root=cloud_cache,
+        local_cache_root=local_cache,
+        environ={},
+        now=NOW,
+    )
+
+    assert len(projected["danger"]) == 1
+
+
+def test_symlinked_parent_cannot_mint_finding_identity(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    real = repo / "real"
+    real.mkdir()
+    source = real / "app.py"
+    source.write_text("open(path).write('unsafe')\n")
+    linked = repo / "linked"
+    try:
+        linked.symlink_to(real, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+
+    annotated = review_decisions.annotate_result_identities(
+        _result(linked / "app.py"),
+        repo,
+    )
+
+    assert "stable_fingerprint" not in annotated["danger"][0]
+
+
+def test_empty_file_finding_can_receive_review_identity(tmp_path):
+    source = tmp_path / "empty_module.py"
+    source.write_text("")
+    result = {
+        "unused_files": [
+            {
+                "rule_id": "SKY-E002",
+                "file": str(source),
+                "line": 1,
+                "severity": "LOW",
+                "category": "DEAD_CODE",
+                "message": "Empty Python file",
+            }
+        ]
+    }
+
+    finding = review_decisions.annotate_result_identities(result, tmp_path)[
+        "unused_files"
+    ][0]
+
+    assert finding["fingerprint_version"] == review_decisions.FINGERPRINT_VERSION
+    assert finding["stable_fingerprint"].startswith("sha256:")
+    assert finding["context_hash"].startswith("sha256:")
+
+
+def _assert_python_dependency_change_resurfaces(
+    project_root,
+    source,
+    dependency,
+    *,
+    line,
+    replacement,
+):
+    result = _result(source, line=line)
+    before = review_decisions.annotate_result_identities(result, project_root)[
+        "danger"
+    ][0]
+    assert before["fingerprint_version"] == review_decisions.FINGERPRINT_VERSION
+    decision = _decision(before, line_number=line)
+
+    dependency.write_text(replacement)
+    after = review_decisions.annotate_result_identities(result, project_root)[
+        "danger"
+    ][0]
+
+    assert before["stable_fingerprint"] == after["stable_fingerprint"]
+    assert before["context_hash"] != after["context_hash"]
+    projected = review_decisions.apply_review_decisions(
+        result,
+        {"version": 2, "decisions": [decision]},
+        project_root,
+        now=NOW,
+    )
+    assert len(projected["danger"]) == 1
+    assert projected.get("reviewed_findings", []) == []
+
+
+def test_python_parent_package_initializer_change_resurfaces_security_finding(
+    tmp_path,
+):
+    package = tmp_path / "pkg"
+    package.mkdir()
+    initializer = package / "__init__.py"
+    initializer.write_text("POLICY = 'strict'\n")
+    validator = package / "validator.py"
+    validator.write_text("def safe_path(value):\n    return '/tmp/report'\n")
+    source = tmp_path / "app.py"
+    source.write_text(
+        "from pkg.validator import safe_path\n"
+        "def write_report(value):\n"
+        "    open(safe_path(value)).write('unsafe')\n"
+    )
+
+    _assert_python_dependency_change_resurfaces(
+        tmp_path,
+        source,
+        initializer,
+        line=3,
+        replacement="POLICY = 'permissive'\n",
+    )
+
+
+def test_literal_dunder_import_dependency_change_resurfaces_security_finding(
+    tmp_path,
+):
+    validator = tmp_path / "validator.py"
+    validator.write_text("def safe_path(value):\n    return '/tmp/report'\n")
+    source = tmp_path / "app.py"
+    source.write_text(
+        "validator = __import__('validator')\n"
+        "def write_report(value):\n"
+        "    open(validator.safe_path(value)).write('unsafe')\n"
+    )
+
+    _assert_python_dependency_change_resurfaces(
+        tmp_path,
+        source,
+        validator,
+        line=3,
+        replacement="def safe_path(value):\n    return value\n",
+    )
+
+
+def test_configured_root_python_dependency_change_resurfaces_security_finding(
+    tmp_path,
+):
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.setuptools]\npackage-dir = {"" = "vendor"}\n'
+    )
+    package = tmp_path / "vendor" / "acme"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("")
+    validator = package / "validator.py"
+    validator.write_text("def safe_path(value):\n    return '/tmp/report'\n")
+    source = tmp_path / "app.py"
+    source.write_text(
+        "import acme.validator\n"
+        "def write_report(value):\n"
+        "    open(acme.validator.safe_path(value)).write('unsafe')\n"
+    )
+
+    _assert_python_dependency_change_resurfaces(
+        tmp_path,
+        source,
+        validator,
+        line=3,
+        replacement="def safe_path(value):\n    return value\n",
+    )
+
+
+def test_transitive_relative_python_dependency_change_resurfaces_security_finding(
+    tmp_path,
+):
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("")
+    validator = package / "validator.py"
+    validator.write_text("def safe_path(value):\n    return '/tmp/report'\n")
+    bridge = package / "bridge.py"
+    bridge.write_text("from .validator import safe_path\n")
+    source = package / "app.py"
+    source.write_text(
+        "from .bridge import safe_path\n"
+        "def write_report(value):\n"
+        "    open(safe_path(value)).write('unsafe')\n"
+    )
+
+    _assert_python_dependency_change_resurfaces(
+        tmp_path,
+        source,
+        validator,
+        line=3,
+        replacement="def safe_path(value):\n    return value\n",
+    )
+
+
+def test_nonliteral_typescript_import_abstains_from_security_identity(tmp_path):
+    source = tmp_path / "app.ts"
+    source.write_text(
+        "const moduleName = process.env.VALIDATOR;\n"
+        "const validator = await import(moduleName);\n"
+        "writeFileSync(validator.safePath(value), 'unsafe');\n"
+    )
+
+    annotated = review_decisions.annotate_result_identities(
+        _result(source, line=3),
+        tmp_path,
+    )
+
+    assert "stable_fingerprint" not in annotated["danger"][0]
+    assert "context_hash" not in annotated["danger"][0]

--- a/test/test_review_mutation_guards.py
+++ b/test/test_review_mutation_guards.py
@@ -11,6 +11,7 @@ import pytest
 
 import skylos.cli as cli
 from skylos.commands import clean_cmd, review_cmd
+from skylos.core.safe_cache_io import write_text_no_symlink
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -22,13 +23,37 @@ def _git(repo: Path, *args: str) -> str:
     ).stdout.strip()
 
 
+def test_agent_verify_json_output_rejects_symlink(tmp_path):
+    from skylos.commands import agent_verify_cmd
+
+    victim = tmp_path / "victim.json"
+    assert write_text_no_symlink(victim, "original\n")
+    output = tmp_path / "verify.json"
+    try:
+        output.symlink_to(victim)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+
+    console = Mock()
+    args = SimpleNamespace(format="json", output=str(output))
+
+    assert not agent_verify_cmd._write_or_print_verify_result(
+        args,
+        console,
+        {"verified_findings": []},
+    )
+    assert victim.read_text(encoding="utf-8") == "original\n"
+    assert output.is_symlink()
+    assert "Cannot safely write output" in str(console.print.call_args)
+
+
 def _reviewed_dead_code_repo(tmp_path: Path, monkeypatch) -> tuple[Path, Path, str]:
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(repo, "init", "-q")
     source = repo / "app.py"
     original = "def reviewed_orphan():\n    return 1\n"
-    source.write_text(original, encoding="utf-8")
+    assert write_text_no_symlink(source, original)
     _git(repo, "add", "app.py")
     _git(
         repo,

--- a/test/test_review_mutation_guards.py
+++ b/test/test_review_mutation_guards.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+import skylos.cli as cli
+from skylos.commands import clean_cmd, review_cmd
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _reviewed_dead_code_repo(tmp_path: Path, monkeypatch) -> tuple[Path, Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    source = repo / "app.py"
+    original = "def reviewed_orphan():\n    return 1\n"
+    source.write_text(original, encoding="utf-8")
+    _git(repo, "add", "app.py")
+    _git(
+        repo,
+        "-c",
+        "user.name=Skylos Test",
+        "-c",
+        "user.email=skylos-test@example.invalid",
+        "commit",
+        "-qm",
+        "fixture",
+    )
+
+    cloud_cache = tmp_path / "reviewed-findings"
+    local_cache = tmp_path / "local-review-decisions"
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "_cache_root",
+        lambda value=None: (
+            Path(value).expanduser() if value is not None else cloud_cache
+        ),
+    )
+    monkeypatch.setattr(
+        review_cmd.review_decisions,
+        "_local_cache_root",
+        lambda value=None: (
+            Path(value).expanduser() if value is not None else local_cache
+        ),
+    )
+    for key in (
+        "CI",
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_JOB",
+        "CI_PIPELINE_ID",
+        "BUILD_BUILDID",
+        "CIRCLE_WORKFLOW_ID",
+        "BUILD_TAG",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    def choose_dead(_console, findings, _input_fn):
+        return next(
+            finding
+            for finding in findings
+            if finding.get("_review_category") == "DEAD_CODE"
+            and finding.get("symbol") == "reviewed_orphan"
+        )
+
+    monkeypatch.setattr(review_cmd, "_choose_finding", choose_dead)
+    answers = iter(["1", "registered runtime callback"])
+    assert (
+        review_cmd.run_review_command(
+            [str(repo)],
+            input_fn=lambda _prompt: next(answers),
+            environ={},
+        )
+        == 0
+    )
+    return repo, source, original
+
+
+@pytest.mark.parametrize("comment_out", [False, True])
+def test_clean_never_edits_a_reviewed_dead_finding(
+    tmp_path,
+    monkeypatch,
+    comment_out,
+):
+    repo, source, original = _reviewed_dead_code_repo(tmp_path, monkeypatch)
+    analyze_calls = []
+    real_analyze = clean_cmd.run_analyze
+
+    def capture_analyze(*args, **kwargs):
+        analyze_calls.append(kwargs)
+        return real_analyze(*args, **kwargs)
+
+    monkeypatch.setattr(clean_cmd, "run_analyze", capture_analyze)
+    args = [str(repo), "--apply", "--confidence", "60"]
+    if comment_out:
+        args.append("--comment-out")
+
+    with (
+        patch(
+            "skylos.commands.clean_cmd.remove_unused_function_cst",
+            side_effect=AssertionError("reviewed function must not be removed"),
+        ),
+        patch(
+            "skylos.commands.clean_cmd.comment_out_unused_function_cst",
+            side_effect=AssertionError("reviewed function must not be commented"),
+        ),
+    ):
+        assert clean_cmd.run_clean_command(args) == 0
+
+    assert analyze_calls[0]["include_review_proofs"] is True
+    assert source.read_text(encoding="utf-8") == original
+    assert _git(repo, "status", "--porcelain") == ""
+
+
+@pytest.mark.parametrize("mutation_flag", ["--apply", "--pr"])
+def test_agent_verify_never_edits_or_commits_a_reviewed_dead_finding(
+    tmp_path,
+    monkeypatch,
+    mutation_flag,
+):
+    repo, source, original = _reviewed_dead_code_repo(tmp_path, monkeypatch)
+    before_head = _git(repo, "rev-parse", "HEAD")
+    before_branch = _git(repo, "branch", "--show-current")
+
+    from skylos.analyzer import analyze as real_analyze
+
+    analyze_calls = []
+
+    def capture_analyze(*args, **kwargs):
+        analyze_calls.append(kwargs)
+        return real_analyze(*args, **kwargs)
+
+    monkeypatch.setattr("skylos.analyzer.analyze", capture_analyze)
+    monkeypatch.setattr(
+        cli,
+        "resolve_llm_runtime",
+        lambda **_kwargs: ("openai", "fake-key", None, False),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "skylos",
+            "agent",
+            "verify",
+            str(repo),
+            "--fix",
+            mutation_flag,
+        ],
+    )
+
+    with patch(
+        "skylos.llm.harness.run_verification_harness",
+        side_effect=AssertionError("reviewed finding must not reach verification"),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+
+    assert exc.value.code == 0
+    assert analyze_calls[0]["include_review_proofs"] is True
+    assert source.read_text(encoding="utf-8") == original
+    assert _git(repo, "rev-parse", "HEAD") == before_head
+    assert _git(repo, "branch", "--show-current") == before_branch
+    assert _git(repo, "status", "--porcelain") == ""
+
+
+def test_agent_verify_cannot_rediscover_a_reviewed_definition_for_a_fix(
+    tmp_path,
+    monkeypatch,
+):
+    from skylos.commands import agent_verify_cmd
+
+    reviewed_file = tmp_path / "reviewed.py"
+    active_file = tmp_path / "active.py"
+    reviewed_file.write_text("def reviewed():\n    return 1\n", encoding="utf-8")
+    active_file.write_text("def active():\n    return 2\n", encoding="utf-8")
+    reviewed = {
+        "name": "reviewed",
+        "full_name": "reviewed.reviewed",
+        "file": str(reviewed_file),
+        "line": 1,
+        "category": "DEAD_CODE",
+        "_llm_verdict": "TRUE_POSITIVE",
+    }
+    active = {
+        "name": "active",
+        "full_name": "active.active",
+        "file": str(active_file),
+        "line": 1,
+        "confidence": 100,
+        "_llm_verdict": "TRUE_POSITIVE",
+    }
+    projected = {
+        "unused_functions": [active],
+        "reviewed_findings": [reviewed],
+        "definitions": {
+            "reviewed.reviewed": {
+                "file": str(reviewed_file),
+                "line": 1,
+                "type": "function",
+                "heuristic_refs": {"callback": 0.5},
+            },
+            "active.active": {
+                "file": str(active_file),
+                "line": 1,
+                "type": "function",
+            },
+        },
+    }
+    seen_defs = {}
+
+    def verify(_args, _path, *, findings, defs_map, **_kwargs):
+        assert findings == [active]
+        seen_defs.update(defs_map)
+        return {
+            "verified_findings": [reviewed, active],
+            "new_dead_code": [],
+            "entry_points": [],
+            "stats": {
+                "total_findings": 2,
+                "verified_true_positive": 2,
+                "verified_false_positive": 0,
+                "uncertain": 0,
+                "entry_points_discovered": 0,
+                "survivors_challenged": 0,
+                "survivors_reclassified_dead": 0,
+                "llm_calls": 1,
+                "elapsed_seconds": 0.1,
+            },
+        }
+
+    generated = []
+
+    def generate(_args, _defs_map, findings, _project_root):
+        generated.extend(findings)
+        return []
+
+    args = SimpleNamespace(
+        path=str(tmp_path),
+        conf=60,
+        format="table",
+        fix=True,
+        apply=True,
+        pr=False,
+    )
+    with (
+        patch.object(
+            agent_verify_cmd,
+            "_run_static_dead_code_scan",
+            return_value={"unused_functions": [active]},
+        ) as scan,
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(True, True),
+        ),
+        patch(
+            "skylos.core.review_decisions.apply_trusted_review_decisions",
+            return_value=projected,
+        ),
+        patch.object(agent_verify_cmd, "_run_verification_harness", verify),
+        patch.object(agent_verify_cmd, "_generate_verify_patches", generate),
+    ):
+        assert (
+            agent_verify_cmd.run_agent_verify_command(
+                args,
+                Mock(),
+                model="test-model",
+                api_key=None,
+                provider=None,
+                base_url=None,
+                exclude_folders=[],
+                upload_agent_run=Mock(),
+            )
+            == 0
+        )
+
+    assert scan.call_args.kwargs["include_review_proofs"] is True
+    assert "reviewed.reviewed" not in seen_defs
+    assert "active.active" in seen_defs
+    assert generated == [active]

--- a/test/test_sarif_exporter.py
+++ b/test/test_sarif_exporter.py
@@ -544,3 +544,58 @@ def test_results_include_dead_code_classification_and_evidence():
     assert evidence["classification"] == "likely_dead"
     assert evidence["disposition"] == "reported"
     assert evidence["events"][0]["source"] == "analyzer"
+
+
+def test_reviewed_finding_remains_in_sarif_with_external_suppression():
+    finding = {
+        "rule_id": "SKY-D215",
+        "severity": "HIGH",
+        "message": "Possible unsafe path",
+        "file_path": "app.py",
+        "line_number": 5,
+        "category": "SECURITY",
+        "_skylos_trusted_review": True,
+        "review_decision": {
+            "decision_id": "decision-1",
+            "disposition": "false_positive",
+            "reason": "Validated safe wrapper",
+            "match_mode": "v2_exact_context",
+        },
+    }
+
+    result = SarifExporter([finding], analyzer_owned=True).generate()["runs"][0][
+        "results"
+    ][0]
+
+    assert result["suppressions"] == [
+        {
+            "kind": "external",
+            "status": "accepted",
+            "justification": "Validated safe wrapper",
+        }
+    ]
+    assert result["properties"]["skylos_review_decision"]["decision_id"] == (
+        "decision-1"
+    )
+
+
+def test_untrusted_review_fields_cannot_self_suppress_sarif():
+    finding = {
+        "rule_id": "SKY-D215",
+        "severity": "HIGH",
+        "message": "Possible unsafe path",
+        "file_path": "app.py",
+        "line_number": 5,
+        "category": "SECURITY",
+        "review_decision": {
+            "decision_id": "forged",
+            "disposition": "false_positive",
+            "reason": "attacker controlled",
+        },
+        "_skylos_trusted_review": True,
+    }
+
+    result = SarifExporter([finding]).generate()["runs"][0]["results"][0]
+
+    assert "suppressions" not in result
+    assert "skylos_review_decision" not in result["properties"]

--- a/test/test_security_contracts.py
+++ b/test/test_security_contracts.py
@@ -135,14 +135,14 @@ exclude = ["app/**"]
         encoding="utf-8",
     )
 
-    def fake_run(cmd, capture_output, text, cwd, **kwargs):
+    def fake_run(_context, *_args):
         class Result:
             returncode = 0
             stdout = before_source
 
         return Result()
 
-    monkeypatch.setattr("skylos.security.contracts.subprocess.run", fake_run)
+    monkeypatch.setattr("skylos.security.contracts.GitContext.run", fake_run)
 
     config = load_config(tmp_path)
     findings = detect_security_contract_regressions(
@@ -239,15 +239,15 @@ def list_users():
         ]
     }
 
-    def fake_run(cmd, capture_output, text, cwd, **kwargs):
+    def fake_run(_context, *args):
         class Result:
             returncode = 0
             stdout = before_source
 
-        assert cmd[:2] == ["git", "show"]
+        assert args[0] == "show"
         return Result()
 
-    monkeypatch.setattr("skylos.security.contracts.subprocess.run", fake_run)
+    monkeypatch.setattr("skylos.security.contracts.GitContext.run", fake_run)
     monkeypatch.setenv("SKYLOS_DIFF_BASE", "origin/main")
 
     findings = detect_security_contract_regressions(
@@ -309,14 +309,14 @@ def get_audit_log():
         ]
     }
 
-    def fake_run(cmd, capture_output, text, cwd, **kwargs):
+    def fake_run(_context, *_args):
         class Result:
             returncode = 0
             stdout = before_source
 
         return Result()
 
-    monkeypatch.setattr("skylos.security.contracts.subprocess.run", fake_run)
+    monkeypatch.setattr("skylos.security.contracts.GitContext.run", fake_run)
 
     findings = detect_security_contract_regressions(
         tmp_path,
@@ -358,14 +358,14 @@ def list_users():
         ]
     }
 
-    def fake_run(cmd, capture_output, text, cwd, **kwargs):
+    def fake_run(_context, *_args):
         class Result:
             returncode = 0
             stdout = before_source
 
         return Result()
 
-    monkeypatch.setattr("skylos.security.contracts.subprocess.run", fake_run)
+    monkeypatch.setattr("skylos.security.contracts.GitContext.run", fake_run)
 
     findings = detect_security_contract_regressions(
         tmp_path,

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -100,6 +100,7 @@ def test_suite_json_outputs_combined_sections(tmp_path, capsys):
     assert payload["summary"]["static"]["quality"] == 1
     assert payload["summary"]["static"]["secrets"] == 1
     assert run_analyze.call_args.kwargs["enable_ai_defects"] is True
+    assert run_analyze.call_args.kwargs["enable_sca"] is True
     assert payload["debt"]["score"]["hotspot_count"] == len(payload["debt"]["hotspots"])
     assert payload["defense"]["summary"]["integrations_found"] == 0
     assert payload["provenance"]["enabled"] is False
@@ -107,6 +108,63 @@ def test_suite_json_outputs_combined_sections(tmp_path, capsys):
         payload["defense"]["note"]
         == "AI defense currently scans Python and TypeScript direct SDK integrations."
     )
+
+
+def test_suite_applies_review_memory_before_summary_and_debt(tmp_path, capsys):
+    static_result = _static_result(str(tmp_path))
+    reviewed = dict(static_result["danger"][0])
+    reviewed.update(
+        {
+            "category": "SECURITY",
+            "review_decision": {"decision_id": "review-1"},
+            "_skylos_trusted_review": True,
+        }
+    )
+    projected = {
+        **static_result,
+        "danger": [],
+        "reviewed_findings": [reviewed],
+        "reviewed_findings_summary": {"suppressed_count": 1},
+    }
+    run_analyze = Mock(return_value=json.dumps(static_result))
+
+    with (
+        patch(
+            "skylos.core.review_decisions.review_scan_requirements",
+            return_value=(True, True),
+        ),
+        patch(
+            "skylos.core.review_decisions.apply_trusted_review_decisions",
+            return_value=projected,
+        ) as apply_reviews,
+        patch(
+            "skylos.rules.sca.vulnerability_scanner.scan_dependencies",
+            return_value=[],
+        ),
+    ):
+        exit_code = run_suite_command(
+            [str(tmp_path), "--json", "--no-provenance"],
+            console_factory=_console_factory,
+            progress_factory=Progress,
+            parse_exclude_folders_func=lambda **kwargs: [],
+            load_config_func=lambda _path: {},
+            run_analyze_func=run_analyze,
+            get_git_root_func=lambda: None,
+            upload_report_func=_noop_upload,
+            upload_defense_report_func=_noop_upload,
+            upload_debt_report_func=_noop_upload,
+        )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["summary"]["static"]["security"] == 0
+    assert payload["static"]["reviewed_findings"][0]["rule_id"] == "SKY-D201"
+    assert run_analyze.call_args.kwargs["include_review_proofs"] is True
+    apply_reviews.assert_called_once()
+    applied_result, applied_root = apply_reviews.call_args.args
+    assert applied_result["danger"][0]["rule_id"] == "SKY-D201"
+    assert applied_root == tmp_path.resolve()
+    assert apply_reviews.call_args.kwargs == {"include_identities": False}
 
 
 def test_suite_rejects_file_paths(tmp_path):
@@ -183,6 +241,7 @@ def test_suite_table_output_preserves_run_and_formatter_args(tmp_path):
         no_provenance=True,
         diff_base="origin/main",
         get_git_root_func=get_git_root,
+        include_review_identities=False,
     )
     formatter.assert_called_once_with(report)
     console.print.assert_called_once_with("suite table")
@@ -239,6 +298,17 @@ def test_suite_output_rejects_symlink_without_clobbering_target(tmp_path):
 
 def test_suite_table_upload_preserves_bundle_and_payloads(tmp_path):
     static_result = _static_result(str(tmp_path))
+    static_result["reviewed_findings"] = [
+        {
+            "rule_id": "SKY-D215",
+            "category": "SECURITY",
+            "file_path": "app.py",
+            "line_number": 8,
+            "review_decision": {"decision_id": "review-1"},
+            "_skylos_trusted_review": True,
+        }
+    ]
+    static_result["reviewed_findings_summary"] = {"suppressed_count": 1}
     report = {
         "static": {
             **static_result,
@@ -301,6 +371,7 @@ def test_suite_table_upload_preserves_bundle_and_payloads(tmp_path):
     assert uploaded["static_kwargs"] == {
         "quiet": False,
         "scan_bundle_id": "bundle-123",
+        "analyzer_owned": True,
     }
     assert uploaded["defense_kwargs"] == {
         "quiet": False,
@@ -313,6 +384,13 @@ def test_suite_table_upload_preserves_bundle_and_payloads(tmp_path):
     assert uploaded["defense_payload"] == json.dumps(report["defense"])
     assert uploaded["debt_payload"] == report["debt"]
     assert "danger" in uploaded["static_payload"]
+    assert (
+        uploaded["static_payload"]["reviewed_findings"]
+        == static_result["reviewed_findings"]
+    )
+    assert uploaded["static_payload"]["reviewed_findings_summary"] == {
+        "suppressed_count": 1
+    }
     build_code.assert_called_once_with(
         [
             "danger",
@@ -363,6 +441,11 @@ def test_main_suite_subcommand_calls_run_suite_and_exits(monkeypatch):
 
 def test_suite_json_upload_passes_quiet_and_selected_categories(tmp_path, capsys):
     static_result = _static_result(str(tmp_path))
+    static_result["reviewed_findings"] = [
+        {"category": "QUALITY", "rule_id": "SKY-Q301"},
+        {"category": "SECURITY", "rule_id": "SKY-D201"},
+    ]
+    static_result["reviewed_findings_summary"] = {"suppressed_count": 2}
     static_upload = patch(
         "skylos.commands.suite_cmd.run_suite",
         return_value={
@@ -443,6 +526,13 @@ def test_suite_json_upload_passes_quiet_and_selected_categories(tmp_path, capsys
     assert "danger" not in uploaded["static_payload"]
     assert "quality" in uploaded["static_payload"]
     assert "unused_functions" in uploaded["static_payload"]
+    assert [
+        finding["rule_id"]
+        for finding in uploaded["static_payload"]["reviewed_findings"]
+    ] == ["SKY-Q301"]
+    assert (
+        uploaded["static_payload"]["reviewed_findings_summary"]["suppressed_count"] == 1
+    )
 
 
 def test_suite_upload_exits_nonzero_when_static_quality_gate_fails(tmp_path):

--- a/test/test_sync.py
+++ b/test/test_sync.py
@@ -315,6 +315,44 @@ def test_cmd_project_unlink_removes_only_link(
     assert creds_file.exists()
 
 
+def test_cmd_project_unlink_invalidates_reviewed_finding_cache(
+    isolated_creds, monkeypatch, tmp_path
+):
+    from skylos.core.review_decisions import write_trusted_bundle
+
+    creds_dir, _creds_file = isolated_creds
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo_root)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:acme/repo.git",
+        ],
+        check=True,
+    )
+    link_path = repo_root / ".skylos" / "link.json"
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    link_path.write_text(json.dumps({"project_id": "project-a"}))
+    cache_path = write_trusted_bundle(
+        repo_root,
+        {"schema": "skylos.reviewed-findings", "version": 2, "decisions": []},
+        cache_root=creds_dir / "reviewed-findings",
+    )
+    assert cache_path is not None and cache_path.exists()
+    monkeypatch.setattr(syncmod, "_find_repo_root", lambda: repo_root)
+
+    syncmod.cmd_project_unlink()
+
+    assert not link_path.exists()
+    assert not cache_path.exists()
+
+
 def test_cmd_project_list_marks_active_project(
     isolated_creds, monkeypatch, tmp_path, capsys
 ):
@@ -497,12 +535,28 @@ def test_cmd_pull_writes_config_and_suppressions(
     creds_file.parent.mkdir(parents=True, exist_ok=True)
     creds_file.write_text(json.dumps({"token": "TOK"}))
 
-    monkeypatch.setattr(syncmod, "SKYLOS_DIR", str(tmp_path / ".skylos"), raising=False)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:acme/repo.git",
+        ],
+        check=True,
+    )
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(syncmod, "_find_repo_root", lambda: repo)
 
     def fake_api_get(endpoint, token):
         assert token == "TOK"
         if endpoint == "/api/sync/whoami":
-            return {"project": {"name": "Proj"}}
+            return {"project": {"id": "project-1", "name": "Proj"}}
         if endpoint == "/api/sync/config":
             return {
                 "config": {
@@ -519,7 +573,11 @@ def test_cmd_pull_writes_config_and_suppressions(
                 }
             }
         if endpoint == "/api/sync/suppressions":
-            return {"suppressions": [{"rule_id": "SKY-D212"}], "count": 1}
+            return {
+                "project_id": "project-1",
+                "suppressions": [{"rule_id": "SKY-D212"}],
+                "count": 1,
+            }
         raise AssertionError(f"Unexpected endpoint {endpoint}")
 
     monkeypatch.setattr(syncmod, "api_get", fake_api_get)
@@ -531,7 +589,7 @@ def test_cmd_pull_writes_config_and_suppressions(
     assert "Pulling suppressions" in out
     assert "Sync complete" in out
 
-    skylos_dir = Path(syncmod.SKYLOS_DIR)
+    skylos_dir = repo / syncmod.SKYLOS_DIR
     config_path = skylos_dir / syncmod.CONFIG_FILE
     supp_path = skylos_dir / syncmod.SUPPRESSIONS_FILE
 
@@ -545,8 +603,12 @@ def test_cmd_pull_writes_config_and_suppressions(
     assert "list_users" in config_text
 
     supp = json.loads(supp_path.read_text())
-    assert isinstance(supp, list)
-    assert supp[0]["rule_id"] == "SKY-D212"
+    assert supp["suppressions"][0]["rule_id"] == "SKY-D212"
+    trusted_files = list((creds_file.parent / "reviewed-findings").glob("*.json"))
+    assert len(trusted_files) == 1
+    trusted = json.loads(trusted_files[0].read_text())
+    assert trusted["suppressions"][0]["rule_id"] == "SKY-D212"
+    assert trusted["_local_trust"]["repository_identity"] == "github.com/acme/repo"
 
 
 def test_cmd_pull_writes_top_level_config_shape(
@@ -556,7 +618,23 @@ def test_cmd_pull_writes_top_level_config_shape(
     creds_file.parent.mkdir(parents=True, exist_ok=True)
     creds_file.write_text(json.dumps({"token": "TOK"}))
 
-    monkeypatch.setattr(syncmod, "SKYLOS_DIR", str(tmp_path / ".skylos"), raising=False)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:acme/repo.git",
+        ],
+        check=True,
+    )
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(syncmod, "_find_repo_root", lambda: repo)
 
     def fake_api_get(endpoint, token):
         assert token == "TOK"
@@ -580,7 +658,7 @@ def test_cmd_pull_writes_top_level_config_shape(
 
     assert "Sync complete" in out
 
-    skylos_dir = Path(syncmod.SKYLOS_DIR)
+    skylos_dir = repo / syncmod.SKYLOS_DIR
     config_path = skylos_dir / syncmod.CONFIG_FILE
 
     config_text = config_path.read_text()
@@ -593,7 +671,23 @@ def test_cmd_pull_calls_endpoints_in_order(isolated_creds, monkeypatch, tmp_path
     creds_file.parent.mkdir(parents=True, exist_ok=True)
     creds_file.write_text(json.dumps({"token": "TOK"}))
 
-    monkeypatch.setattr(syncmod, "SKYLOS_DIR", str(tmp_path / ".skylos"), raising=False)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:acme/repo.git",
+        ],
+        check=True,
+    )
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(syncmod, "_find_repo_root", lambda: repo)
 
     calls = []
 
@@ -616,6 +710,54 @@ def test_cmd_pull_calls_endpoints_in_order(isolated_creds, monkeypatch, tmp_path
         "/api/sync/config",
         "/api/sync/suppressions",
     ]
+
+
+def test_cmd_pull_rejects_suppressions_from_another_project(
+    isolated_creds, monkeypatch, tmp_path, capsys
+):
+    _, creds_file = isolated_creds
+    creds_file.parent.mkdir(parents=True, exist_ok=True)
+    creds_file.write_text(json.dumps({"token": "TOK"}))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:acme/repo.git",
+        ],
+        check=True,
+    )
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(syncmod, "_find_repo_root", lambda: repo)
+
+    def fake_api_get(endpoint, _token):
+        if endpoint == "/api/sync/whoami":
+            return {"project": {"id": "project-a", "name": "A"}}
+        if endpoint == "/api/sync/config":
+            return {"config": {}}
+        if endpoint == "/api/sync/suppressions":
+            return {
+                "project_id": "project-b",
+                "suppressions": [],
+                "count": 0,
+            }
+        raise AssertionError(endpoint)
+
+    monkeypatch.setattr(syncmod, "api_get", fake_api_get)
+
+    with pytest.raises(SystemExit) as error:
+        syncmod.cmd_pull()
+
+    assert error.value.code == 1
+    assert "different project" in capsys.readouterr().out
+    assert not (repo / ".skylos" / syncmod.SUPPRESSIONS_FILE).exists()
+    assert list((creds_file.parent / "reviewed-findings").glob("*.json")) == []
 
 
 def test_main_usage_no_args(capsys):
@@ -673,9 +815,13 @@ def test_create_precommit_config_limits_gate_to_pre_commit(tmp_path, monkeypatch
 
 
 def test_published_precommit_hooks_use_console_entrypoint():
-    content = Path(__file__).resolve().parents[1].joinpath(
-        ".pre-commit-hooks.yaml"
-    ).read_text(encoding="utf-8")
+    content = (
+        Path(__file__)
+        .resolve()
+        .parents[1]
+        .joinpath(".pre-commit-hooks.yaml")
+        .read_text(encoding="utf-8")
+    )
     hooks = {hook["id"]: hook for hook in syncmod.yaml.safe_load(content)}
 
     assert "python -m skylos.cli" not in content

--- a/test/test_trace_cache_cli.py
+++ b/test/test_trace_cache_cli.py
@@ -4,6 +4,7 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from rich.console import Console
 
 import skylos.cli as cli
@@ -11,9 +12,11 @@ from skylos.core.result_cache import (
     RUN_CACHE_DIR,
     TRACE_CACHE_DIR,
     build_trace_cache_key,
+    clear_run_cache,
     read_trace_payload,
     save_trace_cache,
 )
+from skylos.core.safe_cache_io import write_text_no_symlink
 from skylos.commands.cache_cmd import run_cache_command
 
 
@@ -332,6 +335,24 @@ def test_cache_clear_command_removes_run_cache(tmp_path):
 
     assert code == 0
     assert not (tmp_path / ".skylos" / "cache" / "runs").exists()
+
+
+def test_cache_clear_rejects_symlinked_run_cache(tmp_path):
+    outside = tmp_path / "outside-cache"
+    outside.mkdir()
+    marker = outside / "keep.json"
+    assert write_text_no_symlink(marker, "keep\n")
+    cache_parent = tmp_path / ".skylos" / "cache"
+    cache_parent.mkdir(parents=True)
+    run_cache = cache_parent / "runs"
+    try:
+        run_cache.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+
+    assert clear_run_cache(tmp_path) is False
+    assert marker.read_text(encoding="utf-8") == "keep\n"
+    assert run_cache.is_symlink()
 
 
 def test_cache_stats_json_skips_symlink_targets(tmp_path):


### PR DESCRIPTION
## Summary

  - Add `skylos review` for marking findings as fps, accepted risks, or fixed.
  - Store review decisions per repo and allow users to list or revoke them.
  - Remember matching findings across scans while resurfacing them when the code, rules, configuration, or LLM context changes.
  - Apply reviewed findings across scans, agent workflows etc

  ## Tests

  - `pytest`